### PR TITLE
Minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log for hipSOLVER
 
-## [(Unreleased)]
+
+## [(Unreleased) hipSOLVER 1.0.0 for ROCm 4.3]
+### Added
+
+### Removed
+- Removed unused HIPSOLVER_FILL_MODE_FULL enum value.
+
+
+## [hipSOLVER 0.1.0 for ROCm 4.2]
 ### Added
 - Created hipSOLVER repository
 - Added functions

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -40,6 +40,7 @@ target_include_directories( hipsolver-bench
 # External header includes included as system files
 target_include_directories( hipsolver-bench
   SYSTEM PRIVATE
+    $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
 )
 

--- a/clients/common/hipsolver_datatype2string.cpp
+++ b/clients/common/hipsolver_datatype2string.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2020 Advanced Micro Devices, Inc.
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "../include/hipsolver_datatype2string.hpp"
@@ -29,8 +29,6 @@ char hipsolver2char_fill(hipsolverFillMode_t value)
         return 'U';
     case HIPSOLVER_FILL_MODE_LOWER:
         return 'L';
-    case HIPSOLVER_FILL_MODE_FULL:
-        return 'F';
     }
     return '\0';
 }

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -2,23 +2,6 @@
 # Copyright 2016-2021 Advanced Micro Devices, Inc.
 # ########################################################################
 
-# set( Boost_DEBUG ON )
-set( Boost_USE_MULTITHREADED ON )
-set( Boost_DETAILED_FAILURE_MSG ON )
-set( Boost_ADDITIONAL_VERSIONS 1.64.0 1.64 )
-set( Boost_USE_STATIC_LIBS OFF )
-find_package( Boost COMPONENTS program_options )
-
-if( NOT Boost_FOUND )
-  message( STATUS "Dynamic boost libraries not found. Attempting to find static libraries " )
-  set( Boost_USE_STATIC_LIBS ON )
-  find_package( Boost COMPONENTS program_options )
-
-  if( NOT Boost_FOUND )
-    message( FATAL_ERROR "boost is a required dependency and is not found;  try adding boost path to CMAKE_PREFIX_PATH" )
-  endif( )
-endif( )
-
 # Linking lapack library requires fortran flags
 enable_language( Fortran )
 find_package( cblas CONFIG REQUIRED )
