### PR TITLE
API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,18 +17,21 @@
     - hipsolverSgeqrf_bufferSize, hipsolverDgeqrf_bufferSize, hipsolverCgeqrf_bufferSize, hipsolverZgeqrf_bufferSize
     - hipsolverSgeqrf, hipsolverDgeqrf, hipsolverCgeqrf, hipsolverZgeqrf
   - getrs
+    - hipsolverSgetrs_bufferSize, hipsolverDgetrs_bufferSize, hipsolverCgetrs_bufferSize, hipsolverZgetrs_bufferSize
     - hipsolverSgetrs, hipsolverDgetrs, hipsolverCgetrs, hipsolverZgetrs
   - potrf
     - hipsolverSpotrf_bufferSize, hipsolverDpotrf_bufferSize, hipsolverCpotrf_bufferSize, hipsolverZpotrf_bufferSize
     - hipsolverSpotrf, hipsolverDpotrf, hipsolverCpotrf, hipsolverZpotrf
   - potrfBatched
+    - hipsolverSpotrfBatched_bufferSize, hipsolverDpotrfBatched_bufferSize, hipsolverCpotrfBatched_bufferSize, hipsolverZpotrfBatched_bufferSize
     - hipsolverSpotrfBatched, hipsolverDpotrfBatched, hipsolverCpotrfBatched, hipsolverZpotrfBatched
   - sytrd/hetrd
     - hipsolverSsytrd_bufferSize, hipsolverDsytrd_bufferSize, hipsolverChetrd_bufferSize, hipsolverZhetrd_bufferSize
     - hipsolverSsytrd, hipsolverDsytrd, hipsolverChetrd, hipsolverZhetrd
 
 ### Changed
-- hipSOLVER functions will now return HIPSOLVER_STATUS_INVALID_ENUM or HIPSOLVER_STATUS_UNKNOWN status codes rather than throw exceptions
+- hipSOLVER functions will now return HIPSOLVER_STATUS_INVALID_ENUM or HIPSOLVER_STATUS_UNKNOWN status codes rather than throw exceptions.
+- hipsolverXgetrf functions now take lwork as an argument.
 
 ### Removed
 - Removed unused HIPSOLVER_FILL_MODE_FULL enum value.

--- a/README.md
+++ b/README.md
@@ -88,23 +88,23 @@ hipsolverSgetrf(hipsolverHandle_t handle,
 ```
 
 ## Notes on API Differences
-While the API of hipSOLVER is, overall, modeled on that of cuSOLVER, there are some notable differences between the APIs of hipSOLVER and cuSOLVER. In particular, the following functions take additional arguments:
+While the API of hipSOLVER is, overall, modeled after that of cuSOLVER, there are some notable differences. In particular:
 
-* hipsolverXgesvd_bufferSize: Accepts `jobu` and `jobv` as arguments
-* hipsolverXgetrf: Accepts `lwork` as an argument
-* hipsolverXgetrs: Accepts `work` and `lwork` as arguments
-* hipsolverXpotrfBatched: Accepts `work` and `lwork` as arguments
+* hipsolverXgesvd_bufferSize requires `jobu` and `jobv` as arguments
+* hipsolverXgetrf requires `lwork` as an argument
+* hipsolverXgetrs requires `work` and `lwork` as arguments, and
+* hipsolverXpotrfBatched requires `work` and `lwork` as arguments.
 
-In order to support these changes to getrs and potrfBatched, the following functions have been added as well:
+In order to support these changes, hipSOLVER adds the following functions as well:
 
 * hipsolverXgetrs_bufferSize
 * hipsolverXpotrfBatched_bufferSize
 
-Furthermore, due to differences in implementation and API design between rocSOLVER and cuSOLVER, not all arguments are handled identically between the two backends. When using the rocSOLVER backend, keep in mind the following differences.
+Furthermore, due to differences in implementation and API design between rocSOLVER and cuSOLVER, not all arguments are handled identically between the two backends. When using the rocSOLVER backend, keep in mind the following differences:
 
-While many cuSOLVER functions (and, consequently, hipSOLVER functions) take a workspace pointer and size as arguments, rocSOLVER maintains its own internal device workspace by default. In order to take advantage of this feature, users may pass a null pointer for the `work` argument of any function when using the rocSOLVER backend, and the workspace will be automatically managed behind-the-scenes. It is recommended to use a consistent strategy for workspace management, as performance issues may arise if the internal workspace is made to flip-flop between user-provided and automatically allocated workspaces.
+* While many cuSOLVER functions (and, consequently, hipSOLVER functions) take a workspace pointer and size as arguments, rocSOLVER maintains its own internal device workspace by default. In order to take advantage of this feature, users may pass a null pointer for the `work` argument of any function when using the rocSOLVER backend, and the workspace will be automatically managed behind-the-scenes. It is recommended to use a consistent strategy for workspace management, as performance issues may arise if the internal workspace is made to flip-flop between user-provided and automatically allocated workspaces.
 
-Additionally, unlike cuSOLVER, rocSOLVER does not provide information on invalid arguments in its `info` arguments, though it will provide info on singularities and algorithm convergence. As a result, the `info` argument of many functions will not be referenced or altered by the rocSOLVER backend, excepting those that provide info on singularities or convergence.
+* Additionally, unlike cuSOLVER, rocSOLVER does not provide information on invalid arguments in its `info` arguments, though it will provide info on singularities and algorithm convergence. As a result, the `info` argument of many functions will not be referenced or altered by the rocSOLVER backend, excepting those that provide info on singularities or convergence.
 
 ## Supported Functionality
 For a complete description of all the supported functions, see the corresponding backends' documentation

--- a/README.md
+++ b/README.md
@@ -87,12 +87,22 @@ hipsolverSgetrf(hipsolverHandle_t handle,
                 int*              devInfo);
 ```
 
-## Special Considerations with the rocSOLVER Backend
-Due to differences in implementation and API design between rocSOLVER and cuSOLVER, the hipSOLVER library cannot guarantee identical behaviour between the two backends. As the hipSOLVER API is modeled on that of cuSOLVER, some notable discrepancies exist when using the rocSOLVER backend.
+## Notes on API Differences
+While the API of hipSOLVER is, overall, modeled on that of cuSOLVER, there are some notable differences between the APIs of hipSOLVER and cuSOLVER. In particular, the following functions take additional arguments:
 
-While many cuSOLVER functions (and, consequently, hipSOLVER functions) take a workspace pointer and size as arguments, rocSOLVER maintains its own internal device workspace by default. In order to take advantage of this feature, users may pass a null pointer for the `work` argument of any function when using the rocSOLVER backend, and the workspace will be automatically managed behind-the-scenes.
+* hipsolverXgesvd_bufferSize: Accepts `jobu` and `jobv` as arguments
+* hipsolverXgetrf: Accepts `lwork` as an argument
+* hipsolverXgetrs: Accepts `work` and `lwork` as arguments
+* hipsolverXpotrfBatched: Accepts `work` and `lwork` as arguments
 
-Note that several functions do not take a `work` pointer as an argument, and will therefore always use rocSOLVER's internal device workspace management (see, for example, gesvd, getrs, and potrfBatched). This may cause performance issues if combined with function calls that receive non-null `work` pointers, as the internal workspace will flip-flop between the user-provided and automatically allocated workspaces. In these cases, it is recommended to always pass null pointers to the `work` arguments of all other functions.
+In order to support these changes to getrs and potrfBatched, the following functions have been added as well:
+
+* hipsolverXgetrs_bufferSize
+* hipsolverXpotrfBatched_bufferSize
+
+Furthermore, due to differences in implementation and API design between rocSOLVER and cuSOLVER, not all arguments are handled identically between the two backends. When using the rocSOLVER backend, keep in mind the following differences.
+
+While many cuSOLVER functions (and, consequently, hipSOLVER functions) take a workspace pointer and size as arguments, rocSOLVER maintains its own internal device workspace by default. In order to take advantage of this feature, users may pass a null pointer for the `work` argument of any function when using the rocSOLVER backend, and the workspace will be automatically managed behind-the-scenes. It is recommended to use a consistent strategy for workspace management, as performance issues may arise if the internal workspace is made to flip-flop between user-provided and automatically allocated workspaces.
 
 Additionally, unlike cuSOLVER, rocSOLVER does not provide information on invalid arguments in its `info` arguments, though it will provide info on singularities and algorithm convergence. As a result, the `info` argument of many functions will not be referenced or altered by the rocSOLVER backend, excepting those that provide info on singularities or convergence.
 
@@ -127,9 +137,11 @@ at [rocSOLVER API](https://rocsolver.readthedocs.io/en/latest/userguide_api.html
 | hipsolverXgeqrf | x | x | x | x |
 | hipsolverXgetrf_bufferSize | x | x | x | x |
 | hipsolverXgetrf | x | x | x | x |
+| hipsolverXgetrs_bufferSize | x | x | x | x |
 | hipsolverXgetrs | x | x | x | x |
 | hipsolverXpotrf_bufferSize | x | x | x | x |
 | hipsolverXpotrf | x | x | x | x |
+| hipsolverXpotrfBatched_bufferSize | x | x | x | x |
 | hipsolverXpotrfBatched | x | x | x | x |
 | hipsolverXsytrd_bufferSize | x | x |   |   |
 | hipsolverXsytrd | x | x |   |   |

--- a/clients/include/hipsolver.hpp
+++ b/clients/include/hipsolver.hpp
@@ -986,7 +986,8 @@ inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                FORTRAN,
                                                     int                 n,
                                                     float*              A,
                                                     int                 lda,
-                                                    int*                lwork)
+                                                    int*                lwork,
+                                                    int                 bc)
 {
     if(!FORTRAN)
         return hipsolverSpotrf_bufferSize(handle, uplo, n, A, lda, lwork);
@@ -1000,7 +1001,8 @@ inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                FORTRAN,
                                                     int                 n,
                                                     double*             A,
                                                     int                 lda,
-                                                    int*                lwork)
+                                                    int*                lwork,
+                                                    int                 bc)
 {
     if(!FORTRAN)
         return hipsolverDpotrf_bufferSize(handle, uplo, n, A, lda, lwork);
@@ -1014,7 +1016,8 @@ inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                FORTRAN,
                                                     int                 n,
                                                     hipsolverComplex*   A,
                                                     int                 lda,
-                                                    int*                lwork)
+                                                    int*                lwork,
+                                                    int                 bc)
 {
     if(!FORTRAN)
         return hipsolverCpotrf_bufferSize(handle, uplo, n, A, lda, lwork);
@@ -1028,7 +1031,8 @@ inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                    FORT
                                                     int                     n,
                                                     hipsolverDoubleComplex* A,
                                                     int                     lda,
-                                                    int*                    lwork)
+                                                    int*                    lwork,
+                                                    int                     bc)
 {
     if(!FORTRAN)
         return hipsolverZpotrf_bufferSize(handle, uplo, n, A, lda, lwork);
@@ -1109,6 +1113,66 @@ inline hipsolverStatus_t hipsolver_potrf(bool                    FORTRAN,
 }
 
 // batched
+inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                FORTRAN,
+                                                    hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    float*              A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 bc)
+{
+    if(!FORTRAN)
+        return hipsolverSpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, bc);
+    else
+        return hipsolverSpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                FORTRAN,
+                                                    hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    double*             A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 bc)
+{
+    if(!FORTRAN)
+        return hipsolverDpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, bc);
+    else
+        return hipsolverDpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                FORTRAN,
+                                                    hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    hipsolverComplex*   A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 bc)
+{
+    if(!FORTRAN)
+        return hipsolverCpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, bc);
+    else
+        return hipsolverCpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, bc);
+}
+
+inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                    FORTRAN,
+                                                    hipsolverHandle_t       handle,
+                                                    hipsolverFillMode_t     uplo,
+                                                    int                     n,
+                                                    hipsolverDoubleComplex* A[],
+                                                    int                     lda,
+                                                    int*                    lwork,
+                                                    int                     bc)
+{
+    if(!FORTRAN)
+        return hipsolverZpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, bc);
+    else
+        return hipsolverZpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, bc);
+}
+
 inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
                                          hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
@@ -1122,9 +1186,9 @@ inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
                                          int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverSpotrfBatched(handle, uplo, n, A, lda, info, bc);
+        return hipsolverSpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, bc);
     else
-        return hipsolverSpotrfBatchedFortran(handle, uplo, n, A, lda, info, bc);
+        return hipsolverSpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, bc);
 }
 
 inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
@@ -1140,9 +1204,9 @@ inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
                                          int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverDpotrfBatched(handle, uplo, n, A, lda, info, bc);
+        return hipsolverDpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, bc);
     else
-        return hipsolverDpotrfBatchedFortran(handle, uplo, n, A, lda, info, bc);
+        return hipsolverDpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, bc);
 }
 
 inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
@@ -1158,9 +1222,9 @@ inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
                                          int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverCpotrfBatched(handle, uplo, n, A, lda, info, bc);
