### PR TITLE
Enable ccache on CI by default

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -29,13 +29,12 @@ def runCompileCommand(platform, project, jobName, boolean sameOrg=false)
 
 def runTestCommand(platform, project)
 {
-    String sudo = auxiliary.sudo(platform.jenkinsLabel)
     String buildType = project.buildName.contains('Debug') ? "debug" : "release"
     String testExe = project.buildName.contains('Debug') ? "hipsolver-test-d" : "hipsolver-test"
     def command = """#!/usr/bin/env bash
                     set -x
                     cd ${project.paths.project_build_prefix}/build/${buildType}/clients/staging
-                    ${sudo} LD_LIBRARY_PATH=/opt/rocm/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./${testExe} --gtest_output=xml --gtest_color=yes
+                    LD_LIBRARY_PATH=/opt/rocm/lib GTEST_LISTENER=NO_PASS_LINE_IN_LOG ./${testExe} --gtest_output=xml --gtest_color=yes
                 """
 
     platform.runCommand(this, command)

--- a/.jenkins/debug.groovy
+++ b/.jenkins/debug.groovy
@@ -19,6 +19,7 @@ def runCI =
     // customize for project
     prj.paths.build_command = buildCommand
     prj.libraryDependencies = ['rocBLAS-internal', 'rocSOLVER']
+    prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/multicompiler.groovy
+++ b/.jenkins/multicompiler.groovy
@@ -18,6 +18,7 @@ def runCI =
     //customize for project
     prj.paths.build_command = buildCommand
     prj.libraryDependencies = ['rocBLAS-internal', 'rocSOLVER']
+    prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/precheckin-cuda.groovy
+++ b/.jenkins/precheckin-cuda.groovy
@@ -18,6 +18,7 @@ def runCI =
     //customize for project
     prj.paths.build_command = buildCommand
     prj.libraryDependencies = []
+    prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/precheckin.groovy
+++ b/.jenkins/precheckin.groovy
@@ -18,6 +18,7 @@ def runCI =
     //customize for project
     prj.paths.build_command = buildCommand
     prj.libraryDependencies = ['rocBLAS-internal', 'rocSOLVER']
+    prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)

--- a/.jenkins/staticlibrary.groovy
+++ b/.jenkins/staticlibrary.groovy
@@ -16,6 +16,7 @@ def runCI =
     def prj  = new rocProject('hipSOLVER', 'StaticLibrary')
     prj.paths.build_command = './install.sh -cd --static -p /opt/rocm/lib/cmake'
     prj.libraryDependencies = ['rocBLAS-internal', 'rocSOLVER']
+    prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available
     def nodes = new dockerNodes(nodeDetails, jobName, prj)


### PR DESCRIPTION
This PR makes use of ccache the default setting for CI builds. It can be disabled for PRs using the label `ci:no-ccache`.

This doesn't provide much value for hipSOLVER, as its builds are quite fast anyway. I mostly just want to check that this CI functionality is working properly for the builds that support both NVIDIA and AMD.