@@ -64,7 +47,7 @@ target_compile_definitions( hipsolver-test PRIVATE GOOGLE_TEST )
 # External header includes included as SYSTEM files
 target_include_directories( hipsolver-test
   SYSTEM PRIVATE
-    $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
     ${ROCM_PATH}/hsa/include

--- a/clients/include/clientcommon.hpp
+++ b/clients/include/clientcommon.hpp
@@ -2,8 +2,7 @@
  * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef CLIENTCOMMON_HPP
-#define CLIENTCOMMON_HPP
+#pragma once
 
 #include "../rocblascommon/rocblas_vector.hpp"
 #include "../rocsolvercommon/norm.hpp"
@@ -14,5 +13,3 @@
 #include "lapack_host_reference.hpp"
 
 using namespace std;
-
-#endif

--- a/clients/include/complex.hpp
+++ b/clients/include/complex.hpp
@@ -1,9 +1,8 @@
 /* ************************************************************************
- * Copyright 2020 Advanced Micro Devices, Inc.
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef HIPSOLVER_COMPLEX_HPP
-#define HIPSOLVER_COMPLEX_HPP
+#pragma once
 
 #include "hipsolver.h"
 #include <complex>
@@ -206,5 +205,3 @@ namespace std
         return r;
     }
 }
-
-#endif

--- a/clients/include/hipsolver.hpp
+++ b/clients/include/hipsolver.hpp
@@ -1,10 +1,8 @@
 /* ************************************************************************
- * Copyright 2020 Advanced Micro Devices, Inc.
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
-#ifndef HIPSOLVER_HPP
-#define HIPSOLVER_HPP
 
 #include "hipsolver.h"
 #include "hipsolver_fortran.hpp"
@@ -212,5 +210,3 @@ inline hipsolverStatus_t hipsolver_getrf(bool                    FORTRAN,
     }
 }
 /********************************************************/
-
-#endif

--- a/clients/include/hipsolver_datatype2string.hpp
+++ b/clients/include/hipsolver_datatype2string.hpp
@@ -1,9 +1,8 @@
 /* ************************************************************************
- * Copyright 2020 Advanced Micro Devices, Inc.
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef HIPSOLVER_DATATYPE2STRING_H_
-#define HIPSOLVER_DATATYPE2STRING_H_
+#pragma once
 
 #include "hipsolver.h"
 #include <ostream>
@@ -65,5 +64,3 @@ hipsolverStatus_t string2hipsolver_status(const std::string& value);
 hipsolverOperation_t char2hipsolver_operation(char value);
 
 hipsolverFillMode_t char2hipsolver_fill(char value);
-
-#endif

--- a/clients/include/hipsolver_fortran.hpp
+++ b/clients/include/hipsolver_fortran.hpp
@@ -1,9 +1,8 @@
 /* ************************************************************************
- * Copyright 2020 Advanced Micro Devices, Inc.
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef HIPSOLVER_FORTRAN_HPP
-#define HIPSOLVER_FORTRAN_HPP
+#pragma once
 
 #include "hipsolver.h"
 
@@ -72,5 +71,3 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrfFortran(hipsolverHandle_t     
                                                           int*                    devIpiv,
                                                           int*                    devInfo);
 }
-
-#endif

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -3,8 +3,6 @@
  * ************************************************************************ */
 
 #pragma once
-#ifndef TESTING_UTILITY_H
-#define TESTING_UTILITY_H
 
 #include "hipsolver.h"
 
@@ -376,5 +374,3 @@ double get_time_us_sync(hipStream_t stream);
 #endif
 
 /* ============================================================================================ */
-
-#endif

--- a/clients/rocblascommon/rocblas_init.hpp
+++ b/clients/rocblascommon/rocblas_init.hpp
@@ -2,8 +2,7 @@
  * Copyright 2018-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef ROCBLAS_INIT_H
-#define ROCBLAS_INIT_H
+#pragma once
 
 #include "hipsolver.h"
 //#include "rocblas_ostream.hpp"
@@ -267,5 +266,3 @@ void rocblas_copy_matrix(const T* A,
             for(size_t j = 0; j < N; ++j)
                 B[i + j * ldb + i_batch * strideb] = A[i + j * lda + i_batch * stridea];
 }
-
-#endif

--- a/clients/rocsolvercommon/norm.hpp
+++ b/clients/rocsolvercommon/norm.hpp
@@ -1,10 +1,8 @@
 /* ************************************************************************
- * Copyright 2020 Advanced Micro Devices, Inc.
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
-#ifndef NORM_HPP
-#define NORM_HPP
 
 // #include "clientcommon.hpp"
 // #include "rocblas.h"
@@ -179,5 +177,3 @@ S snorm(char norm_type, rocblas_int m, rocblas_int n, T* A, rocblas_int lda)
 {
     return xlange(&norm_type, &m, &n, A, &lda, (S*)nullptr);
 }
-
-#endif

--- a/clients/rocsolvercommon/rocsolver_test.hpp
+++ b/clients/rocsolvercommon/rocsolver_test.hpp
@@ -2,8 +2,7 @@
  * Copyright 2018-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef S_TEST_H
-#define S_TEST_H
+#pragma once
 
 #include <cstdarg>
 #include <iomanip>
@@ -97,5 +96,3 @@ inline void rocsolver_bench_output(T arg, Ts... args)
 // {
 //     return os << x.data;
 // }
-
-#endif

--- a/install.sh
+++ b/install.sh
@@ -188,11 +188,11 @@ install_packages( )
     fi
   fi
 
-  local client_dependencies_ubuntu=( "gfortran" "libboost-program-options-dev" )
-  local client_dependencies_centos=( "devtoolset-7-gcc-gfortran" "boost-devel" )
-  local client_dependencies_centos8=( "gcc-gfortran" "boost-devel" )
-  local client_dependencies_fedora=( "gcc-gfortran" "boost-devel" )
-  local client_dependencies_sles=( "libboost_program_options1_66_0-devel" "pkg-config" "dpkg" )
+  local client_dependencies_ubuntu=( "gfortran" )
+  local client_dependencies_centos=( "devtoolset-7-gcc-gfortran" )
+  local client_dependencies_centos8=( "gcc-gfortran" )
+  local client_dependencies_fedora=( "gcc-gfortran" )
+  local client_dependencies_sles=(  "pkg-config" "dpkg" )
 
   case "${ID}" in
     ubuntu)

--- a/library/include/hipsolver.h
+++ b/library/include/hipsolver.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2020 Advanced Micro Devices, Inc.
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 //! HIP = Heterogeneous-compute Interface for Portability
@@ -173,7 +173,6 @@ typedef enum
 {
     HIPSOLVER_FILL_MODE_UPPER = 121,
     HIPSOLVER_FILL_MODE_LOWER = 122,
-    HIPSOLVER_FILL_MODE_FULL  = 123,
 } hipsolverFillMode_t;
 
 #ifdef __cplusplus

--- a/library/include/hipsolver.h
+++ b/library/include/hipsolver.h
@@ -150,15 +150,16 @@ static_assert(sizeof(hipsolverComplex) == sizeof(float) * 2
 typedef enum
 {
     HIPSOLVER_STATUS_SUCCESS           = 0, // Function succeeds
-    HIPSOLVER_STATUS_NOT_INITIALIZED   = 1, // HIPSOLVER library not initialized
+    HIPSOLVER_STATUS_NOT_INITIALIZED   = 1, // hipSOLVER library not initialized
     HIPSOLVER_STATUS_ALLOC_FAILED      = 2, // resource allocation failed
     HIPSOLVER_STATUS_INVALID_VALUE     = 3, // unsupported numerical value was passed to function
     HIPSOLVER_STATUS_MAPPING_ERROR     = 4, // access to GPU memory space failed
     HIPSOLVER_STATUS_EXECUTION_FAILED  = 5, // GPU program failed to execute
-    HIPSOLVER_STATUS_INTERNAL_ERROR    = 6, // an internal HIPSOLVER operation failed
+    HIPSOLVER_STATUS_INTERNAL_ERROR    = 6, // an internal hipSOLVER operation failed
     HIPSOLVER_STATUS_NOT_SUPPORTED     = 7, // function not implemented
     HIPSOLVER_STATUS_ARCH_MISMATCH     = 8,
     HIPSOLVER_STATUS_HANDLE_IS_NULLPTR = 9, // hipSOLVER handle is null pointer
+    HIPSOLVER_STATUS_UNKNOWN           = 10, // back-end returned an unsupported status code
 } hipsolverStatus_t;
 
 // set the values of enum constants to be the same as those used in cblas

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -91,7 +91,7 @@ hipsolverStatus_t rocblas2hip_status(rocblas_status_ error)
     case rocblas_status_internal_error:
         return HIPSOLVER_STATUS_INTERNAL_ERROR;
     default:
-        throw std::invalid_argument("Unimplemented status");
+        return HIPSOLVER_STATUS_UNKNOWN;
     }
 }
 

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -24,8 +24,9 @@ rocblas_operation_ hip2rocblas_operation(hipsolverOperation_t op)
         return rocblas_operation_transpose;
     case HIPSOLVER_OP_C:
         return rocblas_operation_conjugate_transpose;
+    default:
+        throw std::invalid_argument("Non existent OP");
     }
-    throw "Non existent OP";
 }
 
 hipsolverOperation_t rocblas2hip_operation(rocblas_operation_ op)
@@ -38,8 +39,9 @@ hipsolverOperation_t rocblas2hip_operation(rocblas_operation_ op)
         return HIPSOLVER_OP_T;
     case rocblas_operation_conjugate_transpose:
         return HIPSOLVER_OP_C;
+    default:
+        throw std::invalid_argument("Non existent OP");
     }
-    throw "Non existent OP";
 }
 
 rocblas_fill_ hip2rocblas_fill(hipsolverFillMode_t fill)
@@ -50,10 +52,9 @@ rocblas_fill_ hip2rocblas_fill(hipsolverFillMode_t fill)
         return rocblas_fill_upper;
     case HIPSOLVER_FILL_MODE_LOWER:
         return rocblas_fill_lower;
-    case HIPSOLVER_FILL_MODE_FULL:
-        return rocblas_fill_full;
+    default:
+        throw std::invalid_argument("Non existent FILL");
     }
-    throw "Non existent FILL";
 }
 
 hipsolverFillMode_t rocblas2hip_fill(rocblas_fill_ fill)
@@ -64,10 +65,9 @@ hipsolverFillMode_t rocblas2hip_fill(rocblas_fill_ fill)
         return HIPSOLVER_FILL_MODE_UPPER;
     case rocblas_fill_lower:
         return HIPSOLVER_FILL_MODE_LOWER;
-    case rocblas_fill_full:
-        return HIPSOLVER_FILL_MODE_FULL;
+    default:
+        throw std::invalid_argument("Non existent FILL");
     }
-    throw "Non existent FILL";
 }
 
 hipsolverStatus_t rocblas2hip_status(rocblas_status_ error)
@@ -91,7 +91,7 @@ hipsolverStatus_t rocblas2hip_status(rocblas_status_ error)
     case rocblas_status_internal_error:
         return HIPSOLVER_STATUS_INTERNAL_ERROR;
     default:
-        throw "Unimplemented status";
+        throw std::invalid_argument("Unimplemented status");
     }
 }
 

--- a/library/src/hipsolver_module.f90
+++ b/library/src/hipsolver_module.f90
@@ -18,7 +18,6 @@ module hipsolver_enums
     enum, bind(c)
         enumerator :: HIPSOLVER_FILL_MODE_UPPER = 121
         enumerator :: HIPSOLVER_FILL_MODE_LOWER = 122
-        enumerator :: HIPSOLVER_FILL_MODE_FULL  = 123
     end enum
 
     enum, bind(c)

--- a/library/src/nvcc_detail/hipsolver.cpp
+++ b/library/src/nvcc_detail/hipsolver.cpp
@@ -90,7 +90,7 @@ hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus)
     case CUSOLVER_STATUS_ARCH_MISMATCH:
         return HIPSOLVER_STATUS_ARCH_MISMATCH;
     default:
-        throw std::invalid_argument("Unimplemented status");
+        return HIPSOLVER_STATUS_UNKNOWN;
     }
 }
 

--- a/library/src/nvcc_detail/hipsolver.cpp
+++ b/library/src/nvcc_detail/hipsolver.cpp
@@ -21,8 +21,9 @@ cublasOperation_t hip2cuda_operation(hipsolverOperation_t op)
         return CUBLAS_OP_T;
     case HIPSOLVER_OP_C:
         return CUBLAS_OP_C;
+    default:
+        throw std::invalid_argument("Non existent OP");
     }
-    throw "Non existent OP";
 }
 
 hipsolverOperation_t cuda2hip_operation(cublasOperation_t op)
@@ -35,8 +36,9 @@ hipsolverOperation_t cuda2hip_operation(cublasOperation_t op)
         return HIPSOLVER_OP_T;
     case CUBLAS_OP_C:
         return HIPSOLVER_OP_C;
+    default:
+        throw std::invalid_argument("Non existent OP");
     }
-    throw "Non existent OP";
 }
 
 cublasFillMode_t hip2cuda_fill(hipsolverFillMode_t fill)
@@ -47,8 +49,9 @@ cublasFillMode_t hip2cuda_fill(hipsolverFillMode_t fill)
         return CUBLAS_FILL_MODE_UPPER;
     case HIPSOLVER_FILL_MODE_LOWER:
         return CUBLAS_FILL_MODE_LOWER;
+    default:
+        throw std::invalid_argument("Non existent FILL");
     }
-    throw "Non existent FILL";
 }
 
 hipsolverFillMode_t cuda2hip_fill(cublasFillMode_t fill)
@@ -59,8 +62,9 @@ hipsolverFillMode_t cuda2hip_fill(cublasFillMode_t fill)
         return HIPSOLVER_FILL_MODE_UPPER;
     case CUBLAS_FILL_MODE_LOWER:
         return HIPSOLVER_FILL_MODE_LOWER;
+    default:
+        throw std::invalid_argument("Non existent FILL");
     }
-    throw "Non existent FILL";
 }
 
 hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus)
@@ -86,7 +90,7 @@ hipsolverStatus_t cuda2hip_status(cusolverStatus_t cuStatus)
     case CUSOLVER_STATUS_ARCH_MISMATCH:
         return HIPSOLVER_STATUS_ARCH_MISMATCH;
     default:
-        throw "Unimplemented status";
+        throw std::invalid_argument("Unimplemented status");
     }
 }
 


### PR DESCRIPTION
Improves exception handling and uses #pragma once across library headers as suggested by @cgmb.

Also removes HIPSOLVER_FILL_MODE_FULL, as this fill mode is missing from cuSOLVER. While this is a change to the public API, there are currently no functions that use hipsolverFillMode_t and the library is so early in development that I don't believe a deprecation process is required.