+        return hipsolverCpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, bc);
     else
-        return hipsolverCpotrfBatchedFortran(handle, uplo, n, A, lda, info, bc);
+        return hipsolverCpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, bc);
 }
 
 inline hipsolverStatus_t hipsolver_potrf(bool                    FORTRAN,
@@ -1176,9 +1240,9 @@ inline hipsolverStatus_t hipsolver_potrf(bool                    FORTRAN,
                                          int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZpotrfBatched(handle, uplo, n, A, lda, info, bc);
+        return hipsolverZpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, bc);
     else
-        return hipsolverZpotrfBatchedFortran(handle, uplo, n, A, lda, info, bc);
+        return hipsolverZpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, bc);
 }
 /********************************************************/
 

--- a/clients/include/hipsolver.hpp
+++ b/clients/include/hipsolver.hpp
@@ -687,6 +687,7 @@ inline hipsolverStatus_t hipsolver_getrf(bool              FORTRAN,
                                          int               lda,
                                          int               stA,
                                          float*            work,
+                                         int               lwork,
                                          int*              ipiv,
                                          int               stP,
                                          int*              info,
@@ -695,13 +696,13 @@ inline hipsolverStatus_t hipsolver_getrf(bool              FORTRAN,
     switch(bool2marshal(FORTRAN, NPVT))
     {
     case C_NORMAL:
-        return hipsolverSgetrf(handle, m, n, A, lda, work, ipiv, info);
+        return hipsolverSgetrf(handle, m, n, A, lda, work, lwork, ipiv, info);
     case C_NORMAL_ALT:
-        return hipsolverSgetrf(handle, m, n, A, lda, work, nullptr, info);
+        return hipsolverSgetrf(handle, m, n, A, lda, work, lwork, nullptr, info);
     case FORTRAN_NORMAL:
-        return hipsolverSgetrfFortran(handle, m, n, A, lda, work, ipiv, info);
+        return hipsolverSgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info);
     case FORTRAN_NORMAL_ALT:
-        return hipsolverSgetrfFortran(handle, m, n, A, lda, work, nullptr, info);
+        return hipsolverSgetrfFortran(handle, m, n, A, lda, work, lwork, nullptr, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -716,6 +717,7 @@ inline hipsolverStatus_t hipsolver_getrf(bool              FORTRAN,
                                          int               lda,
                                          int               stA,
                                          double*           work,
+                                         int               lwork,
                                          int*              ipiv,
                                          int               stP,
                                          int*              info,
@@ -724,13 +726,13 @@ inline hipsolverStatus_t hipsolver_getrf(bool              FORTRAN,
     switch(bool2marshal(FORTRAN, NPVT))
     {
     case C_NORMAL:
-        return hipsolverDgetrf(handle, m, n, A, lda, work, ipiv, info);
+        return hipsolverDgetrf(handle, m, n, A, lda, work, lwork, ipiv, info);
     case C_NORMAL_ALT:
-        return hipsolverDgetrf(handle, m, n, A, lda, work, nullptr, info);
+        return hipsolverDgetrf(handle, m, n, A, lda, work, lwork, nullptr, info);
     case FORTRAN_NORMAL:
-        return hipsolverDgetrfFortran(handle, m, n, A, lda, work, ipiv, info);
+        return hipsolverDgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info);
     case FORTRAN_NORMAL_ALT:
-        return hipsolverDgetrfFortran(handle, m, n, A, lda, work, nullptr, info);
+        return hipsolverDgetrfFortran(handle, m, n, A, lda, work, lwork, nullptr, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -745,6 +747,7 @@ inline hipsolverStatus_t hipsolver_getrf(bool              FORTRAN,
                                          int               lda,
                                          int               stA,
                                          hipsolverComplex* work,
+                                         int               lwork,
                                          int*              ipiv,
                                          int               stP,
                                          int*              info,
@@ -753,13 +756,13 @@ inline hipsolverStatus_t hipsolver_getrf(bool              FORTRAN,
     switch(bool2marshal(FORTRAN, NPVT))
     {
     case C_NORMAL:
-        return hipsolverCgetrf(handle, m, n, A, lda, work, ipiv, info);
+        return hipsolverCgetrf(handle, m, n, A, lda, work, lwork, ipiv, info);
     case C_NORMAL_ALT:
-        return hipsolverCgetrf(handle, m, n, A, lda, work, nullptr, info);
+        return hipsolverCgetrf(handle, m, n, A, lda, work, lwork, nullptr, info);
     case FORTRAN_NORMAL:
-        return hipsolverCgetrfFortran(handle, m, n, A, lda, work, ipiv, info);
+        return hipsolverCgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info);
     case FORTRAN_NORMAL_ALT:
-        return hipsolverCgetrfFortran(handle, m, n, A, lda, work, nullptr, info);
+        return hipsolverCgetrfFortran(handle, m, n, A, lda, work, lwork, nullptr, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -774,6 +777,7 @@ inline hipsolverStatus_t hipsolver_getrf(bool                    FORTRAN,
                                          int                     lda,
                                          int                     stA,
                                          hipsolverDoubleComplex* work,
+                                         int                     lwork,
                                          int*                    ipiv,
                                          int                     stP,
                                          int*                    info,
@@ -782,13 +786,13 @@ inline hipsolverStatus_t hipsolver_getrf(bool                    FORTRAN,
     switch(bool2marshal(FORTRAN, NPVT))
     {
     case C_NORMAL:
-        return hipsolverZgetrf(handle, m, n, A, lda, work, ipiv, info);
+        return hipsolverZgetrf(handle, m, n, A, lda, work, lwork, ipiv, info);
     case C_NORMAL_ALT:
-        return hipsolverZgetrf(handle, m, n, A, lda, work, nullptr, info);
+        return hipsolverZgetrf(handle, m, n, A, lda, work, lwork, nullptr, info);
     case FORTRAN_NORMAL:
-        return hipsolverZgetrfFortran(handle, m, n, A, lda, work, ipiv, info);
+        return hipsolverZgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info);
     case FORTRAN_NORMAL_ALT:
-        return hipsolverZgetrfFortran(handle, m, n, A, lda, work, nullptr, info);
+        return hipsolverZgetrfFortran(handle, m, n, A, lda, work, lwork, nullptr, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }

--- a/clients/include/hipsolver.hpp
+++ b/clients/include/hipsolver.hpp
@@ -801,6 +801,82 @@ inline hipsolverStatus_t hipsolver_getrf(bool                    FORTRAN,
 
 /******************** GETRS ********************/
 // normal and strided_batched
+inline hipsolverStatus_t hipsolver_getrs_bufferSize(bool                 FORTRAN,
+                                                    hipsolverHandle_t    handle,
+                                                    hipsolverOperation_t trans,
+                                                    int                  n,
+                                                    int                  nrhs,
+                                                    float*               A,
+                                                    int                  lda,
+                                                    int*                 ipiv,
+                                                    float*               B,
+                                                    int                  ldb,
+                                                    int*                 lwork)
+{
+    if(!FORTRAN)
+        return hipsolverSgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+    else
+        return hipsolverSgetrs_bufferSizeFortran(
+            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+}
+
+inline hipsolverStatus_t hipsolver_getrs_bufferSize(bool                 FORTRAN,
+                                                    hipsolverHandle_t    handle,
+                                                    hipsolverOperation_t trans,
+                                                    int                  n,
+                                                    int                  nrhs,
+                                                    double*              A,
+                                                    int                  lda,
+                                                    int*                 ipiv,
+                                                    double*              B,
+                                                    int                  ldb,
+                                                    int*                 lwork)
+{
+    if(!FORTRAN)
+        return hipsolverDgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+    else
+        return hipsolverDgetrs_bufferSizeFortran(
+            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+}
+
+inline hipsolverStatus_t hipsolver_getrs_bufferSize(bool                 FORTRAN,
+                                                    hipsolverHandle_t    handle,
+                                                    hipsolverOperation_t trans,
+                                                    int                  n,
+                                                    int                  nrhs,
+                                                    hipsolverComplex*    A,
+                                                    int                  lda,
+                                                    int*                 ipiv,
+                                                    hipsolverComplex*    B,
+                                                    int                  ldb,
+                                                    int*                 lwork)
+{
+    if(!FORTRAN)
+        return hipsolverCgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+    else
+        return hipsolverCgetrs_bufferSizeFortran(
+            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+}
+
+inline hipsolverStatus_t hipsolver_getrs_bufferSize(bool                    FORTRAN,
+                                                    hipsolverHandle_t       handle,
+                                                    hipsolverOperation_t    trans,
+                                                    int                     n,
+                                                    int                     nrhs,
+                                                    hipsolverDoubleComplex* A,
+                                                    int                     lda,
+                                                    int*                    ipiv,
+                                                    hipsolverDoubleComplex* B,
+                                                    int                     ldb,
+                                                    int*                    lwork)
+{
+    if(!FORTRAN)
+        return hipsolverZgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+    else
+        return hipsolverZgetrs_bufferSizeFortran(
+            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+}
+
 inline hipsolverStatus_t hipsolver_getrs(bool                 FORTRAN,
                                          hipsolverHandle_t    handle,
                                          hipsolverOperation_t trans,
@@ -814,13 +890,16 @@ inline hipsolverStatus_t hipsolver_getrs(bool                 FORTRAN,
                                          float*               B,
                                          int                  ldb,
                                          int                  stB,
+                                         float*               work,
+                                         int                  lwork,
                                          int*                 info,
                                          int                  bc)
 {
     if(!FORTRAN)
-        return hipsolverSgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+        return hipsolverSgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
     else
-        return hipsolverSgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+        return hipsolverSgetrsFortran(
+            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
 }
 
 inline hipsolverStatus_t hipsolver_getrs(bool                 FORTRAN,
@@ -836,13 +915,16 @@ inline hipsolverStatus_t hipsolver_getrs(bool                 FORTRAN,
                                          double*              B,
                                          int                  ldb,
                                          int                  stB,
+                                         double*              work,
+                                         int                  lwork,
                                          int*                 info,
                                          int                  bc)
 {
     if(!FORTRAN)
-        return hipsolverDgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+        return hipsolverDgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
     else
-        return hipsolverDgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+        return hipsolverDgetrsFortran(
+            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
 }
 
 inline hipsolverStatus_t hipsolver_getrs(bool                 FORTRAN,
@@ -858,13 +940,16 @@ inline hipsolverStatus_t hipsolver_getrs(bool                 FORTRAN,
                                          hipsolverComplex*    B,
                                          int                  ldb,
                                          int                  stB,
+                                         hipsolverComplex*    work,
+                                         int                  lwork,
                                          int*                 info,
                                          int                  bc)
 {
     if(!FORTRAN)
-        return hipsolverCgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+        return hipsolverCgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
     else
-        return hipsolverCgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+        return hipsolverCgetrsFortran(
+            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
 }
 
 inline hipsolverStatus_t hipsolver_getrs(bool                    FORTRAN,
@@ -880,13 +965,16 @@ inline hipsolverStatus_t hipsolver_getrs(bool                    FORTRAN,
                                          hipsolverDoubleComplex* B,
                                          int                     ldb,
                                          int                     stB,
+                                         hipsolverDoubleComplex* work,
+                                         int                     lwork,
                                          int*                    info,
                                          int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+        return hipsolverZgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
     else
-        return hipsolverZgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info);
+        return hipsolverZgetrsFortran(
+            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
 }
 /********************************************************/
 

--- a/clients/include/hipsolver_fortran.f90
+++ b/clients/include/hipsolver_fortran.f90
@@ -1084,7 +1084,75 @@ module hipsolver_interface
     end function hipsolverZpotrfFortran
     
     ! ******************** POTRF_BATCHED ********************
-    function hipsolverSpotrfBatchedFortran(handle, uplo, n, A, lda, info, batch_count) &
+    function hipsolverSpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, batch_count) &
+            result(res) &
+            bind(c, name = 'hipsolverSpotrfBatched_bufferSizeFortran')
+        use iso_c_binding
+        use hipsolver_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: lwork
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipsolverSpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count)
+    end function hipsolverSpotrfBatched_bufferSizeFortran
+    
+    function hipsolverDpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, batch_count) &
+            result(res) &
+            bind(c, name = 'hipsolverDpotrfBatched_bufferSizeFortran')
+        use iso_c_binding
+        use hipsolver_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: lwork
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipsolverDpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count)
+    end function hipsolverDpotrfBatched_bufferSizeFortran
+    
+    function hipsolverCpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, batch_count) &
+            result(res) &
+            bind(c, name = 'hipsolverCpotrfBatched_bufferSizeFortran')
+        use iso_c_binding
+        use hipsolver_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: lwork
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipsolverCpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count)
+    end function hipsolverCpotrfBatched_bufferSizeFortran
+    
+    function hipsolverZpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, batch_count) &
+            result(res) &
+            bind(c, name = 'hipsolverZpotrfBatched_bufferSizeFortran')
+        use iso_c_binding
+        use hipsolver_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
+        integer(c_int), value :: n
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: lwork
+        integer(c_int), value :: batch_count
+        integer(c_int) :: res
+        res = hipsolverZpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count)
+    end function hipsolverZpotrfBatched_bufferSizeFortran
+
+    function hipsolverSpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
             result(res) &
             bind(c, name = 'hipsolverSpotrfBatchedFortran')
         use iso_c_binding
@@ -1095,13 +1163,15 @@ module hipsolver_interface
         integer(c_int), value :: n
         type(c_ptr), value :: A
         integer(c_int), value :: lda
+        type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: info
         integer(c_int), value :: batch_count
         integer(c_int) :: res
-        res = hipsolverSpotrfBatched(handle, uplo, n, A, lda, info, batch_count)
+        res = hipsolverSpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count)
     end function hipsolverSpotrfBatchedFortran
     
-    function hipsolverDpotrfBatchedFortran(handle, uplo, n, A, lda, info, batch_count) &
+    function hipsolverDpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
             result(res) &
             bind(c, name = 'hipsolverDpotrfBatchedFortran')
         use iso_c_binding
@@ -1112,13 +1182,15 @@ module hipsolver_interface
         integer(c_int), value :: n
         type(c_ptr), value :: A
         integer(c_int), value :: lda
+        type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: info
         integer(c_int), value :: batch_count
         integer(c_int) :: res
-        res = hipsolverDpotrfBatched(handle, uplo, n, A, lda, info, batch_count)
+        res = hipsolverDpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count)
     end function hipsolverDpotrfBatchedFortran
     
-    function hipsolverCpotrfBatchedFortran(handle, uplo, n, A, lda, info, batch_count) &
+    function hipsolverCpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
             result(res) &
             bind(c, name = 'hipsolverCpotrfBatchedFortran')
         use iso_c_binding
@@ -1129,13 +1201,15 @@ module hipsolver_interface
         integer(c_int), value :: n
         type(c_ptr), value :: A
         integer(c_int), value :: lda
+        type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: info
         integer(c_int), value :: batch_count
         integer(c_int) :: res
-        res = hipsolverCpotrfBatched(handle, uplo, n, A, lda, info, batch_count)
+        res = hipsolverCpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count)
     end function hipsolverCpotrfBatchedFortran
     
-    function hipsolverZpotrfBatchedFortran(handle, uplo, n, A, lda, info, batch_count) &
+    function hipsolverZpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
             result(res) &
             bind(c, name = 'hipsolverZpotrfBatchedFortran')
         use iso_c_binding
@@ -1146,10 +1220,12 @@ module hipsolver_interface
         integer(c_int), value :: n
         type(c_ptr), value :: A
         integer(c_int), value :: lda
+        type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: info
         integer(c_int), value :: batch_count
         integer(c_int) :: res
-        res = hipsolverZpotrfBatched(handle, uplo, n, A, lda, info, batch_count)
+        res = hipsolverZpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count)
     end function hipsolverZpotrfBatchedFortran
 
     ! ******************** SYTRD/HETRD ********************

--- a/clients/include/hipsolver_fortran.f90
+++ b/clients/include/hipsolver_fortran.f90
@@ -778,7 +778,87 @@ module hipsolver_interface
     end function hipsolverZgetrfFortran
     
     ! ******************** GETRS ********************
-    function hipsolverSgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info) &
+    function hipsolverSgetrs_bufferSizeFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
+            result(res) &
+            bind(c, name = 'hipsolverSgetrs_bufferSizeFortran')
+        use iso_c_binding
+        use hipsolver_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPSOLVER_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: lwork
+        integer(c_int) :: res
+        res = hipsolverSgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork)
+    end function hipsolverSgetrs_bufferSizeFortran
+    
+    function hipsolverDgetrs_bufferSizeFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
+            result(res) &
+            bind(c, name = 'hipsolverDgetrs_bufferSizeFortran')
+        use iso_c_binding
+        use hipsolver_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPSOLVER_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: lwork
+        integer(c_int) :: res
+        res = hipsolverDgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork)
+    end function hipsolverDgetrs_bufferSizeFortran
+    
+    function hipsolverCgetrs_bufferSizeFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
+            result(res) &
+            bind(c, name = 'hipsolverCgetrs_bufferSizeFortran')
+        use iso_c_binding
+        use hipsolver_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPSOLVER_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: lwork
+        integer(c_int) :: res
+        res = hipsolverCgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork)
+    end function hipsolverCgetrs_bufferSizeFortran
+    
+    function hipsolverZgetrs_bufferSizeFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
+            result(res) &
+            bind(c, name = 'hipsolverZgetrs_bufferSizeFortran')
+        use iso_c_binding
+        use hipsolver_enums
+        implicit none
+        type(c_ptr), value :: handle
+        integer(kind(HIPSOLVER_OP_N)), value :: trans
+        integer(c_int), value :: n
+        integer(c_int), value :: nrhs
+        type(c_ptr), value :: A
+        integer(c_int), value :: lda
+        type(c_ptr), value :: ipiv
+        type(c_ptr), value :: B
+        integer(c_int), value :: ldb
+        type(c_ptr), value :: lwork
+        integer(c_int) :: res
+        res = hipsolverZgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork)
+    end function hipsolverZgetrs_bufferSizeFortran
+
+    function hipsolverSgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
             result(res) &
             bind(c, name = 'hipsolverSgetrsFortran')
         use iso_c_binding
@@ -793,12 +873,14 @@ module hipsolver_interface
         type(c_ptr), value :: ipiv
         type(c_ptr), value :: B
         integer(c_int), value :: ldb
+        type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: info
         integer(c_int) :: res
-        res = hipsolverSgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info)
+        res = hipsolverSgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info)
     end function hipsolverSgetrsFortran
     
-    function hipsolverDgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info) &
+    function hipsolverDgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
             result(res) &
             bind(c, name = 'hipsolverDgetrsFortran')
         use iso_c_binding
@@ -813,12 +895,14 @@ module hipsolver_interface
         type(c_ptr), value :: ipiv
         type(c_ptr), value :: B
         integer(c_int), value :: ldb
+        type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: info
         integer(c_int) :: res
-        res = hipsolverDgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info)
+        res = hipsolverDgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info)
     end function hipsolverDgetrsFortran
     
-    function hipsolverCgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info) &
+    function hipsolverCgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
             result(res) &
             bind(c, name = 'hipsolverCgetrsFortran')
         use iso_c_binding
