### PR TITLE
Leave AMDGPU_TARGETS unset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,9 +95,6 @@ if( USE_CUDA )
     list( APPEND HIP_INCLUDE_DIRS "${HIP_ROOT_DIR}/include" )
 endif( )
 
-# CMake list of machine targets
-set( AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target" )
-
 add_subdirectory( library )
 
 include( clients/cmake/build-options.cmake )


### PR DESCRIPTION
hipSOLVER does not need to set AMDGPU_TARGETS. It has no kernels
itself, so this variable does not control anything within the library.