@@ -833,12 +917,14 @@ module hipsolver_interface
         type(c_ptr), value :: ipiv
         type(c_ptr), value :: B
         integer(c_int), value :: ldb
+        type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: info
         integer(c_int) :: res
-        res = hipsolverCgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info)
+        res = hipsolverCgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info)
     end function hipsolverCgetrsFortran
     
-    function hipsolverZgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info) &
+    function hipsolverZgetrsFortran(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
             result(res) &
             bind(c, name = 'hipsolverZgetrsFortran')
         use iso_c_binding
@@ -853,9 +939,11 @@ module hipsolver_interface
         type(c_ptr), value :: ipiv
         type(c_ptr), value :: B
         integer(c_int), value :: ldb
+        type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: info
         integer(c_int) :: res
-        res = hipsolverZgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info)
+        res = hipsolverZgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info)
     end function hipsolverZgetrsFortran
 
     ! ******************** POTRF ********************

--- a/clients/include/hipsolver_fortran.f90
+++ b/clients/include/hipsolver_fortran.f90
@@ -701,7 +701,7 @@ module hipsolver_interface
         res = hipsolverZgetrf_bufferSize(handle, m, n, A, lda, lwork)
     end function hipsolverZgetrf_bufferSizeFortran
 
-    function hipsolverSgetrfFortran(handle, m, n, A, lda, work, ipiv, info) &
+    function hipsolverSgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info) &
             result(res) &
             bind(c, name = 'hipsolverSgetrfFortran')
         use iso_c_binding
@@ -713,13 +713,14 @@ module hipsolver_interface
         type(c_ptr), value :: A
         integer(c_int), value :: lda
         type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: ipiv
         type(c_ptr), value :: info
         integer(c_int) :: res
-        res = hipsolverSgetrf(handle, m, n, A, lda, work, ipiv, info)
+        res = hipsolverSgetrf(handle, m, n, A, lda, work, lwork, ipiv, info)
     end function hipsolverSgetrfFortran
     
-    function hipsolverDgetrfFortran(handle, m, n, A, lda, work, ipiv, info) &
+    function hipsolverDgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info) &
             result(res) &
             bind(c, name = 'hipsolverDgetrfFortran')
         use iso_c_binding
@@ -731,13 +732,14 @@ module hipsolver_interface
         type(c_ptr), value :: A
         integer(c_int), value :: lda
         type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: ipiv
         type(c_ptr), value :: info
         integer(c_int) :: res
-        res = hipsolverDgetrf(handle, m, n, A, lda, work, ipiv, info)
+        res = hipsolverDgetrf(handle, m, n, A, lda, work, lwork, ipiv, info)
     end function hipsolverDgetrfFortran
     
-    function hipsolverCgetrfFortran(handle, m, n, A, lda, work, ipiv, info) &
+    function hipsolverCgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info) &
             result(res) &
             bind(c, name = 'hipsolverCgetrfFortran')
         use iso_c_binding
@@ -749,13 +751,14 @@ module hipsolver_interface
         type(c_ptr), value :: A
         integer(c_int), value :: lda
         type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: ipiv
         type(c_ptr), value :: info
         integer(c_int) :: res
-        res = hipsolverCgetrf(handle, m, n, A, lda, work, ipiv, info)
+        res = hipsolverCgetrf(handle, m, n, A, lda, work, lwork, ipiv, info)
     end function hipsolverCgetrfFortran
 
-    function hipsolverZgetrfFortran(handle, m, n, A, lda, work, ipiv, info) &
+    function hipsolverZgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info) &
             result(res) &
             bind(c, name = 'hipsolverZgetrfFortran')
         use iso_c_binding
@@ -767,10 +770,11 @@ module hipsolver_interface
         type(c_ptr), value :: A
         integer(c_int), value :: lda
         type(c_ptr), value :: work
+        integer(c_int), value :: lwork
         type(c_ptr), value :: ipiv
         type(c_ptr), value :: info
         integer(c_int) :: res
-        res = hipsolverZgetrf(handle, m, n, A, lda, work, ipiv, info)
+        res = hipsolverZgetrf(handle, m, n, A, lda, work, lwork, ipiv, info)
     end function hipsolverZgetrfFortran
     
     ! ******************** GETRS ********************

--- a/clients/include/hipsolver_fortran.hpp
+++ b/clients/include/hipsolver_fortran.hpp
@@ -538,11 +538,49 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfFortran(hipsolverHandle_t     
                                                           int*                    devInfo);
 
 // potrf_batched
+HIPSOLVER_EXPORT hipsolverStatus_t
+    hipsolverSpotrfBatched_bufferSizeFortran(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             float*              A[],
+                                             int                 lda,
+                                             int*                lwork,
+                                             int                 batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t
+    hipsolverDpotrfBatched_bufferSizeFortran(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             double*             A[],
+                                             int                 lda,
+                                             int*                lwork,
+                                             int                 batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t
+    hipsolverCpotrfBatched_bufferSizeFortran(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipsolverComplex*   A[],
+                                             int                 lda,
+                                             int*                lwork,
+                                             int                 batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t
+    hipsolverZpotrfBatched_bufferSizeFortran(hipsolverHandle_t       handle,
+                                             hipsolverFillMode_t     uplo,
+                                             int                     n,
+                                             hipsolverDoubleComplex* A[],
+                                             int                     lda,
+                                             int*                    lwork,
+                                             int                     batch_count);
+
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrfBatchedFortran(hipsolverHandle_t   handle,
                                                                  hipsolverFillMode_t uplo,
                                                                  int                 n,
                                                                  float*              A[],
                                                                  int                 lda,
+                                                                 float*              work,
+                                                                 int                 lwork,
                                                                  int*                devInfo,
                                                                  int                 batch_count);
 
@@ -551,6 +589,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrfBatchedFortran(hipsolverHandle
                                                                  int                 n,
                                                                  double*             A[],
                                                                  int                 lda,
+                                                                 double*             work,
+                                                                 int                 lwork,
                                                                  int*                devInfo,
                                                                  int                 batch_count);
 
@@ -559,6 +599,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrfBatchedFortran(hipsolverHandle
                                                                  int                 n,
                                                                  hipsolverComplex*   A[],
                                                                  int                 lda,
+                                                                 hipsolverComplex*   work,
+                                                                 int                 lwork,
                                                                  int*                devInfo,
                                                                  int                 batch_count);
 
@@ -567,6 +609,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfBatchedFortran(hipsolverHandle
                                                                  int                     n,
                                                                  hipsolverDoubleComplex* A[],
                                                                  int                     lda,
+                                                                 hipsolverDoubleComplex* work,
+                                                                 int                     lwork,
                                                                  int*                    devInfo,
                                                                  int batch_count);
 

--- a/clients/include/hipsolver_fortran.hpp
+++ b/clients/include/hipsolver_fortran.hpp
@@ -384,6 +384,50 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrfFortran(hipsolverHandle_t     
                                                           int*                    devInfo);
 
 // getrs
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrs_bufferSizeFortran(hipsolverHandle_t    handle,
+                                                                     hipsolverOperation_t trans,
+                                                                     int                  n,
+                                                                     int                  nrhs,
+                                                                     float*               A,
+                                                                     int                  lda,
+                                                                     int*                 devIpiv,
+                                                                     float*               B,
+                                                                     int                  ldb,
+                                                                     int*                 lwork);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrs_bufferSizeFortran(hipsolverHandle_t    handle,
+                                                                     hipsolverOperation_t trans,
+                                                                     int                  n,
+                                                                     int                  nrhs,
+                                                                     double*              A,
+                                                                     int                  lda,
+                                                                     int*                 devIpiv,
+                                                                     double*              B,
+                                                                     int                  ldb,
+                                                                     int*                 lwork);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrs_bufferSizeFortran(hipsolverHandle_t    handle,
+                                                                     hipsolverOperation_t trans,
+                                                                     int                  n,
+                                                                     int                  nrhs,
+                                                                     hipsolverComplex*    A,
+                                                                     int                  lda,
+                                                                     int*                 devIpiv,
+                                                                     hipsolverComplex*    B,
+                                                                     int                  ldb,
+                                                                     int*                 lwork);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs_bufferSizeFortran(hipsolverHandle_t       handle,
+                                                                     hipsolverOperation_t    trans,
+                                                                     int                     n,
+                                                                     int                     nrhs,
+                                                                     hipsolverDoubleComplex* A,
+                                                                     int                     lda,
+                                                                     int* devIpiv,
+                                                                     hipsolverDoubleComplex* B,
+                                                                     int                     ldb,
+                                                                     int*                    lwork);
+
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrsFortran(hipsolverHandle_t    handle,
                                                           hipsolverOperation_t trans,
                                                           int                  n,
@@ -393,6 +437,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrsFortran(hipsolverHandle_t    h
                                                           int*                 devIpiv,
                                                           float*               B,
                                                           int                  ldb,
+                                                          float*               work,
+                                                          int                  lwork,
                                                           int*                 devInfo);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrsFortran(hipsolverHandle_t    handle,
@@ -404,6 +450,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrsFortran(hipsolverHandle_t    h
                                                           int*                 devIpiv,
                                                           double*              B,
                                                           int                  ldb,
+                                                          double*              work,
+                                                          int                  lwork,
                                                           int*                 devInfo);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrsFortran(hipsolverHandle_t    handle,
@@ -415,6 +463,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrsFortran(hipsolverHandle_t    h
                                                           int*                 devIpiv,
                                                           hipsolverComplex*    B,
                                                           int                  ldb,
+                                                          hipsolverComplex*    work,
+                                                          int                  lwork,
                                                           int*                 devInfo);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrsFortran(hipsolverHandle_t       handle,
@@ -426,6 +476,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrsFortran(hipsolverHandle_t     
                                                           int*                    devIpiv,
                                                           hipsolverDoubleComplex* B,
                                                           int                     ldb,
+                                                          hipsolverDoubleComplex* work,
+                                                          int                     lwork,
                                                           int*                    devInfo);
 
 // potrf

--- a/clients/include/hipsolver_fortran.hpp
+++ b/clients/include/hipsolver_fortran.hpp
@@ -349,6 +349,7 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrfFortran(hipsolverHandle_t hand
                                                           float*            A,
                                                           int               lda,
                                                           float*            work,
+                                                          int               lwork,
                                                           int*              devIpiv,
                                                           int*              devInfo);
 
@@ -358,6 +359,7 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrfFortran(hipsolverHandle_t hand
                                                           double*           A,
                                                           int               lda,
                                                           double*           work,
+                                                          int               lwork,
                                                           int*              devIpiv,
                                                           int*              devInfo);
 
@@ -367,6 +369,7 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrfFortran(hipsolverHandle_t hand
                                                           hipsolverComplex* A,
                                                           int               lda,
                                                           hipsolverComplex* work,
+                                                          int               lwork,
                                                           int*              devIpiv,
                                                           int*              devInfo);
 
@@ -376,6 +379,7 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrfFortran(hipsolverHandle_t     
                                                           hipsolverDoubleComplex* A,
                                                           int                     lda,
                                                           hipsolverDoubleComplex* work,
+                                                          int                     lwork,
                                                           int*                    devIpiv,
                                                           int*                    devInfo);
 

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -12,6 +12,7 @@ void getrf_checkBadArgs(const hipsolverHandle_t handle,
                         const int               lda,
                         const int               stA,
                         U                       dWork,
+                        const int               lwork,
                         V                       dIpiv,
                         const int               stP,
                         V                       dinfo,
@@ -20,20 +21,32 @@ void getrf_checkBadArgs(const hipsolverHandle_t handle,
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_getrf(FORTRAN, false, nullptr, m, n, dA, lda, stA, dWork, dIpiv, stP, dinfo, bc),
+        hipsolver_getrf(
+            FORTRAN, false, nullptr, m, n, dA, lda, stA, dWork, lwork, dIpiv, stP, dinfo, bc),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
     // N/A
 
     // pointers
+    EXPECT_ROCBLAS_STATUS(hipsolver_getrf(FORTRAN,
+                                          false,
+                                          handle,
+                                          m,
+                                          n,
+                                          (T) nullptr,
+                                          lda,
+                                          stA,
+                                          dWork,
+                                          lwork,
+                                          dIpiv,
+                                          stP,
+                                          dinfo,
+                                          bc),
+                          HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
         hipsolver_getrf(
-            FORTRAN, false, handle, m, n, (T) nullptr, lda, stA, dWork, dIpiv, stP, dinfo, bc),
-        HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(
-        hipsolver_getrf(
-            FORTRAN, false, handle, m, n, dA, lda, stA, dWork, dIpiv, stP, (V) nullptr, bc),
+            FORTRAN, false, handle, m, n, dA, lda, stA, dWork, lwork, dIpiv, stP, (V) nullptr, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
@@ -68,7 +81,7 @@ void testing_getrf_bad_arg()
 
         // // check bad arguments
         // getrf_checkBadArgs<FORTRAN>(
-        //     handle, m, n, dA.data(), lda, stA, dWork.data(), dIpiv.data(), stP, dInfo.data(), bc);
+        //     handle, m, n, dA.data(), lda, stA, dWork.data(), size_W, dIpiv.data(), stP, dInfo.data(), bc);
     }
     else
     {
@@ -87,8 +100,18 @@ void testing_getrf_bad_arg()
             CHECK_HIP_ERROR(dWork.memcheck());
 
         // check bad arguments
-        getrf_checkBadArgs<FORTRAN>(
-            handle, m, n, dA.data(), lda, stA, dWork.data(), dIpiv.data(), stP, dInfo.data(), bc);
+        getrf_checkBadArgs<FORTRAN>(handle,
+                                    m,
+                                    n,
+                                    dA.data(),
+                                    lda,
+                                    stA,
+                                    dWork.data(),
+                                    size_W,
+                                    dIpiv.data(),
+                                    stP,
+                                    dInfo.data(),
+                                    bc);
     }
 }
 
@@ -155,6 +178,7 @@ void getrf_getError(const hipsolverHandle_t handle,
                     const int               lda,
                     const int               stA,
                     Td&                     dWork,
+                    const int               lwork,
                     Ud&                     dIpiv,
                     const int               stP,
                     Ud&                     dInfo,
@@ -182,6 +206,7 @@ void getrf_getError(const hipsolverHandle_t handle,
                                         lda,
                                         stA,
                                         dWork.data(),
+                                        lwork,
                                         dIpiv.data(),
                                         stP,
                                         dInfo.data(),
@@ -230,6 +255,7 @@ void getrf_getPerfData(const hipsolverHandle_t handle,
                        const int               lda,
                        const int               stA,
                        Td&                     dWork,
+                       const int               lwork,
                        Ud&                     dIpiv,
                        const int               stP,
                        Ud&                     dInfo,
@@ -272,6 +298,7 @@ void getrf_getPerfData(const hipsolverHandle_t handle,
                                             lda,
                                             stA,
                                             dWork.data(),
+                                            lwork,
                                             dIpiv.data(),
                                             stP,
                                             dInfo.data(),
@@ -298,6 +325,7 @@ void getrf_getPerfData(const hipsolverHandle_t handle,
                         lda,
                         stA,
                         dWork.data(),
+                        lwork,
                         dIpiv.data(),
                         stP,
                         dInfo.data(),
@@ -350,6 +378,7 @@ void testing_getrf(Arguments& argus)
             //                                       lda,
             //                                       stA,
             //                                       (T*)nullptr,
+            //                                       0,
             //                                       (int*)nullptr,
             //                                       stP,
             //                                       (int*)nullptr,
@@ -367,6 +396,7 @@ void testing_getrf(Arguments& argus)
                                                   lda,
                                                   stA,
                                                   (T*)nullptr,
+                                                  0,
                                                   (int*)nullptr,
                                                   stP,
                                                   (int*)nullptr,
@@ -413,6 +443,7 @@ void testing_getrf(Arguments& argus)
         //                                lda,
         //                                stA,
         //                                dWork,
+        //                                size_W,
         //                                dIpiv,
         //                                stP,
         //                                dInfo,
@@ -434,6 +465,7 @@ void testing_getrf(Arguments& argus)
         //                                   lda,
         //                                   stA,
         //                                   dWork,
+        //                                   size_W,
         //                                   dIpiv,
         //                                   stP,
         //                                   dInfo,
@@ -480,6 +512,7 @@ void testing_getrf(Arguments& argus)
                                        lda,
                                        stA,
                                        dWork,
+                                       size_W,
                                        dIpiv,
                                        stP,
                                        dInfo,
@@ -501,6 +534,7 @@ void testing_getrf(Arguments& argus)
                                           lda,
                                           stA,
                                           dWork,
+                                          size_W,
                                           dIpiv,
                                           stP,
                                           dInfo,

--- a/clients/include/testing_getrf_npvt.hpp
+++ b/clients/include/testing_getrf_npvt.hpp
@@ -12,6 +12,7 @@ void getrf_npvt_checkBadArgs(const hipsolverHandle_t handle,
                              const int               lda,
                              const int               stA,
                              U                       dWork,
+                             const int               lwork,
                              V                       dIpiv,
                              const int               stP,
                              V                       dinfo,
@@ -20,20 +21,32 @@ void getrf_npvt_checkBadArgs(const hipsolverHandle_t handle,
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_getrf(FORTRAN, true, nullptr, m, n, dA, lda, stA, dWork, dIpiv, stP, dinfo, bc),
+        hipsolver_getrf(
+            FORTRAN, true, nullptr, m, n, dA, lda, stA, dWork, lwork, dIpiv, stP, dinfo, bc),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
     // N/A
 
     // pointers
+    EXPECT_ROCBLAS_STATUS(hipsolver_getrf(FORTRAN,
+                                          true,
+                                          handle,
+                                          m,
+                                          n,
+                                          (T) nullptr,
+                                          lda,
+                                          stA,
+                                          dWork,
+                                          lwork,
+                                          dIpiv,
+                                          stP,
+                                          dinfo,
+                                          bc),
+                          HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
         hipsolver_getrf(
-            FORTRAN, true, handle, m, n, (T) nullptr, lda, stA, dWork, dIpiv, stP, dinfo, bc),
-        HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(
-        hipsolver_getrf(
-            FORTRAN, true, handle, m, n, dA, lda, stA, dWork, dIpiv, stP, (V) nullptr, bc),
+            FORTRAN, true, handle, m, n, dA, lda, stA, dWork, lwork, dIpiv, stP, (V) nullptr, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
@@ -68,7 +81,7 @@ void testing_getrf_npvt_bad_arg()
 
         // // check bad arguments
         // getrf_npvt_checkBadArgs<FORTRAN>(
-        //     handle, m, n, dA.data(), lda, stA, dWork.data(), dIpiv.data(), stP, dInfo.data(), bc);
+        //     handle, m, n, dA.data(), lda, stA, dWork.data(), size_W, dIpiv.data(), stP, dInfo.data(), bc);
     }
     else
     {
@@ -87,8 +100,18 @@ void testing_getrf_npvt_bad_arg()
             CHECK_HIP_ERROR(dWork.memcheck());
 
         // check bad arguments
-        getrf_npvt_checkBadArgs<FORTRAN>(
-            handle, m, n, dA.data(), lda, stA, dWork.data(), dIpiv.data(), stP, dInfo.data(), bc);
+        getrf_npvt_checkBadArgs<FORTRAN>(handle,
+                                         m,
+                                         n,
+                                         dA.data(),
+                                         lda,
+                                         stA,
+                                         dWork.data(),
+                                         size_W,
+                                         dIpiv.data(),
+                                         stP,
+                                         dInfo.data(),
+                                         bc);
     }
 }
 
@@ -140,6 +163,7 @@ void getrf_npvt_getError(const hipsolverHandle_t handle,
                          const int               lda,
                          const int               stA,
                          Td&                     dWork,
+                         const int               lwork,
                          Ud&                     dInfo,
                          const int               bc,
                          Th&                     hA,
@@ -163,6 +187,7 @@ void getrf_npvt_getError(const hipsolverHandle_t handle,
                                         lda,
                                         stA,
                                         dWork.data(),
+                                        lwork,
                                         (int*)nullptr,
                                         0,
                                         dInfo.data(),
@@ -203,6 +228,7 @@ void getrf_npvt_getPerfData(const hipsolverHandle_t handle,
                             const int               lda,
                             const int               stA,
                             Td&                     dWork,
+                            const int               lwork,
                             Ud&                     dInfo,
                             const int               bc,
                             Th&                     hA,
@@ -240,6 +266,7 @@ void getrf_npvt_getPerfData(const hipsolverHandle_t handle,
                                             lda,
                                             stA,
                                             dWork.data(),
+                                            lwork,
                                             (int*)nullptr,
                                             0,
                                             dInfo.data(),
@@ -265,6 +292,7 @@ void getrf_npvt_getPerfData(const hipsolverHandle_t handle,
                         lda,
                         stA,
                         dWork.data(),
+                        lwork,
                         (int*)nullptr,
                         0,
                         dInfo.data(),
@@ -315,6 +343,7 @@ void testing_getrf_npvt(Arguments& argus)
             //                                       lda,
             //                                       stA,
             //                                       (T*)nullptr,
+            //                                       0,
             //                                       (int*)nullptr,
             //                                       0,
             //                                       (int*)nullptr,
@@ -332,6 +361,7 @@ void testing_getrf_npvt(Arguments& argus)
                                                   lda,
                                                   stA,
                                                   (T*)nullptr,
+                                                  0,
                                                   (int*)nullptr,
                                                   0,
                                                   (int*)nullptr,
@@ -374,6 +404,7 @@ void testing_getrf_npvt(Arguments& argus)
         //                                     lda,
         //                                     stA,
         //                                     dWork,
+        //                                     size_W,
         //                                     dInfo,
         //                                     bc,
         //                                     hA,
@@ -392,6 +423,7 @@ void testing_getrf_npvt(Arguments& argus)
         //                                        lda,
         //                                        stA,
         //                                        dWork,
+        //                                        size_W,
         //                                        dInfo,
         //                                        bc,
         //                                        hA,
@@ -432,6 +464,7 @@ void testing_getrf_npvt(Arguments& argus)
                                             lda,
                                             stA,
                                             dWork,
+                                            size_W,
                                             dInfo,
                                             bc,
                                             hA,
@@ -450,6 +483,7 @@ void testing_getrf_npvt(Arguments& argus)
                                                lda,
                                                stA,
                                                dWork,
+                                               size_W,
                                                dInfo,
                                                bc,
                                                hA,

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -19,14 +19,30 @@ void getrs_checkBadArgs(const hipsolverHandle_t    handle,
                         T                          dB,
                         const int                  ldb,
                         const int                  stB,
+                        T                          dWork,
+                        const int                  lwork,
                         U                          dInfo,
                         const int                  bc)
 {
     // handle
-    EXPECT_ROCBLAS_STATUS(
-        hipsolver_getrs(
-            FORTRAN, nullptr, trans, m, nrhs, dA, lda, stA, dIpiv, stP, dB, ldb, stB, dInfo, bc),
-        HIPSOLVER_STATUS_NOT_INITIALIZED);
+    EXPECT_ROCBLAS_STATUS(hipsolver_getrs(FORTRAN,
+                                          nullptr,
+                                          trans,
+                                          m,
+                                          nrhs,
+                                          dA,
+                                          lda,
+                                          stA,
+                                          dIpiv,
+                                          stP,
+                                          dB,
+                                          ldb,
+                                          stB,
+                                          dWork,
+                                          lwork,
+                                          dInfo,
+                                          bc),
+                          HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
     EXPECT_ROCBLAS_STATUS(hipsolver_getrs(FORTRAN,
@@ -42,6 +58,8 @@ void getrs_checkBadArgs(const hipsolverHandle_t    handle,
                                           dB,
                                           ldb,
                                           stB,
+                                          dWork,
+                                          lwork,
                                           dInfo,
                                           bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
@@ -61,6 +79,8 @@ void getrs_checkBadArgs(const hipsolverHandle_t    handle,
                                           dB,
                                           ldb,
                                           stB,
+                                          dWork,
+                                          lwork,
                                           dInfo,
                                           bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
@@ -77,6 +97,8 @@ void getrs_checkBadArgs(const hipsolverHandle_t    handle,
                                           dB,
                                           ldb,
                                           stB,
+                                          dWork,
+                                          lwork,
                                           dInfo,
                                           bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
@@ -93,6 +115,8 @@ void getrs_checkBadArgs(const hipsolverHandle_t    handle,
                                           (T) nullptr,
                                           ldb,
                                           stB,
+                                          dWork,
+                                          lwork,
                                           dInfo,
                                           bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
@@ -126,6 +150,12 @@ void testing_getrs_bad_arg()
         // CHECK_HIP_ERROR(dIpiv.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
 
+        // int size_W;
+        // hipsolver_getrs_bufferSize(FORTRAN, handle, trans, m, nrhs, dA.data(), lda, dIpiv.data(), dB.data(), ldb, &size_W);
+        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
+        // if(size_W)
+        //     CHECK_HIP_ERROR(dWork.memcheck());
+
         // // check bad arguments
         // getrs_checkBadArgs<FORTRAN>(handle,
         //                             trans,
@@ -154,6 +184,13 @@ void testing_getrs_bad_arg()
         CHECK_HIP_ERROR(dIpiv.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
 
+        int size_W;
+        hipsolver_getrs_bufferSize(
+            FORTRAN, handle, trans, m, nrhs, dA.data(), lda, dIpiv.data(), dB.data(), ldb, &size_W);
+        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
+        if(size_W)
+            CHECK_HIP_ERROR(dWork.memcheck());
+
         // check bad arguments
         getrs_checkBadArgs<FORTRAN>(handle,
                                     trans,
@@ -167,6 +204,8 @@ void testing_getrs_bad_arg()
                                     dB.data(),
                                     ldb,
                                     stB,
+                                    dWork.data(),
+                                    size_W,
                                     dInfo.data(),
                                     bc);
     }
@@ -240,6 +279,8 @@ void getrs_getError(const hipsolverHandle_t    handle,
                     Td&                        dB,
                     const int                  ldb,
                     const int                  stB,
+                    Td&                        dWork,
+                    const int                  lwork,
                     Ud&                        dInfo,
                     const int                  bc,
                     Th&                        hA,
@@ -268,6 +309,8 @@ void getrs_getError(const hipsolverHandle_t    handle,
                                         dB.data(),
                                         ldb,
                                         stB,
+                                        dWork.data(),
+                                        lwork,
                                         dInfo.data(),
                                         bc));
     CHECK_HIP_ERROR(hBRes.transfer_from(dB));
@@ -304,6 +347,8 @@ void getrs_getPerfData(const hipsolverHandle_t    handle,
                        Td&                        dB,
                        const int                  ldb,
                        const int                  stB,
+                       Td&                        dWork,
+                       const int                  lwork,
                        Ud&                        dInfo,
                        const int                  bc,
                        Th&                        hA,
@@ -351,6 +396,8 @@ void getrs_getPerfData(const hipsolverHandle_t    handle,
                                             dB.data(),
                                             ldb,
                                             stB,
+                                            dWork.data(),
+                                            lwork,
                                             dInfo.data(),
                                             bc));
     }
@@ -379,6 +426,8 @@ void getrs_getPerfData(const hipsolverHandle_t    handle,
                         dB.data(),
                         ldb,
                         stB,
+                        dWork.data(),
+                        lwork,
                         dInfo.data(),
                         bc);
         *gpu_time_used += get_time_us_sync(stream) - start;
@@ -436,6 +485,8 @@ void testing_getrs(Arguments& argus)
             //                                       (T* const*)nullptr,
             //                                       ldb,
             //                                       stB,
+            //                                       (T*)nullptr,
+            //                                       0,
             //                                       (int*)nullptr,
             //                                       bc),
             //                       HIPSOLVER_STATUS_INVALID_VALUE);
@@ -455,6 +506,8 @@ void testing_getrs(Arguments& argus)
                                                   (T*)nullptr,
                                                   ldb,
                                                   stB,
+                                                  (T*)nullptr,
+                                                  0,
                                                   (int*)nullptr,
                                                   bc),
                                   HIPSOLVER_STATUS_INVALID_VALUE);
@@ -486,6 +539,13 @@ void testing_getrs(Arguments& argus)
         //     CHECK_HIP_ERROR(dIpiv.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
 
+        // int size_W;
+        // hipsolver_getrs_bufferSize(
+        //    FORTRAN, handle, trans, m, nrhs, dA.data(), lda, dIpiv.data(), dB.data(), ldb, &size_W);
+        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
+        // if(size_W)
+        //     CHECK_HIP_ERROR(dWork.memcheck());
+
         // // check computations
         // if(argus.unit_check || argus.norm_check)
         //     getrs_getError<FORTRAN, T>(handle,
@@ -500,6 +560,8 @@ void testing_getrs(Arguments& argus)
         //                                dB,
         //                                ldb,
         //                                stB,
+        //                                dWork,
+        //                                size_W,
         //                                dInfo,
         //                                bc,
         //                                hA,
@@ -523,6 +585,8 @@ void testing_getrs(Arguments& argus)
         //                                   dB,
         //                                   ldb,
         //                                   stB,
+        //                                   dWork,
+        //                                   size_W,
         //                                   dInfo,
         //                                   bc,
         //                                   hA,
@@ -555,6 +619,13 @@ void testing_getrs(Arguments& argus)
             CHECK_HIP_ERROR(dIpiv.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
 
+        int size_W;
+        hipsolver_getrs_bufferSize(
+            FORTRAN, handle, trans, m, nrhs, dA.data(), lda, dIpiv.data(), dB.data(), ldb, &size_W);
+        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
+        if(size_W)
+            CHECK_HIP_ERROR(dWork.memcheck());
+
         // check computations
         if(argus.unit_check || argus.norm_check)
             getrs_getError<FORTRAN, T>(handle,
@@ -569,6 +640,8 @@ void testing_getrs(Arguments& argus)
                                        dB,
                                        ldb,
                                        stB,
+                                       dWork,
+                                       size_W,
                                        dInfo,
                                        bc,
                                        hA,
@@ -592,6 +665,8 @@ void testing_getrs(Arguments& argus)
                                           dB,
                                           ldb,
                                           stB,
+                                          dWork,
+                                          size_W,
                                           dInfo,
                                           bc,
                                           hA,

--- a/clients/include/testing_potrf.hpp
+++ b/clients/include/testing_potrf.hpp
@@ -59,8 +59,8 @@ void testing_potrf_bad_arg()
         CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dinfo.memcheck());
 
-        int size_W = 0;
-        // hipsolver_potrf_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W);
+        int size_W;
+        hipsolver_potrf_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W, bc);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
@@ -78,7 +78,7 @@ void testing_potrf_bad_arg()
         CHECK_HIP_ERROR(dinfo.memcheck());
 
         int size_W;
-        hipsolver_potrf_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W);
+        hipsolver_potrf_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W, bc);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
@@ -370,8 +370,8 @@ void testing_potrf(Arguments& argus)
             CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
 
-        int size_W = 0;
-        // hipsolver_potrf_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W);
+        int size_W;
+        hipsolver_potrf_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W, bc);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
@@ -429,7 +429,7 @@ void testing_potrf(Arguments& argus)
         CHECK_HIP_ERROR(dInfo.memcheck());
 
         int size_W;
-        hipsolver_potrf_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W);
+        hipsolver_potrf_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W, bc);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());

--- a/clients/samples/example_basic.c
+++ b/clients/samples/example_basic.c
@@ -76,7 +76,8 @@ int main()
     hipMalloc((void**)&dWork, sizeof(double) * size_work);
 
     // compute the LU factorization on the GPU
-    hipsolverStatus_t status = hipsolverDgetrf(handle, M, N, dA, lda, dWork, dIpiv, dInfo);
+    hipsolverStatus_t status
+        = hipsolverDgetrf(handle, M, N, dA, lda, dWork, size_work, dIpiv, dInfo);
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
 

--- a/clients/samples/example_basic.cpp
+++ b/clients/samples/example_basic.cpp
@@ -74,7 +74,8 @@ int main()
     hipMalloc(&dWork, sizeof(double) * size_work);
 
     // compute the LU factorization on the GPU
-    hipsolverStatus_t status = hipsolverDgetrf(handle, M, N, dA, lda, dWork, dIpiv, dInfo);
+    hipsolverStatus_t status
+        = hipsolverDgetrf(handle, M, N, dA, lda, dWork, size_work, dIpiv, dInfo);
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
 

--- a/library/include/hipsolver.h
+++ b/library/include/hipsolver.h
@@ -713,11 +713,45 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrf(hipsolverHandle_t       handl
                                                    int*                    devInfo);
 
 // potrf_batched
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                                     hipsolverFillMode_t uplo,
+                                                                     int                 n,
+                                                                     float*              A[],
+                                                                     int                 lda,
+                                                                     int*                lwork,
+                                                                     int batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                                     hipsolverFillMode_t uplo,
+                                                                     int                 n,
+                                                                     double*             A[],
+                                                                     int                 lda,
+                                                                     int*                lwork,
+                                                                     int batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                                     hipsolverFillMode_t uplo,
+                                                                     int                 n,
+                                                                     hipsolverComplex*   A[],
+                                                                     int                 lda,
+                                                                     int*                lwork,
+                                                                     int batch_count);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t       handle,
+                                                                     hipsolverFillMode_t     uplo,
+                                                                     int                     n,
+                                                                     hipsolverDoubleComplex* A[],
+                                                                     int                     lda,
+                                                                     int*                    lwork,
+                                                                     int batch_count);
+
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrfBatched(hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
                                                           float*              A[],
                                                           int                 lda,
+                                                          float*              work,
+                                                          int                 lwork,
                                                           int*                devInfo,
                                                           int                 batch_count);
 
@@ -726,6 +760,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrfBatched(hipsolverHandle_t   ha
                                                           int                 n,
                                                           double*             A[],
                                                           int                 lda,
+                                                          double*             work,
+                                                          int                 lwork,
                                                           int*                devInfo,
                                                           int                 batch_count);
 
@@ -734,6 +770,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrfBatched(hipsolverHandle_t   ha
                                                           int                 n,
                                                           hipsolverComplex*   A[],
                                                           int                 lda,
+                                                          hipsolverComplex*   work,
+                                                          int                 lwork,
                                                           int*                devInfo,
                                                           int                 batch_count);
 
@@ -742,6 +780,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t     
                                                           int                     n,
                                                           hipsolverDoubleComplex* A[],
                                                           int                     lda,
+                                                          hipsolverDoubleComplex* work,
+                                                          int                     lwork,
                                                           int*                    devInfo,
                                                           int                     batch_count);
 

--- a/library/include/hipsolver.h
+++ b/library/include/hipsolver.h
@@ -559,6 +559,50 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t       handl
                                                    int*                    devInfo);
 
 // getrs
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,
+                                                              hipsolverOperation_t trans,
+                                                              int                  n,
+                                                              int                  nrhs,
+                                                              float*               A,
+                                                              int                  lda,
+                                                              int*                 devIpiv,
+                                                              float*               B,
+                                                              int                  ldb,
+                                                              int*                 lwork);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrs_bufferSize(hipsolverHandle_t    handle,
+                                                              hipsolverOperation_t trans,
+                                                              int                  n,
+                                                              int                  nrhs,
+                                                              double*              A,
+                                                              int                  lda,
+                                                              int*                 devIpiv,
+                                                              double*              B,
+                                                              int                  ldb,
+                                                              int*                 lwork);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrs_bufferSize(hipsolverHandle_t    handle,
+                                                              hipsolverOperation_t trans,
+                                                              int                  n,
+                                                              int                  nrhs,
+                                                              hipsolverComplex*    A,
+                                                              int                  lda,
+                                                              int*                 devIpiv,
+                                                              hipsolverComplex*    B,
+                                                              int                  ldb,
+                                                              int*                 lwork);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t       handle,
+                                                              hipsolverOperation_t    trans,
+                                                              int                     n,
+                                                              int                     nrhs,
+                                                              hipsolverDoubleComplex* A,
+                                                              int                     lda,
+                                                              int*                    devIpiv,
+                                                              hipsolverDoubleComplex* B,
+                                                              int                     ldb,
+                                                              int*                    lwork);
+
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrs(hipsolverHandle_t    handle,
                                                    hipsolverOperation_t trans,
                                                    int                  n,
@@ -568,6 +612,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrs(hipsolverHandle_t    handle,
                                                    int*                 devIpiv,
                                                    float*               B,
                                                    int                  ldb,
+                                                   float*               work,
+                                                   int                  lwork,
                                                    int*                 devInfo);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrs(hipsolverHandle_t    handle,
@@ -579,6 +625,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrs(hipsolverHandle_t    handle,
                                                    int*                 devIpiv,
                                                    double*              B,
                                                    int                  ldb,
+                                                   double*              work,
+                                                   int                  lwork,
                                                    int*                 devInfo);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrs(hipsolverHandle_t    handle,
@@ -590,6 +638,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrs(hipsolverHandle_t    handle,
                                                    int*                 devIpiv,
                                                    hipsolverComplex*    B,
                                                    int                  ldb,
+                                                   hipsolverComplex*    work,
+                                                   int                  lwork,
                                                    int*                 devInfo);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t       handle,
@@ -601,6 +651,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t       handl
                                                    int*                    devIpiv,
                                                    hipsolverDoubleComplex* B,
                                                    int                     ldb,
+                                                   hipsolverDoubleComplex* work,
+                                                   int                     lwork,
                                                    int*                    devInfo);
 
 // potrf

--- a/library/include/hipsolver.h
+++ b/library/include/hipsolver.h
@@ -524,6 +524,7 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrf(hipsolverHandle_t handle,
                                                    float*            A,
                                                    int               lda,
                                                    float*            work,
+                                                   int               lwork,
                                                    int*              devIpiv,
                                                    int*              devInfo);
 
@@ -533,6 +534,7 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrf(hipsolverHandle_t handle,
                                                    double*           A,
                                                    int               lda,
                                                    double*           work,
+                                                   int               lwork,
                                                    int*              devIpiv,
                                                    int*              devInfo);
 
@@ -542,6 +544,7 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrf(hipsolverHandle_t handle,
                                                    hipsolverComplex* A,
                                                    int               lda,
                                                    hipsolverComplex* work,
+                                                   int               lwork,
                                                    int*              devIpiv,
                                                    int*              devInfo);
 
@@ -551,6 +554,7 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t       handl
                                                    hipsolverDoubleComplex* A,
                                                    int                     lda,
                                                    hipsolverDoubleComplex* work,
+                                                   int                     lwork,
                                                    int*                    devIpiv,
                                                    int*                    devInfo);
 

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -1142,21 +1142,18 @@ hipsolverStatus_t hipsolverSgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork)
 try
 {
-    size_t sz1, sz2;
+    size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     rocblas_status status
         = rocsolver_sgetrf((rocblas_handle)handle, m, n, nullptr, lda, nullptr, nullptr);
-    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz1);
-
-    rocblas_start_device_memory_size_query((rocblas_handle)handle);
     rocsolver_sgetrf_npvt((rocblas_handle)handle, m, n, nullptr, lda, nullptr);
-    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz2);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    if(max(sz1, sz2) > INT_MAX)
+    if(sz > INT_MAX)
         return HIPSOLVER_STATUS_INTERNAL_ERROR;
 
-    *lwork = (int)max(sz1, sz2);
+    *lwork = (int)sz;
     return rocblas2hip_status(status);
 }
 catch(...)
@@ -1168,21 +1165,18 @@ hipsolverStatus_t hipsolverDgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork)
 try
 {
-    size_t sz1, sz2;
+    size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     rocblas_status status
         = rocsolver_dgetrf((rocblas_handle)handle, m, n, nullptr, lda, nullptr, nullptr);
-    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz1);
-
-    rocblas_start_device_memory_size_query((rocblas_handle)handle);
     rocsolver_dgetrf_npvt((rocblas_handle)handle, m, n, nullptr, lda, nullptr);
-    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz2);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    if(max(sz1, sz2) > INT_MAX)
+    if(sz > INT_MAX)
         return HIPSOLVER_STATUS_INTERNAL_ERROR;
 
-    *lwork = (int)max(sz1, sz2);
+    *lwork = (int)sz;
     return rocblas2hip_status(status);
 }
 catch(...)
@@ -1194,21 +1188,18 @@ hipsolverStatus_t hipsolverCgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
 try
 {
-    size_t sz1, sz2;
+    size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     rocblas_status status
         = rocsolver_cgetrf((rocblas_handle)handle, m, n, nullptr, lda, nullptr, nullptr);
-    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz1);
-
-    rocblas_start_device_memory_size_query((rocblas_handle)handle);
     rocsolver_cgetrf_npvt((rocblas_handle)handle, m, n, nullptr, lda, nullptr);
-    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz2);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    if(max(sz1, sz2) > INT_MAX)
+    if(sz > INT_MAX)
         return HIPSOLVER_STATUS_INTERNAL_ERROR;
 
-    *lwork = (int)max(sz1, sz2);
+    *lwork = (int)sz;
     return rocblas2hip_status(status);
 }
 catch(...)
@@ -1220,21 +1211,18 @@ hipsolverStatus_t hipsolverZgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex* A, int lda, int* lwork)
 try
 {
-    size_t sz1, sz2;
+    size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     rocblas_status status
         = rocsolver_zgetrf((rocblas_handle)handle, m, n, nullptr, lda, nullptr, nullptr);
-    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz1);
-
-    rocblas_start_device_memory_size_query((rocblas_handle)handle);
     rocsolver_zgetrf_npvt((rocblas_handle)handle, m, n, nullptr, lda, nullptr);
-    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz2);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    if(max(sz1, sz2) > INT_MAX)
+    if(sz > INT_MAX)
         return HIPSOLVER_STATUS_INTERNAL_ERROR;
 
-    *lwork = (int)max(sz1, sz2);
+    *lwork = (int)sz;
     return rocblas2hip_status(status);
 }
 catch(...)
@@ -1248,22 +1236,13 @@ hipsolverStatus_t hipsolverSgetrf(hipsolverHandle_t handle,
                                   float*            A,
                                   int               lda,
                                   float*            work,
+                                  int               lwork,
                                   int*              devIpiv,
                                   int*              devInfo)
 try
 {
     if(work != nullptr)
-    {
-        size_t sz;
-        rocblas_start_device_memory_size_query((rocblas_handle)handle);
-        if(devIpiv != nullptr)
-            rocsolver_sgetrf((rocblas_handle)handle, m, n, nullptr, lda, nullptr, nullptr);
-        else
-            rocsolver_sgetrf_npvt((rocblas_handle)handle, m, n, nullptr, lda, nullptr);
-        rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
-
-        rocblas_set_workspace((rocblas_handle)handle, work, sz);
-    }
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
     else
     {
         if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
@@ -1288,22 +1267,13 @@ hipsolverStatus_t hipsolverDgetrf(hipsolverHandle_t handle,
                                   double*           A,
                                   int               lda,
                                   double*           work,
+                                  int               lwork,
                                   int*              devIpiv,
                                   int*              devInfo)
 try
 {
     if(work != nullptr)
-    {
-        size_t sz;
-        rocblas_start_device_memory_size_query((rocblas_handle)handle);
-        if(devIpiv != nullptr)
-            rocsolver_dgetrf((rocblas_handle)handle, m, n, nullptr, lda, nullptr, nullptr);
-        else
-            rocsolver_dgetrf_npvt((rocblas_handle)handle, m, n, nullptr, lda, nullptr);
-        rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
-
-        rocblas_set_workspace((rocblas_handle)handle, work, sz);
-    }
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
     else
     {
         if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
@@ -1328,22 +1298,13 @@ hipsolverStatus_t hipsolverCgetrf(hipsolverHandle_t handle,
                                   hipsolverComplex* A,
                                   int               lda,
                                   hipsolverComplex* work,
+                                  int               lwork,
                                   int*              devIpiv,
                                   int*              devInfo)
 try
 {
     if(work != nullptr)
-    {
-        size_t sz;
-        rocblas_start_device_memory_size_query((rocblas_handle)handle);
-        if(devIpiv != nullptr)
-            rocsolver_cgetrf((rocblas_handle)handle, m, n, nullptr, lda, nullptr, nullptr);
-        else
-            rocsolver_cgetrf_npvt((rocblas_handle)handle, m, n, nullptr, lda, nullptr);
-        rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
-
-        rocblas_set_workspace((rocblas_handle)handle, work, sz);
-    }
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
     else
     {
         if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
@@ -1368,22 +1329,13 @@ hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t       handle,
                                   hipsolverDoubleComplex* A,
                                   int                     lda,
                                   hipsolverDoubleComplex* work,
+                                  int                     lwork,
                                   int*                    devIpiv,
                                   int*                    devInfo)
 try
 {
     if(work != nullptr)
-    {
-        size_t sz;
-        rocblas_start_device_memory_size_query((rocblas_handle)handle);
-        if(devIpiv != nullptr)
-            rocsolver_zgetrf((rocblas_handle)handle, m, n, nullptr, lda, nullptr, nullptr);
-        else
-            rocsolver_zgetrf_npvt((rocblas_handle)handle, m, n, nullptr, lda, nullptr);
-        rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
-
-        rocblas_set_workspace((rocblas_handle)handle, work, sz);
-    }
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
     else
     {
         if(!rocblas_is_managing_device_memory((rocblas_handle)handle))

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -1847,17 +1847,132 @@ catch(...)
 }
 
 /******************** POTRF_BATCHED ********************/
+hipsolverStatus_t hipsolverSpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    float*              A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 batch_count)
+try
+{
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_status status = rocsolver_spotrf_batched(
+        (rocblas_handle)handle, hip2rocblas_fill(uplo), n, nullptr, lda, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return rocblas2hip_status(status);
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    double*             A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 batch_count)
+try
+{
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_status status = rocsolver_dpotrf_batched(
+        (rocblas_handle)handle, hip2rocblas_fill(uplo), n, nullptr, lda, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return rocblas2hip_status(status);
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    hipsolverComplex*   A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 batch_count)
+try
+{
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_status status = rocsolver_cpotrf_batched(
+        (rocblas_handle)handle, hip2rocblas_fill(uplo), n, nullptr, lda, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return rocblas2hip_status(status);
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t       handle,
+                                                    hipsolverFillMode_t     uplo,
+                                                    int                     n,
+                                                    hipsolverDoubleComplex* A[],
+                                                    int                     lda,
+                                                    int*                    lwork,
+                                                    int                     batch_count)
+try
+{
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_status status = rocsolver_zpotrf_batched(
+        (rocblas_handle)handle, hip2rocblas_fill(uplo), n, nullptr, lda, nullptr, batch_count);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return rocblas2hip_status(status);
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
 hipsolverStatus_t hipsolverSpotrfBatched(hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
                                          float*              A[],
                                          int                 lda,
+                                         float*              work,
+                                         int                 lwork,
                                          int*                devInfo,
                                          int                 batch_count)
 try
 {
-    if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
-        rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    if(work != nullptr)
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
+    else
+    {
+        if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
+            rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    }
 
     return rocblas2hip_status(rocsolver_spotrf_batched(
         (rocblas_handle)handle, hip2rocblas_fill(uplo), n, A, lda, devInfo, batch_count));
@@ -1872,12 +1987,19 @@ hipsolverStatus_t hipsolverDpotrfBatched(hipsolverHandle_t   handle,
                                          int                 n,
                                          double*             A[],
                                          int                 lda,
+                                         double*             work,
+                                         int                 lwork,
                                          int*                devInfo,
                                          int                 batch_count)
 try
 {
-    if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
-        rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    if(work != nullptr)
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
+    else
+    {
+        if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
+            rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    }
 
     return rocblas2hip_status(rocsolver_dpotrf_batched(
         (rocblas_handle)handle, hip2rocblas_fill(uplo), n, A, lda, devInfo, batch_count));
@@ -1892,12 +2014,19 @@ hipsolverStatus_t hipsolverCpotrfBatched(hipsolverHandle_t   handle,
                                          int                 n,
                                          hipsolverComplex*   A[],
                                          int                 lda,
+                                         hipsolverComplex*   work,
+                                         int                 lwork,
                                          int*                devInfo,
                                          int                 batch_count)
 try
 {
-    if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
-        rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    if(work != nullptr)
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
+    else
+    {
+        if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
+            rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    }
 
     return rocblas2hip_status(rocsolver_cpotrf_batched((rocblas_handle)handle,
                                                        hip2rocblas_fill(uplo),
@@ -1917,12 +2046,19 @@ hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t       handle,
                                          int                     n,
                                          hipsolverDoubleComplex* A[],
                                          int                     lda,
+                                         hipsolverDoubleComplex* work,
+                                         int                     lwork,
                                          int*                    devInfo,
                                          int                     batch_count)
 try
 {
-    if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
-        rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    if(work != nullptr)
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
+    else
+    {
+        if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
+            rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    }
 
     return rocblas2hip_status(rocsolver_zpotrf_batched((rocblas_handle)handle,
                                                        hip2rocblas_fill(uplo),

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -1355,6 +1355,154 @@ catch(...)
 }
 
 /******************** GETRS ********************/
+hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverOperation_t trans,
+                                             int                  n,
+                                             int                  nrhs,
+                                             float*               A,
+                                             int                  lda,
+                                             int*                 devIpiv,
+                                             float*               B,
+                                             int                  ldb,
+                                             int*                 lwork)
+try
+{
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_status status = rocsolver_sgetrs((rocblas_handle)handle,
+                                             hip2rocblas_operation(trans),
+                                             n,
+                                             nrhs,
+                                             nullptr,
+                                             lda,
+                                             nullptr,
+                                             nullptr,
+                                             ldb);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return rocblas2hip_status(status);
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetrs_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverOperation_t trans,
+                                             int                  n,
+                                             int                  nrhs,
+                                             double*              A,
+                                             int                  lda,
+                                             int*                 devIpiv,
+                                             double*              B,
+                                             int                  ldb,
+                                             int*                 lwork)
+try
+{
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_status status = rocsolver_dgetrs((rocblas_handle)handle,
+                                             hip2rocblas_operation(trans),
+                                             n,
+                                             nrhs,
+                                             nullptr,
+                                             lda,
+                                             nullptr,
+                                             nullptr,
+                                             ldb);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return rocblas2hip_status(status);
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetrs_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverOperation_t trans,
+                                             int                  n,
+                                             int                  nrhs,
+                                             hipsolverComplex*    A,
+                                             int                  lda,
+                                             int*                 devIpiv,
+                                             hipsolverComplex*    B,
+                                             int                  ldb,
+                                             int*                 lwork)
+try
+{
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_status status = rocsolver_cgetrs((rocblas_handle)handle,
+                                             hip2rocblas_operation(trans),
+                                             n,
+                                             nrhs,
+                                             nullptr,
+                                             lda,
+                                             nullptr,
+                                             nullptr,
+                                             ldb);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return rocblas2hip_status(status);
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t       handle,
+                                             hipsolverOperation_t    trans,
+                                             int                     n,
+                                             int                     nrhs,
+                                             hipsolverDoubleComplex* A,
+                                             int                     lda,
+                                             int*                    devIpiv,
+                                             hipsolverDoubleComplex* B,
+                                             int                     ldb,
+                                             int*                    lwork)
+try
+{
+    size_t sz;
+
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_status status = rocsolver_zgetrs((rocblas_handle)handle,
+                                             hip2rocblas_operation(trans),
+                                             n,
+                                             nrhs,
+                                             nullptr,
+                                             lda,
+                                             nullptr,
+                                             nullptr,
+                                             ldb);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
+    if(sz > INT_MAX)
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+    *lwork = (int)sz;
+    return rocblas2hip_status(status);
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
 hipsolverStatus_t hipsolverSgetrs(hipsolverHandle_t    handle,
                                   hipsolverOperation_t trans,
                                   int                  n,
@@ -1364,11 +1512,18 @@ hipsolverStatus_t hipsolverSgetrs(hipsolverHandle_t    handle,
                                   int*                 devIpiv,
                                   float*               B,
                                   int                  ldb,
+                                  float*               work,
+                                  int                  lwork,
                                   int*                 devInfo)
 try
 {
-    if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
-        rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    if(work != nullptr)
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
+    else
+    {
+        if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
+            rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    }
 
     return rocblas2hip_status(rocsolver_sgetrs(
         (rocblas_handle)handle, hip2rocblas_operation(trans), n, nrhs, A, lda, devIpiv, B, ldb));
@@ -1387,11 +1542,18 @@ hipsolverStatus_t hipsolverDgetrs(hipsolverHandle_t    handle,
                                   int*                 devIpiv,
                                   double*              B,
                                   int                  ldb,
+                                  double*              work,
+                                  int                  lwork,
                                   int*                 devInfo)
 try
 {
-    if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
-        rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    if(work != nullptr)
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
+    else
+    {
+        if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
+            rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    }
 
     return rocblas2hip_status(rocsolver_dgetrs(
         (rocblas_handle)handle, hip2rocblas_operation(trans), n, nrhs, A, lda, devIpiv, B, ldb));
@@ -1410,11 +1572,18 @@ hipsolverStatus_t hipsolverCgetrs(hipsolverHandle_t    handle,
                                   int*                 devIpiv,
                                   hipsolverComplex*    B,
                                   int                  ldb,
+                                  hipsolverComplex*    work,
+                                  int                  lwork,
                                   int*                 devInfo)
 try
 {
-    if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
-        rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    if(work != nullptr)
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
+    else
+    {
+        if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
+            rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    }
 
     return rocblas2hip_status(rocsolver_cgetrs((rocblas_handle)handle,
                                                hip2rocblas_operation(trans),
@@ -1440,11 +1609,18 @@ hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t       handle,
                                   int*                    devIpiv,
                                   hipsolverDoubleComplex* B,
                                   int                     ldb,
+                                  hipsolverDoubleComplex* work,
+                                  int                     lwork,
                                   int*                    devInfo)
 try
 {
-    if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
-        rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    if(work != nullptr)
+        rocblas_set_workspace((rocblas_handle)handle, work, lwork);
+    else
+    {
+        if(!rocblas_is_managing_device_memory((rocblas_handle)handle))
+            rocblas_set_workspace((rocblas_handle)handle, nullptr, 0);
+    }
 
     return rocblas2hip_status(rocsolver_zgetrs((rocblas_handle)handle,
                                                hip2rocblas_operation(trans),

--- a/library/src/hipsolver_module.f90
+++ b/library/src/hipsolver_module.f90
@@ -785,7 +785,7 @@ module hipsolver
     end interface
 
     interface
-        function hipsolverSgetrf(handle, m, n, A, lda, work, ipiv, info) &
+        function hipsolverSgetrf(handle, m, n, A, lda, work, lwork, ipiv, info) &
                 result(c_int) &
                 bind(c, name = 'hipsolverSgetrf')
             use iso_c_binding
@@ -797,13 +797,14 @@ module hipsolver
             type(c_ptr), value :: A
             integer(c_int), value :: lda
             type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: ipiv
             type(c_ptr), value :: info
         end function hipsolverSgetrf
     end interface
     
     interface
-        function hipsolverDgetrf(handle, m, n, A, lda, work, ipiv, info) &
+        function hipsolverDgetrf(handle, m, n, A, lda, work, lwork, ipiv, info) &
                 result(c_int) &
                 bind(c, name = 'hipsolverDgetrf')
             use iso_c_binding
@@ -815,13 +816,14 @@ module hipsolver
             type(c_ptr), value :: A
             integer(c_int), value :: lda
             type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: ipiv
             type(c_ptr), value :: info
         end function hipsolverDgetrf
     end interface
     
     interface
-        function hipsolverCgetrf(handle, m, n, A, lda, work, ipiv, info) &
+        function hipsolverCgetrf(handle, m, n, A, lda, work, lwork, ipiv, info) &
                 result(c_int) &
                 bind(c, name = 'hipsolverCgetrf')
             use iso_c_binding
@@ -833,13 +835,14 @@ module hipsolver
             type(c_ptr), value :: A
             integer(c_int), value :: lda
             type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: ipiv
             type(c_ptr), value :: info
         end function hipsolverCgetrf
     end interface
     
     interface
-        function hipsolverZgetrf(handle, m, n, A, lda, work, ipiv, info) &
+        function hipsolverZgetrf(handle, m, n, A, lda, work, lwork, ipiv, info) &
                 result(c_int) &
                 bind(c, name = 'hipsolverZgetrf')
             use iso_c_binding
@@ -851,6 +854,7 @@ module hipsolver
             type(c_ptr), value :: A
             integer(c_int), value :: lda
             type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: ipiv
             type(c_ptr), value :: info
         end function hipsolverZgetrf

--- a/library/src/hipsolver_module.f90
+++ b/library/src/hipsolver_module.f90
@@ -862,7 +862,87 @@ module hipsolver
 
     ! ******************** GETRS ********************
     interface
-        function hipsolverSgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info) &
+        function hipsolverSgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
+                result(c_int) &
+                bind(c, name = 'hipsolverSgetrs_bufferSize')
+            use iso_c_binding
+            use hipsolver_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPSOLVER_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: lwork
+        end function hipsolverSgetrs_bufferSize
+    end interface
+    
+    interface
+        function hipsolverDgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
+                result(c_int) &
+                bind(c, name = 'hipsolverDgetrs_bufferSize')
+            use iso_c_binding
+            use hipsolver_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPSOLVER_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: lwork
+        end function hipsolverDgetrs_bufferSize
+    end interface
+    
+    interface
+        function hipsolverCgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
+                result(c_int) &
+                bind(c, name = 'hipsolverCgetrs_bufferSize')
+            use iso_c_binding
+            use hipsolver_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPSOLVER_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: lwork
+        end function hipsolverCgetrs_bufferSize
+    end interface
+    
+    interface
+        function hipsolverZgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
+                result(c_int) &
+                bind(c, name = 'hipsolverZgetrs_bufferSize')
+            use iso_c_binding
+            use hipsolver_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPSOLVER_OP_N)), value :: trans
+            integer(c_int), value :: n
+            integer(c_int), value :: nrhs
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: ipiv
+            type(c_ptr), value :: B
+            integer(c_int), value :: ldb
+            type(c_ptr), value :: lwork
+        end function hipsolverZgetrs_bufferSize
+    end interface
+
+    interface
+        function hipsolverSgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
                 result(c_int) &
                 bind(c, name = 'hipsolverSgetrs')
             use iso_c_binding
@@ -877,12 +957,14 @@ module hipsolver
             type(c_ptr), value :: ipiv
             type(c_ptr), value :: B
             integer(c_int), value :: ldb
+            type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: info
         end function hipsolverSgetrs
     end interface
     
     interface
-        function hipsolverDgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info) &
+        function hipsolverDgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
                 result(c_int) &
                 bind(c, name = 'hipsolverDgetrs')
             use iso_c_binding
@@ -897,12 +979,14 @@ module hipsolver
             type(c_ptr), value :: ipiv
             type(c_ptr), value :: B
             integer(c_int), value :: ldb
+            type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: info
         end function hipsolverDgetrs
     end interface
     
     interface
-        function hipsolverCgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info) &
+        function hipsolverCgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
                 result(c_int) &
                 bind(c, name = 'hipsolverCgetrs')
             use iso_c_binding
@@ -917,12 +1001,14 @@ module hipsolver
             type(c_ptr), value :: ipiv
             type(c_ptr), value :: B
             integer(c_int), value :: ldb
+            type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: info
         end function hipsolverCgetrs
     end interface
     
     interface
-        function hipsolverZgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, info) &
+        function hipsolverZgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
                 result(c_int) &
                 bind(c, name = 'hipsolverZgetrs')
             use iso_c_binding
@@ -937,6 +1023,8 @@ module hipsolver
             type(c_ptr), value :: ipiv
             type(c_ptr), value :: B
             integer(c_int), value :: ldb
+            type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: info
         end function hipsolverZgetrs
     end interface

--- a/library/src/hipsolver_module.f90
+++ b/library/src/hipsolver_module.f90
@@ -1168,7 +1168,75 @@ module hipsolver
     
     ! ******************** POTRF_BATCHED ********************
     interface
-        function hipsolverSpotrfBatched(handle, uplo, n, A, lda, info, batch_count) &
+        function hipsolverSpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipsolverSpotrfBatched_bufferSize')
+            use iso_c_binding
+            use hipsolver_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: lwork
+            integer(c_int), value :: batch_count
+        end function hipsolverSpotrfBatched_bufferSize
+    end interface
+    
+    interface
+        function hipsolverDpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipsolverDpotrfBatched_bufferSize')
+            use iso_c_binding
+            use hipsolver_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: lwork
+            integer(c_int), value :: batch_count
+        end function hipsolverDpotrfBatched_bufferSize
+    end interface
+    
+    interface
+        function hipsolverCpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipsolverCpotrfBatched_bufferSize')
+            use iso_c_binding
+            use hipsolver_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: lwork
+            integer(c_int), value :: batch_count
+        end function hipsolverCpotrfBatched_bufferSize
+    end interface
+    
+    interface
+        function hipsolverZpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count) &
+                result(c_int) &
+                bind(c, name = 'hipsolverZpotrfBatched_bufferSize')
+            use iso_c_binding
+            use hipsolver_enums
+            implicit none
+            type(c_ptr), value :: handle
+            integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
+            integer(c_int), value :: n
+            type(c_ptr), value :: A
+            integer(c_int), value :: lda
+            type(c_ptr), value :: lwork
+            integer(c_int), value :: batch_count
+        end function hipsolverZpotrfBatched_bufferSize
+    end interface
+
+    interface
+        function hipsolverSpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
                 result(c_int) &
                 bind(c, name = 'hipsolverSpotrfBatched')
             use iso_c_binding
@@ -1179,13 +1247,15 @@ module hipsolver
             integer(c_int), value :: n
             type(c_ptr), value :: A
             integer(c_int), value :: lda
+            type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: info
             integer(c_int), value :: batch_count
         end function hipsolverSpotrfBatched
     end interface
     
     interface
-        function hipsolverDpotrfBatched(handle, uplo, n, A, lda, info, batch_count) &
+        function hipsolverDpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
                 result(c_int) &
                 bind(c, name = 'hipsolverDpotrfBatched')
             use iso_c_binding
@@ -1196,13 +1266,15 @@ module hipsolver
             integer(c_int), value :: n
             type(c_ptr), value :: A
             integer(c_int), value :: lda
+            type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: info
             integer(c_int), value :: batch_count
         end function hipsolverDpotrfBatched
     end interface
     
     interface
-        function hipsolverCpotrfBatched(handle, uplo, n, A, lda, info, batch_count) &
+        function hipsolverCpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
                 result(c_int) &
                 bind(c, name = 'hipsolverCpotrfBatched')
             use iso_c_binding
@@ -1213,13 +1285,15 @@ module hipsolver
             integer(c_int), value :: n
             type(c_ptr), value :: A
             integer(c_int), value :: lda
+            type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: info
             integer(c_int), value :: batch_count
         end function hipsolverCpotrfBatched
     end interface
     
     interface
-        function hipsolverZpotrfBatched(handle, uplo, n, A, lda, info, batch_count) &
+        function hipsolverZpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
                 result(c_int) &
                 bind(c, name = 'hipsolverZpotrfBatched')
             use iso_c_binding
@@ -1230,6 +1304,8 @@ module hipsolver
             integer(c_int), value :: n
             type(c_ptr), value :: A
             integer(c_int), value :: lda
+            type(c_ptr), value :: work
+            integer(c_int), value :: lwork
             type(c_ptr), value :: info
             integer(c_int), value :: batch_count
         end function hipsolverZpotrfBatched

--- a/library/src/nvcc_detail/hipsolver.cpp
+++ b/library/src/nvcc_detail/hipsolver.cpp
@@ -938,6 +938,7 @@ hipsolverStatus_t hipsolverSgetrf(hipsolverHandle_t handle,
                                   float*            A,
                                   int               lda,
                                   float*            work,
+                                  int               lwork,
                                   int*              devIpiv,
                                   int*              devInfo)
 try
@@ -956,6 +957,7 @@ hipsolverStatus_t hipsolverDgetrf(hipsolverHandle_t handle,
                                   double*           A,
                                   int               lda,
                                   double*           work,
+                                  int               lwork,
                                   int*              devIpiv,
                                   int*              devInfo)
 try
@@ -974,6 +976,7 @@ hipsolverStatus_t hipsolverCgetrf(hipsolverHandle_t handle,
                                   hipsolverComplex* A,
                                   int               lda,
                                   hipsolverComplex* work,
+                                  int               lwork,
                                   int*              devIpiv,
                                   int*              devInfo)
 try
@@ -992,6 +995,7 @@ hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t       handle,
                                   hipsolverDoubleComplex* A,
                                   int                     lda,
                                   hipsolverDoubleComplex* work,
+                                  int                     lwork,
                                   int*                    devIpiv,
                                   int*                    devInfo)
 try

--- a/library/src/nvcc_detail/hipsolver.cpp
+++ b/library/src/nvcc_detail/hipsolver.cpp
@@ -1015,6 +1015,86 @@ catch(...)
 }
 
 /******************** GETRS ********************/
+hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverOperation_t trans,
+                                             int                  n,
+                                             int                  nrhs,
+                                             float*               A,
+                                             int                  lda,
+                                             int*                 devIpiv,
+                                             float*               B,
+                                             int                  ldb,
+                                             int*                 lwork)
+try
+{
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDgetrs_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverOperation_t trans,
+                                             int                  n,
+                                             int                  nrhs,
+                                             double*              A,
+                                             int                  lda,
+                                             int*                 devIpiv,
+                                             double*              B,
+                                             int                  ldb,
+                                             int*                 lwork)
+try
+{
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCgetrs_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverOperation_t trans,
+                                             int                  n,
+                                             int                  nrhs,
+                                             hipsolverComplex*    A,
+                                             int                  lda,
+                                             int*                 devIpiv,
+                                             hipsolverComplex*    B,
+                                             int                  ldb,
+                                             int*                 lwork)
+try
+{
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t       handle,
+                                             hipsolverOperation_t    trans,
+                                             int                     n,
+                                             int                     nrhs,
+                                             hipsolverDoubleComplex* A,
+                                             int                     lda,
+                                             int*                    devIpiv,
+                                             hipsolverDoubleComplex* B,
+                                             int                     ldb,
+                                             int*                    lwork)
+try
+{
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
 hipsolverStatus_t hipsolverSgetrs(hipsolverHandle_t    handle,
                                   hipsolverOperation_t trans,
                                   int                  n,
@@ -1024,6 +1104,8 @@ hipsolverStatus_t hipsolverSgetrs(hipsolverHandle_t    handle,
                                   int*                 devIpiv,
                                   float*               B,
                                   int                  ldb,
+                                  float*               work,
+                                  int                  lwork,
                                   int*                 devInfo)
 try
 {
@@ -1052,6 +1134,8 @@ hipsolverStatus_t hipsolverDgetrs(hipsolverHandle_t    handle,
                                   int*                 devIpiv,
                                   double*              B,
                                   int                  ldb,
+                                  double*              work,
+                                  int                  lwork,
                                   int*                 devInfo)
 try
 {
@@ -1080,6 +1164,8 @@ hipsolverStatus_t hipsolverCgetrs(hipsolverHandle_t    handle,
                                   int*                 devIpiv,
                                   hipsolverComplex*    B,
                                   int                  ldb,
+                                  hipsolverComplex*    work,
+                                  int                  lwork,
                                   int*                 devInfo)
 try
 {
@@ -1108,6 +1194,8 @@ hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t       handle,
                                   int*                    devIpiv,
                                   hipsolverDoubleComplex* B,
                                   int                     ldb,
+                                  hipsolverDoubleComplex* work,
+                                  int                     lwork,
                                   int*                    devInfo)
 try
 {

--- a/library/src/nvcc_detail/hipsolver.cpp
+++ b/library/src/nvcc_detail/hipsolver.cpp
@@ -1357,11 +1357,81 @@ catch(...)
 }
 
 /******************** POTRF_BATCHED ********************/
+hipsolverStatus_t hipsolverSpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    float*              A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 batch_count)
+try
+{
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverDpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    double*             A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 batch_count)
+try
+{
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverCpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    hipsolverComplex*   A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 batch_count)
+try
+{
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t       handle,
+                                                    hipsolverFillMode_t     uplo,
+                                                    int                     n,
+                                                    hipsolverDoubleComplex* A[],
+                                                    int                     lda,
+                                                    int*                    lwork,
+                                                    int                     batch_count)
+try
+{
+    *lwork = 0;
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+catch(...)
+{
+    return exception2hip_status();
+}
+
 hipsolverStatus_t hipsolverSpotrfBatched(hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
                                          float*              A[],
                                          int                 lda,
+                                         float*              work,
+                                         int                 lwork,
                                          int*                devInfo,
                                          int                 batch_count)
 try
@@ -1379,6 +1449,8 @@ hipsolverStatus_t hipsolverDpotrfBatched(hipsolverHandle_t   handle,
                                          int                 n,
                                          double*             A[],
                                          int                 lda,
+                                         double*             work,
+                                         int                 lwork,
                                          int*                devInfo,
                                          int                 batch_count)
 try
@@ -1396,6 +1468,8 @@ hipsolverStatus_t hipsolverCpotrfBatched(hipsolverHandle_t   handle,
                                          int                 n,
                                          hipsolverComplex*   A[],
                                          int                 lda,
+                                         hipsolverComplex*   work,
+                                         int                 lwork,
                                          int*                devInfo,
                                          int                 batch_count)
 try
@@ -1418,6 +1492,8 @@ hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t       handle,
                                          int                     n,
                                          hipsolverDoubleComplex* A[],
                                          int                     lda,
+                                         hipsolverDoubleComplex* work,
+                                         int                     lwork,
                                          int*                    devInfo,
                                          int                     batch_count)
 try


### PR DESCRIPTION
As discussed in https://github.com/ROCmSoftwarePlatform/hipSOLVER/pull/18#discussion_r639136057, I am making the following API changes to hipSOLVER:

1. getrf now takes an `lwork` argument
2. getrs now takes `work` and `lwork` arguments (this required the addition of a getrs_bufferSize method)
3. potrfBatched now takes `work` and `lwork` arguments (this required the addition of a potrfBatched_bufferSize method)

As with the removal of HIPSOLVER_FILL_MODE_FULL in https://github.com/ROCmSoftwarePlatform/hipSOLVER/pull/4, I think that we are early enough in the development process for hipSOLVER that a deprecation process for getrf is currently unnecessary.