### PR TITLE
Use hip complex types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 ### Removed
 - Removed unused HIPSOLVER_FILL_MODE_FULL enum value.
+- Removed hipsolverComplex and hipsolverDoubleComplex from the library. Use hipFloatComplex and hipDoubleComplex instead.
 
 
 ## [hipSOLVER 0.1.0 for ROCm 4.2]

--- a/clients/include/complex.hpp
+++ b/clients/include/complex.hpp
@@ -7,6 +7,78 @@
 #include "hipsolver.h"
 #include <complex>
 
+typedef struct hipsolverComplex
+{
+private:
+    float x, y;
+
+public:
+#if __cplusplus >= 201103L
+    hipsolverComplex() = default;
+#else
+    hipsolverComplex() {}
+#endif
+
+    hipsolverComplex(float r, float i = 0)
+        : x(r)
+        , y(i)
+    {
+    }
+
+    float real() const
+    {
+        return x;
+    }
+    float imag() const
+    {
+        return y;
+    }
+    void real(float r)
+    {
+        x = r;
+    }
+    void imag(float i)
+    {
+        y = i;
+    }
+} hipsolverComplex;
+
+typedef struct hipsolverDoubleComplex
+{
+private:
+    double x, y;
+
+public:
+#if __cplusplus >= 201103L
+    hipsolverDoubleComplex() = default;
+#else
+    hipsolverDoubleComplex() {}
+#endif
+
+    hipsolverDoubleComplex(double r, double i = 0)
+        : x(r)
+        , y(i)
+    {
+    }
+
+    double real() const
+    {
+        return x;
+    }
+    double imag() const
+    {
+        return y;
+    }
+    void real(double r)
+    {
+        x = r;
+    }
+    void imag(double i)
+    {
+        y = i;
+    }
+} hipsolverDoubleComplex;
+
 inline hipsolverComplex& operator+=(hipsolverComplex& lhs, const hipsolverComplex& rhs)
 {
     reinterpret_cast<std::complex<float>&>(lhs)

--- a/clients/include/hipsolver.hpp
+++ b/clients/include/hipsolver.hpp
@@ -89,9 +89,11 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                FO
                                                           int*                lwork)
 {
     if(!FORTRAN)
-        return hipsolverCungbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork);
+        return hipsolverCungbr_bufferSize(
+            handle, side, m, n, k, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
     else
-        return hipsolverCungbr_bufferSizeFortran(handle, side, m, n, k, A, lda, tau, lwork);
+        return hipsolverCungbr_bufferSizeFortran(
+            handle, side, m, n, k, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                    FORTRAN,
@@ -106,9 +108,11 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                  
                                                           int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZungbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork);
+        return hipsolverZungbr_bufferSize(
+            handle, side, m, n, k, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
     else
-        return hipsolverZungbr_bufferSizeFortran(handle, side, m, n, k, A, lda, tau, lwork);
+        return hipsolverZungbr_bufferSizeFortran(
+            handle, side, m, n, k, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
@@ -163,9 +167,29 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
                                                int*                info)
 {
     if(!FORTRAN)
-        return hipsolverCungbr(handle, side, m, n, k, A, lda, tau, work, lwork, info);
+        return hipsolverCungbr(handle,
+                               side,
+                               m,
+                               n,
+                               k,
+                               (hipFloatComplex*)A,
+                               lda,
+                               (hipFloatComplex*)tau,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverCungbrFortran(handle, side, m, n, k, A, lda, tau, work, lwork, info);
+        return hipsolverCungbrFortran(handle,
+                                      side,
+                                      m,
+                                      n,
+                                      k,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      (hipFloatComplex*)tau,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                    FORTRAN,
@@ -182,9 +206,29 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                    FORTRAN,
                                                int*                    info)
 {
     if(!FORTRAN)
-        return hipsolverZungbr(handle, side, m, n, k, A, lda, tau, work, lwork, info);
+        return hipsolverZungbr(handle,
+                               side,
+                               m,
+                               n,
+                               k,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               (hipDoubleComplex*)tau,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZungbrFortran(handle, side, m, n, k, A, lda, tau, work, lwork, info);
+        return hipsolverZungbrFortran(handle,
+                                      side,
+                                      m,
+                                      n,
+                                      k,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      (hipDoubleComplex*)tau,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 /******************** ORGQR/UNGQR ********************/
@@ -232,9 +276,11 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool              FORT
                                                           int*              lwork)
 {
     if(!FORTRAN)
-        return hipsolverCungqr_bufferSize(handle, m, n, k, A, lda, tau, lwork);
+        return hipsolverCungqr_bufferSize(
+            handle, m, n, k, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
     else
-        return hipsolverCungqr_bufferSizeFortran(handle, m, n, k, A, lda, tau, lwork);
+        return hipsolverCungqr_bufferSizeFortran(
+            handle, m, n, k, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool                    FORTRAN,
@@ -248,9 +294,11 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool                  
                                                           int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZungqr_bufferSize(handle, m, n, k, A, lda, tau, lwork);
+        return hipsolverZungqr_bufferSize(
+            handle, m, n, k, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
     else
-        return hipsolverZungqr_bufferSizeFortran(handle, m, n, k, A, lda, tau, lwork);
+        return hipsolverZungqr_bufferSizeFortran(
+            handle, m, n, k, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
@@ -302,9 +350,27 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
                                                int*              info)
 {
     if(!FORTRAN)
-        return hipsolverCungqr(handle, m, n, k, A, lda, tau, work, lwork, info);
+        return hipsolverCungqr(handle,
+                               m,
+                               n,
+                               k,
+                               (hipFloatComplex*)A,
+                               lda,
+                               (hipFloatComplex*)tau,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverCungqrFortran(handle, m, n, k, A, lda, tau, work, lwork, info);
+        return hipsolverCungqrFortran(handle,
+                                      m,
+                                      n,
+                                      k,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      (hipFloatComplex*)tau,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool                    FORTRAN,
@@ -320,9 +386,27 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool                    FORTRAN,
                                                int*                    info)
 {
     if(!FORTRAN)
-        return hipsolverZungqr(handle, m, n, k, A, lda, tau, work, lwork, info);
+        return hipsolverZungqr(handle,
+                               m,
+                               n,
+                               k,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               (hipDoubleComplex*)tau,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZungqrFortran(handle, m, n, k, A, lda, tau, work, lwork, info);
+        return hipsolverZungqrFortran(handle,
+                                      m,
+                                      n,
+                                      k,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      (hipDoubleComplex*)tau,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/
 
@@ -368,9 +452,11 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                FO
                                                           int*                lwork)
 {
     if(!FORTRAN)
-        return hipsolverCungtr_bufferSize(handle, uplo, n, A, lda, tau, lwork);
+        return hipsolverCungtr_bufferSize(
+            handle, uplo, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
     else
-        return hipsolverCungtr_bufferSizeFortran(handle, uplo, n, A, lda, tau, lwork);
+        return hipsolverCungtr_bufferSizeFortran(
+            handle, uplo, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                    FORTRAN,
@@ -383,9 +469,11 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                  
                                                           int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZungtr_bufferSize(handle, uplo, n, A, lda, tau, lwork);
+        return hipsolverZungtr_bufferSize(
+            handle, uplo, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
     else
-        return hipsolverZungtr_bufferSizeFortran(handle, uplo, n, A, lda, tau, lwork);
+        return hipsolverZungtr_bufferSizeFortran(
+            handle, uplo, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
@@ -434,9 +522,25 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
                                                int*                info)
 {
     if(!FORTRAN)
-        return hipsolverCungtr(handle, uplo, n, A, lda, tau, work, lwork, info);
+        return hipsolverCungtr(handle,
+                               uplo,
+                               n,
+                               (hipFloatComplex*)A,
+                               lda,
+                               (hipFloatComplex*)tau,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverCungtrFortran(handle, uplo, n, A, lda, tau, work, lwork, info);
+        return hipsolverCungtrFortran(handle,
+                                      uplo,
+                                      n,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      (hipFloatComplex*)tau,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                    FORTRAN,
@@ -451,9 +555,25 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                    FORTRAN,
                                                int*                    info)
 {
     if(!FORTRAN)
-        return hipsolverZungtr(handle, uplo, n, A, lda, tau, work, lwork, info);
+        return hipsolverZungtr(handle,
+                               uplo,
+                               n,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               (hipDoubleComplex*)tau,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZungtrFortran(handle, uplo, n, A, lda, tau, work, lwork, info);
+        return hipsolverZungtrFortran(handle,
+                                      uplo,
+                                      n,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      (hipDoubleComplex*)tau,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/
 
@@ -516,10 +636,31 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                 F
                                                           int*                 lwork)
 {
     if(!FORTRAN)
-        return hipsolverCunmqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
+        return hipsolverCunmqr_bufferSize(handle,
+                                          side,
+                                          trans,
+                                          m,
+                                          n,
+                                          k,
+                                          (hipFloatComplex*)A,
+                                          lda,
+                                          (hipFloatComplex*)tau,
+                                          (hipFloatComplex*)C,
+                                          ldc,
+                                          lwork);
     else
-        return hipsolverCunmqr_bufferSizeFortran(
-            handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
+        return hipsolverCunmqr_bufferSizeFortran(handle,
+                                                 side,
+                                                 trans,
+                                                 m,
+                                                 n,
+                                                 k,
+                                                 (hipFloatComplex*)A,
+                                                 lda,
+                                                 (hipFloatComplex*)tau,
+                                                 (hipFloatComplex*)C,
+                                                 ldc,
+                                                 lwork);
 }
 
 inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                    FORTRAN,
@@ -537,10 +678,31 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                  
                                                           int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZunmqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
+        return hipsolverZunmqr_bufferSize(handle,
+                                          side,
+                                          trans,
+                                          m,
+                                          n,
+                                          k,
+                                          (hipDoubleComplex*)A,
+                                          lda,
+                                          (hipDoubleComplex*)tau,
+                                          (hipDoubleComplex*)C,
+                                          ldc,
+                                          lwork);
     else
-        return hipsolverZunmqr_bufferSizeFortran(
-            handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
+        return hipsolverZunmqr_bufferSizeFortran(handle,
+                                                 side,
+                                                 trans,
+                                                 m,
+                                                 n,
+                                                 k,
+                                                 (hipDoubleComplex*)A,
+                                                 lda,
+                                                 (hipDoubleComplex*)tau,
+                                                 (hipDoubleComplex*)C,
+                                                 ldc,
+                                                 lwork);
 }
 
 inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
@@ -608,11 +770,35 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
                                                int*                 info)
 {
     if(!FORTRAN)
-        return hipsolverCunmqr(
-            handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info);
+        return hipsolverCunmqr(handle,
+                               side,
+                               trans,
+                               m,
+                               n,
+                               k,
+                               (hipFloatComplex*)A,
+                               lda,
+                               (hipFloatComplex*)tau,
+                               (hipFloatComplex*)C,
+                               ldc,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverCunmqrFortran(
-            handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info);
+        return hipsolverCunmqrFortran(handle,
+                                      side,
+                                      trans,
+                                      m,
+                                      n,
+                                      k,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      (hipFloatComplex*)tau,
+                                      (hipFloatComplex*)C,
+                                      ldc,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                    FORTRAN,
@@ -632,11 +818,35 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                    FORTRAN,
                                                int*                    info)
 {
     if(!FORTRAN)
-        return hipsolverZunmqr(
-            handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info);
+        return hipsolverZunmqr(handle,
+                               side,
+                               trans,
+                               m,
+                               n,
+                               k,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               (hipDoubleComplex*)tau,
+                               (hipDoubleComplex*)C,
+                               ldc,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZunmqrFortran(
-            handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info);
+        return hipsolverZunmqrFortran(handle,
+                                      side,
+                                      trans,
+                                      m,
+                                      n,
+                                      k,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      (hipDoubleComplex*)tau,
+                                      (hipDoubleComplex*)C,
+                                      ldc,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/
 
@@ -701,11 +911,31 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                 F
                                                           int*                 lwork)
 {
     if(!FORTRAN)
-        return hipsolverCunmtr_bufferSize(
-            handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork);
+        return hipsolverCunmtr_bufferSize(handle,
+                                          side,
+                                          uplo,
+                                          trans,
+                                          m,
+                                          n,
+                                          (hipFloatComplex*)A,
+                                          lda,
+                                          (hipFloatComplex*)tau,
+                                          (hipFloatComplex*)C,
+                                          ldc,
+                                          lwork);
     else
-        return hipsolverCunmtr_bufferSizeFortran(
-            handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork);
+        return hipsolverCunmtr_bufferSizeFortran(handle,
+                                                 side,
+                                                 uplo,
+                                                 trans,
+                                                 m,
+                                                 n,
+                                                 (hipFloatComplex*)A,
+                                                 lda,
+                                                 (hipFloatComplex*)tau,
+                                                 (hipFloatComplex*)C,
+                                                 ldc,
+                                                 lwork);
 }
 
 inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                    FORTRAN,
@@ -723,11 +953,31 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                  
                                                           int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZunmtr_bufferSize(
-            handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork);
+        return hipsolverZunmtr_bufferSize(handle,
+                                          side,
+                                          uplo,
+                                          trans,
+                                          m,
+                                          n,
+                                          (hipDoubleComplex*)A,
+                                          lda,
+                                          (hipDoubleComplex*)tau,
+                                          (hipDoubleComplex*)C,
+                                          ldc,
+                                          lwork);
     else
-        return hipsolverZunmtr_bufferSizeFortran(
-            handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork);
+        return hipsolverZunmtr_bufferSizeFortran(handle,
+                                                 side,
+                                                 uplo,
+                                                 trans,
+                                                 m,
+                                                 n,
+                                                 (hipDoubleComplex*)A,
+                                                 lda,
+                                                 (hipDoubleComplex*)tau,
+                                                 (hipDoubleComplex*)C,
+                                                 ldc,
+                                                 lwork);
 }
 
 inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
@@ -795,11 +1045,35 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
                                                int*                 info)
 {
     if(!FORTRAN)
-        return hipsolverCunmtr(
-            handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info);
+        return hipsolverCunmtr(handle,
+                               side,
+                               uplo,
+                               trans,
+                               m,
+                               n,
+                               (hipFloatComplex*)A,
+                               lda,
+                               (hipFloatComplex*)tau,
+                               (hipFloatComplex*)C,
+                               ldc,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverCunmtrFortran(
-            handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info);
+        return hipsolverCunmtrFortran(handle,
+                                      side,
+                                      uplo,
+                                      trans,
+                                      m,
+                                      n,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      (hipFloatComplex*)tau,
+                                      (hipFloatComplex*)C,
+                                      ldc,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                    FORTRAN,
@@ -819,11 +1093,35 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                    FORTRAN,
                                                int*                    info)
 {
     if(!FORTRAN)
-        return hipsolverZunmtr(
-            handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info);
+        return hipsolverZunmtr(handle,
+                               side,
+                               uplo,
+                               trans,
+                               m,
+                               n,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               (hipDoubleComplex*)tau,
+                               (hipDoubleComplex*)C,
+                               ldc,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZunmtrFortran(
-            handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info);
+        return hipsolverZunmtrFortran(handle,
+                                      side,
+                                      uplo,
+                                      trans,
+                                      m,
+                                      n,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      (hipDoubleComplex*)tau,
+                                      (hipDoubleComplex*)C,
+                                      ldc,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/
 
@@ -943,9 +1241,31 @@ inline hipsolverStatus_t hipsolver_gebrd(bool              FORTRAN,
                                          int               bc)
 {
     if(!FORTRAN)
-        return hipsolverCgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
+        return hipsolverCgebrd(handle,
+                               m,
+                               n,
+                               (hipFloatComplex*)A,
+                               lda,
+                               D,
+                               E,
+                               (hipFloatComplex*)tauq,
+                               (hipFloatComplex*)taup,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverCgebrdFortran(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
+        return hipsolverCgebrdFortran(handle,
+                                      m,
+                                      n,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      D,
+                                      E,
+                                      (hipFloatComplex*)tauq,
+                                      (hipFloatComplex*)taup,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_gebrd(bool                    FORTRAN,
@@ -969,9 +1289,31 @@ inline hipsolverStatus_t hipsolver_gebrd(bool                    FORTRAN,
                                          int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
+        return hipsolverZgebrd(handle,
+                               m,
+                               n,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               D,
+                               E,
+                               (hipDoubleComplex*)tauq,
+                               (hipDoubleComplex*)taup,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZgebrdFortran(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
+        return hipsolverZgebrdFortran(handle,
+                                      m,
+                                      n,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      D,
+                                      E,
+                                      (hipDoubleComplex*)tauq,
+                                      (hipDoubleComplex*)taup,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/
 
@@ -999,9 +1341,9 @@ inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
     bool FORTRAN, hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
 {
     if(!FORTRAN)
-        return hipsolverCgeqrf_bufferSize(handle, m, n, A, lda, lwork);
+        return hipsolverCgeqrf_bufferSize(handle, m, n, (hipFloatComplex*)A, lda, lwork);
     else
-        return hipsolverCgeqrf_bufferSizeFortran(handle, m, n, A, lda, lwork);
+        return hipsolverCgeqrf_bufferSizeFortran(handle, m, n, (hipFloatComplex*)A, lda, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_geqrf_bufferSize(bool                    FORTRAN,
@@ -1013,9 +1355,9 @@ inline hipsolverStatus_t hipsolver_geqrf_bufferSize(bool                    FORT
                                                     int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZgeqrf_bufferSize(handle, m, n, A, lda, lwork);
+        return hipsolverZgeqrf_bufferSize(handle, m, n, (hipDoubleComplex*)A, lda, lwork);
     else
-        return hipsolverZgeqrf_bufferSizeFortran(handle, m, n, A, lda, lwork);
+        return hipsolverZgeqrf_bufferSizeFortran(handle, m, n, (hipDoubleComplex*)A, lda, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
@@ -1073,9 +1415,25 @@ inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
                                          int               bc)
 {
     if(!FORTRAN)
-        return hipsolverCgeqrf(handle, m, n, A, lda, tau, work, lwork, info);
+        return hipsolverCgeqrf(handle,
+                               m,
+                               n,
+                               (hipFloatComplex*)A,
+                               lda,
+                               (hipFloatComplex*)tau,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverCgeqrfFortran(handle, m, n, A, lda, tau, work, lwork, info);
+        return hipsolverCgeqrfFortran(handle,
+                                      m,
+                                      n,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      (hipFloatComplex*)tau,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_geqrf(bool                    FORTRAN,
@@ -1093,9 +1451,25 @@ inline hipsolverStatus_t hipsolver_geqrf(bool                    FORTRAN,
                                          int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZgeqrf(handle, m, n, A, lda, tau, work, lwork, info);
+        return hipsolverZgeqrf(handle,
+                               m,
+                               n,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               (hipDoubleComplex*)tau,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZgeqrfFortran(handle, m, n, A, lda, tau, work, lwork, info);
+        return hipsolverZgeqrfFortran(handle,
+                                      m,
+                                      n,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      (hipDoubleComplex*)tau,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/
 
@@ -1266,11 +1640,39 @@ inline hipsolverStatus_t hipsolver_gesvd(bool              FORTRAN,
     switch(bool2marshal(FORTRAN, bc != 1))
     {
     case C_NORMAL:
-        return hipsolverCgesvd(
-            handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info);
+        return hipsolverCgesvd(handle,
+                               jobu,
+                               jobv,
+                               m,
+                               n,
+                               (hipFloatComplex*)A,
+                               lda,
+                               S,
+                               (hipFloatComplex*)U,
+                               ldu,
+                               (hipFloatComplex*)V,
+                               ldv,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               rwork,
+                               info);
     case FORTRAN_NORMAL:
-        return hipsolverCgesvdFortran(
-            handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info);
+        return hipsolverCgesvdFortran(handle,
+                                      jobu,
+                                      jobv,
+                                      m,
+                                      n,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      S,
+                                      (hipFloatComplex*)U,
+                                      ldu,
+                                      (hipFloatComplex*)V,
+                                      ldv,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      rwork,
+                                      info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1303,11 +1705,39 @@ inline hipsolverStatus_t hipsolver_gesvd(bool                    FORTRAN,
     switch(bool2marshal(FORTRAN, bc != 1))
     {
     case C_NORMAL:
-        return hipsolverZgesvd(
-            handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info);
+        return hipsolverZgesvd(handle,
+                               jobu,
+                               jobv,
+                               m,
+                               n,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               S,
+                               (hipDoubleComplex*)U,
+                               ldu,
+                               (hipDoubleComplex*)V,
+                               ldv,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               rwork,
+                               info);
     case FORTRAN_NORMAL:
-        return hipsolverZgesvdFortran(
-            handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info);
+        return hipsolverZgesvdFortran(handle,
+                                      jobu,
+                                      jobv,
+                                      m,
+                                      n,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      S,
+                                      (hipDoubleComplex*)U,
+                                      ldu,
+                                      (hipDoubleComplex*)V,
+                                      ldv,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      rwork,
+                                      info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1338,9 +1768,9 @@ inline hipsolverStatus_t hipsolver_getrf_bufferSize(
     bool FORTRAN, hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
 {
     if(!FORTRAN)
-        return hipsolverCgetrf_bufferSize(handle, m, n, A, lda, lwork);
+        return hipsolverCgetrf_bufferSize(handle, m, n, (hipFloatComplex*)A, lda, lwork);
     else
-        return hipsolverCgetrf_bufferSizeFortran(handle, m, n, A, lda, lwork);
+        return hipsolverCgetrf_bufferSizeFortran(handle, m, n, (hipFloatComplex*)A, lda, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_getrf_bufferSize(bool                    FORTRAN,
@@ -1352,9 +1782,9 @@ inline hipsolverStatus_t hipsolver_getrf_bufferSize(bool                    FORT
                                                     int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZgetrf_bufferSize(handle, m, n, A, lda, lwork);
+        return hipsolverZgetrf_bufferSize(handle, m, n, (hipDoubleComplex*)A, lda, lwork);
     else
-        return hipsolverZgetrf_bufferSizeFortran(handle, m, n, A, lda, lwork);
+        return hipsolverZgetrf_bufferSizeFortran(handle, m, n, (hipDoubleComplex*)A, lda, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_getrf(bool              FORTRAN,
@@ -1435,13 +1865,17 @@ inline hipsolverStatus_t hipsolver_getrf(bool              FORTRAN,
     switch(bool2marshal(FORTRAN, NPVT))
     {
     case C_NORMAL:
-        return hipsolverCgetrf(handle, m, n, A, lda, work, lwork, ipiv, info);
+        return hipsolverCgetrf(
+            handle, m, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)work, lwork, ipiv, info);
     case C_NORMAL_ALT:
-        return hipsolverCgetrf(handle, m, n, A, lda, work, lwork, nullptr, info);
+        return hipsolverCgetrf(
+            handle, m, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)work, lwork, nullptr, info);
     case FORTRAN_NORMAL:
-        return hipsolverCgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info);
+        return hipsolverCgetrfFortran(
+            handle, m, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)work, lwork, ipiv, info);
     case FORTRAN_NORMAL_ALT:
-        return hipsolverCgetrfFortran(handle, m, n, A, lda, work, lwork, nullptr, info);
+        return hipsolverCgetrfFortran(
+            handle, m, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)work, lwork, nullptr, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1465,13 +1899,17 @@ inline hipsolverStatus_t hipsolver_getrf(bool                    FORTRAN,
     switch(bool2marshal(FORTRAN, NPVT))
     {
     case C_NORMAL:
-        return hipsolverZgetrf(handle, m, n, A, lda, work, lwork, ipiv, info);
+        return hipsolverZgetrf(
+            handle, m, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)work, lwork, ipiv, info);
     case C_NORMAL_ALT:
-        return hipsolverZgetrf(handle, m, n, A, lda, work, lwork, nullptr, info);
+        return hipsolverZgetrf(
+            handle, m, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)work, lwork, nullptr, info);
     case FORTRAN_NORMAL:
-        return hipsolverZgetrfFortran(handle, m, n, A, lda, work, lwork, ipiv, info);
+        return hipsolverZgetrfFortran(
+            handle, m, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)work, lwork, ipiv, info);
     case FORTRAN_NORMAL_ALT:
-        return hipsolverZgetrfFortran(handle, m, n, A, lda, work, lwork, nullptr, info);
+        return hipsolverZgetrfFortran(
+            handle, m, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)work, lwork, nullptr, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1531,10 +1969,27 @@ inline hipsolverStatus_t hipsolver_getrs_bufferSize(bool                 FORTRAN
                                                     int*                 lwork)
 {
     if(!FORTRAN)
-        return hipsolverCgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+        return hipsolverCgetrs_bufferSize(handle,
+                                          trans,
+                                          n,
+                                          nrhs,
+                                          (hipFloatComplex*)A,
+                                          lda,
+                                          ipiv,
+                                          (hipFloatComplex*)B,
+                                          ldb,
+                                          lwork);
     else
-        return hipsolverCgetrs_bufferSizeFortran(
-            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+        return hipsolverCgetrs_bufferSizeFortran(handle,
+                                                 trans,
+                                                 n,
+                                                 nrhs,
+                                                 (hipFloatComplex*)A,
+                                                 lda,
+                                                 ipiv,
+                                                 (hipFloatComplex*)B,
+                                                 ldb,
+                                                 lwork);
 }
 
 inline hipsolverStatus_t hipsolver_getrs_bufferSize(bool                    FORTRAN,
@@ -1550,10 +2005,27 @@ inline hipsolverStatus_t hipsolver_getrs_bufferSize(bool                    FORT
                                                     int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+        return hipsolverZgetrs_bufferSize(handle,
+                                          trans,
+                                          n,
+                                          nrhs,
+                                          (hipDoubleComplex*)A,
+                                          lda,
+                                          ipiv,
+                                          (hipDoubleComplex*)B,
+                                          ldb,
+                                          lwork);
     else
-        return hipsolverZgetrs_bufferSizeFortran(
-            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork);
+        return hipsolverZgetrs_bufferSizeFortran(handle,
+                                                 trans,
+                                                 n,
+                                                 nrhs,
+                                                 (hipDoubleComplex*)A,
+                                                 lda,
+                                                 ipiv,
+                                                 (hipDoubleComplex*)B,
+                                                 ldb,
+                                                 lwork);
 }
 
 inline hipsolverStatus_t hipsolver_getrs(bool                 FORTRAN,
@@ -1625,10 +2097,31 @@ inline hipsolverStatus_t hipsolver_getrs(bool                 FORTRAN,
                                          int                  bc)
 {
     if(!FORTRAN)
-        return hipsolverCgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
+        return hipsolverCgetrs(handle,
+                               trans,
+                               n,
+                               nrhs,
+                               (hipFloatComplex*)A,
+                               lda,
+                               ipiv,
+                               (hipFloatComplex*)B,
+                               ldb,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverCgetrsFortran(
-            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
+        return hipsolverCgetrsFortran(handle,
+                                      trans,
+                                      n,
+                                      nrhs,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      ipiv,
+                                      (hipFloatComplex*)B,
+                                      ldb,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_getrs(bool                    FORTRAN,
@@ -1650,10 +2143,31 @@ inline hipsolverStatus_t hipsolver_getrs(bool                    FORTRAN,
                                          int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
+        return hipsolverZgetrs(handle,
+                               trans,
+                               n,
+                               nrhs,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               ipiv,
+                               (hipDoubleComplex*)B,
+                               ldb,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZgetrsFortran(
-            handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info);
+        return hipsolverZgetrsFortran(handle,
+                                      trans,
+                                      n,
+                                      nrhs,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      ipiv,
+                                      (hipDoubleComplex*)B,
+                                      ldb,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/
 
@@ -1699,9 +2213,9 @@ inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                FORTRAN,
                                                     int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverCpotrf_bufferSize(handle, uplo, n, A, lda, lwork);
+        return hipsolverCpotrf_bufferSize(handle, uplo, n, (hipFloatComplex*)A, lda, lwork);
     else
-        return hipsolverCpotrf_bufferSizeFortran(handle, uplo, n, A, lda, lwork);
+        return hipsolverCpotrf_bufferSizeFortran(handle, uplo, n, (hipFloatComplex*)A, lda, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                    FORTRAN,
@@ -1714,9 +2228,9 @@ inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                    FORT
                                                     int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZpotrf_bufferSize(handle, uplo, n, A, lda, lwork);
+        return hipsolverZpotrf_bufferSize(handle, uplo, n, (hipDoubleComplex*)A, lda, lwork);
     else
-        return hipsolverZpotrf_bufferSizeFortran(handle, uplo, n, A, lda, lwork);
+        return hipsolverZpotrf_bufferSizeFortran(handle, uplo, n, (hipDoubleComplex*)A, lda, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
@@ -1768,9 +2282,11 @@ inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
                                          int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverCpotrf(handle, uplo, n, A, lda, work, lwork, info);
+        return hipsolverCpotrf(
+            handle, uplo, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)work, lwork, info);
     else
-        return hipsolverCpotrfFortran(handle, uplo, n, A, lda, work, lwork, info);
+        return hipsolverCpotrfFortran(
+            handle, uplo, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)work, lwork, info);
 }
 
 inline hipsolverStatus_t hipsolver_potrf(bool                    FORTRAN,
@@ -1786,9 +2302,11 @@ inline hipsolverStatus_t hipsolver_potrf(bool                    FORTRAN,
                                          int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZpotrf(handle, uplo, n, A, lda, work, lwork, info);
+        return hipsolverZpotrf(
+            handle, uplo, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)work, lwork, info);
     else
-        return hipsolverZpotrfFortran(handle, uplo, n, A, lda, work, lwork, info);
+        return hipsolverZpotrfFortran(
+            handle, uplo, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)work, lwork, info);
 }
 
 // batched
@@ -1832,9 +2350,11 @@ inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                FORTRAN,
                                                     int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverCpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, bc);
+        return hipsolverCpotrfBatched_bufferSize(
+            handle, uplo, n, (hipFloatComplex**)A, lda, lwork, bc);
     else
-        return hipsolverCpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, bc);
+        return hipsolverCpotrfBatched_bufferSizeFortran(
+            handle, uplo, n, (hipFloatComplex**)A, lda, lwork, bc);
 }
 
 inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                    FORTRAN,
@@ -1847,9 +2367,11 @@ inline hipsolverStatus_t hipsolver_potrf_bufferSize(bool                    FORT
                                                     int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, bc);
+        return hipsolverZpotrfBatched_bufferSize(
+            handle, uplo, n, (hipDoubleComplex**)A, lda, lwork, bc);
     else
-        return hipsolverZpotrfBatched_bufferSizeFortran(handle, uplo, n, A, lda, lwork, bc);
+        return hipsolverZpotrfBatched_bufferSizeFortran(
+            handle, uplo, n, (hipDoubleComplex**)A, lda, lwork, bc);
 }
 
 inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
@@ -1901,9 +2423,11 @@ inline hipsolverStatus_t hipsolver_potrf(bool                FORTRAN,
                                          int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverCpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, bc);
+        return hipsolverCpotrfBatched(
+            handle, uplo, n, (hipFloatComplex**)A, lda, (hipFloatComplex*)work, lwork, info, bc);
     else
-        return hipsolverCpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, bc);
+        return hipsolverCpotrfBatchedFortran(
+            handle, uplo, n, (hipFloatComplex**)A, lda, (hipFloatComplex*)work, lwork, info, bc);
 }
 
 inline hipsolverStatus_t hipsolver_potrf(bool                    FORTRAN,
@@ -1919,9 +2443,11 @@ inline hipsolverStatus_t hipsolver_potrf(bool                    FORTRAN,
                                          int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, bc);
+        return hipsolverZpotrfBatched(
+            handle, uplo, n, (hipDoubleComplex**)A, lda, (hipDoubleComplex*)work, lwork, info, bc);
     else
-        return hipsolverZpotrfBatchedFortran(handle, uplo, n, A, lda, work, lwork, info, bc);
+        return hipsolverZpotrfBatchedFortran(
+            handle, uplo, n, (hipDoubleComplex**)A, lda, (hipDoubleComplex*)work, lwork, info, bc);
 }
 /********************************************************/
 
@@ -1970,9 +2496,11 @@ inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                FO
                                                           int*                lwork)
 {
     if(!FORTRAN)
-        return hipsolverCheevd_bufferSize(handle, jobz, uplo, n, A, lda, D, lwork);
+        return hipsolverCheevd_bufferSize(
+            handle, jobz, uplo, n, (hipFloatComplex*)A, lda, D, lwork);
     else
-        return hipsolverCheevd_bufferSizeFortran(handle, jobz, uplo, n, A, lda, D, lwork);
+        return hipsolverCheevd_bufferSizeFortran(
+            handle, jobz, uplo, n, (hipFloatComplex*)A, lda, D, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                    FORTRAN,
@@ -1986,9 +2514,11 @@ inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                  
                                                           int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZheevd_bufferSize(handle, jobz, uplo, n, A, lda, D, lwork);
+        return hipsolverZheevd_bufferSize(
+            handle, jobz, uplo, n, (hipDoubleComplex*)A, lda, D, lwork);
     else
-        return hipsolverZheevd_bufferSizeFortran(handle, jobz, uplo, n, A, lda, D, lwork);
+        return hipsolverZheevd_bufferSizeFortran(
+            handle, jobz, uplo, n, (hipDoubleComplex*)A, lda, D, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
@@ -2049,9 +2579,27 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
                                                int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverCheevd(handle, jobz, uplo, n, A, lda, D, work, lwork, info);
+        return hipsolverCheevd(handle,
+                               jobz,
+                               uplo,
+                               n,
+                               (hipFloatComplex*)A,
+                               lda,
+                               D,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverCheevdFortran(handle, jobz, uplo, n, A, lda, D, work, lwork, info);
+        return hipsolverCheevdFortran(handle,
+                                      jobz,
+                                      uplo,
+                                      n,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      D,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_syevd_heevd(bool                    FORTRAN,
@@ -2070,9 +2618,27 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                    FORTRAN,
                                                int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZheevd(handle, jobz, uplo, n, A, lda, D, work, lwork, info);
+        return hipsolverZheevd(handle,
+                               jobz,
+                               uplo,
+                               n,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               D,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZheevdFortran(handle, jobz, uplo, n, A, lda, D, work, lwork, info);
+        return hipsolverZheevdFortran(handle,
+                                      jobz,
+                                      uplo,
+                                      n,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      D,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/
 
@@ -2132,10 +2698,29 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                FO
                                                           int*                lwork)
 {
     if(!FORTRAN)
-        return hipsolverChegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, lwork);
+        return hipsolverChegvd_bufferSize(handle,
+                                          itype,
+                                          jobz,
+                                          uplo,
+                                          n,
+                                          (hipFloatComplex*)A,
+                                          lda,
+                                          (hipFloatComplex*)B,
+                                          ldb,
+                                          D,
+                                          lwork);
     else
-        return hipsolverChegvd_bufferSizeFortran(
-            handle, itype, jobz, uplo, n, A, lda, B, ldb, D, lwork);
+        return hipsolverChegvd_bufferSizeFortran(handle,
+                                                 itype,
+                                                 jobz,
+                                                 uplo,
+                                                 n,
+                                                 (hipFloatComplex*)A,
+                                                 lda,
+                                                 (hipFloatComplex*)B,
+                                                 ldb,
+                                                 D,
+                                                 lwork);
 }
 
 inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                    FORTRAN,
@@ -2152,10 +2737,29 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                  
                                                           int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZhegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, lwork);
+        return hipsolverZhegvd_bufferSize(handle,
+                                          itype,
+                                          jobz,
+                                          uplo,
+                                          n,
+                                          (hipDoubleComplex*)A,
+                                          lda,
+                                          (hipDoubleComplex*)B,
+                                          ldb,
+                                          D,
+                                          lwork);
     else
-        return hipsolverZhegvd_bufferSizeFortran(
-            handle, itype, jobz, uplo, n, A, lda, B, ldb, D, lwork);
+        return hipsolverZhegvd_bufferSizeFortran(handle,
+                                                 itype,
+                                                 jobz,
+                                                 uplo,
+                                                 n,
+                                                 (hipDoubleComplex*)A,
+                                                 lda,
+                                                 (hipDoubleComplex*)B,
+                                                 ldb,
+                                                 D,
+                                                 lwork);
 }
 
 inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
@@ -2230,10 +2834,33 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
                                                int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverChegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, work, lwork, info);
+        return hipsolverChegvd(handle,
+                               itype,
+                               jobz,
+                               uplo,
+                               n,
+                               (hipFloatComplex*)A,
+                               lda,
+                               (hipFloatComplex*)B,
+                               ldb,
+                               D,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverChegvdFortran(
-            handle, itype, jobz, uplo, n, A, lda, B, ldb, D, work, lwork, info);
+        return hipsolverChegvdFortran(handle,
+                                      itype,
+                                      jobz,
+                                      uplo,
+                                      n,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      (hipFloatComplex*)B,
+                                      ldb,
+                                      D,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                    FORTRAN,
@@ -2256,10 +2883,33 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                    FORTRAN,
                                                int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZhegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, work, lwork, info);
+        return hipsolverZhegvd(handle,
+                               itype,
+                               jobz,
+                               uplo,
+                               n,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               (hipDoubleComplex*)B,
+                               ldb,
+                               D,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZhegvdFortran(
-            handle, itype, jobz, uplo, n, A, lda, B, ldb, D, work, lwork, info);
+        return hipsolverZhegvdFortran(handle,
+                                      itype,
+                                      jobz,
+                                      uplo,
+                                      n,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      (hipDoubleComplex*)B,
+                                      ldb,
+                                      D,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/
 
@@ -2311,9 +2961,11 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                FO
                                                           int*                lwork)
 {
     if(!FORTRAN)
-        return hipsolverChetrd_bufferSize(handle, uplo, n, A, lda, D, E, tau, lwork);
+        return hipsolverChetrd_bufferSize(
+            handle, uplo, n, (hipFloatComplex*)A, lda, D, E, (hipFloatComplex*)tau, lwork);
     else
-        return hipsolverChetrd_bufferSizeFortran(handle, uplo, n, A, lda, D, E, tau, lwork);
+        return hipsolverChetrd_bufferSizeFortran(
+            handle, uplo, n, (hipFloatComplex*)A, lda, D, E, (hipFloatComplex*)tau, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                    FORTRAN,
@@ -2328,9 +2980,11 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                  
                                                           int*                    lwork)
 {
     if(!FORTRAN)
-        return hipsolverZhetrd_bufferSize(handle, uplo, n, A, lda, D, E, tau, lwork);
+        return hipsolverZhetrd_bufferSize(
+            handle, uplo, n, (hipDoubleComplex*)A, lda, D, E, (hipDoubleComplex*)tau, lwork);
     else
-        return hipsolverZhetrd_bufferSizeFortran(handle, uplo, n, A, lda, D, E, tau, lwork);
+        return hipsolverZhetrd_bufferSizeFortran(
+            handle, uplo, n, (hipDoubleComplex*)A, lda, D, E, (hipDoubleComplex*)tau, lwork);
 }
 
 inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
@@ -2400,9 +3054,29 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
                                                int                 bc)
 {
     if(!FORTRAN)
-        return hipsolverChetrd(handle, uplo, n, A, lda, D, E, tau, work, lwork, info);
+        return hipsolverChetrd(handle,
+                               uplo,
+                               n,
+                               (hipFloatComplex*)A,
+                               lda,
+                               D,
+                               E,
+                               (hipFloatComplex*)tau,
+                               (hipFloatComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverChetrdFortran(handle, uplo, n, A, lda, D, E, tau, work, lwork, info);
+        return hipsolverChetrdFortran(handle,
+                                      uplo,
+                                      n,
+                                      (hipFloatComplex*)A,
+                                      lda,
+                                      D,
+                                      E,
+                                      (hipFloatComplex*)tau,
+                                      (hipFloatComplex*)work,
+                                      lwork,
+                                      info);
 }
 
 inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                    FORTRAN,
@@ -2424,8 +3098,28 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                    FORTRAN,
                                                int                     bc)
 {
     if(!FORTRAN)
-        return hipsolverZhetrd(handle, uplo, n, A, lda, D, E, tau, work, lwork, info);
+        return hipsolverZhetrd(handle,
+                               uplo,
+                               n,
+                               (hipDoubleComplex*)A,
+                               lda,
+                               D,
+                               E,
+                               (hipDoubleComplex*)tau,
+                               (hipDoubleComplex*)work,
+                               lwork,
+                               info);
     else
-        return hipsolverZhetrdFortran(handle, uplo, n, A, lda, D, E, tau, work, lwork, info);
+        return hipsolverZhetrdFortran(handle,
+                                      uplo,
+                                      n,
+                                      (hipDoubleComplex*)A,
+                                      lda,
+                                      D,
+                                      E,
+                                      (hipDoubleComplex*)tau,
+                                      (hipDoubleComplex*)work,
+                                      lwork,
+                                      info);
 }
 /********************************************************/

--- a/clients/include/hipsolver.hpp
+++ b/clients/include/hipsolver.hpp
@@ -1563,17 +1563,12 @@ inline hipsolverStatus_t hipsolver_gesvd(bool              FORTRAN,
                                          int*              info,
                                          int               bc)
 {
-    switch(bool2marshal(FORTRAN, bc != 1))
-    {
-    case C_NORMAL:
+    if(!FORTRAN)
         return hipsolverSgesvd(
             handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info);
-    case FORTRAN_NORMAL:
+    else
         return hipsolverSgesvdFortran(
             handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info);
-    default:
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    }
 }
 
 inline hipsolverStatus_t hipsolver_gesvd(bool              FORTRAN,
@@ -1600,17 +1595,12 @@ inline hipsolverStatus_t hipsolver_gesvd(bool              FORTRAN,
                                          int*              info,
                                          int               bc)
 {
-    switch(bool2marshal(FORTRAN, bc != 1))
-    {
-    case C_NORMAL:
+    if(!FORTRAN)
         return hipsolverDgesvd(
             handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info);
-    case FORTRAN_NORMAL:
+    else
         return hipsolverDgesvdFortran(
             handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info);
-    default:
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    }
 }
 
 inline hipsolverStatus_t hipsolver_gesvd(bool              FORTRAN,
@@ -1637,9 +1627,7 @@ inline hipsolverStatus_t hipsolver_gesvd(bool              FORTRAN,
                                          int*              info,
                                          int               bc)
 {
-    switch(bool2marshal(FORTRAN, bc != 1))
-    {
-    case C_NORMAL:
+    if(!FORTRAN)
         return hipsolverCgesvd(handle,
                                jobu,
                                jobv,
@@ -1656,7 +1644,7 @@ inline hipsolverStatus_t hipsolver_gesvd(bool              FORTRAN,
                                lwork,
                                rwork,
                                info);
-    case FORTRAN_NORMAL:
+    else
         return hipsolverCgesvdFortran(handle,
                                       jobu,
                                       jobv,
@@ -1673,9 +1661,6 @@ inline hipsolverStatus_t hipsolver_gesvd(bool              FORTRAN,
                                       lwork,
                                       rwork,
                                       info);
-    default:
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    }
 }
 
 inline hipsolverStatus_t hipsolver_gesvd(bool                    FORTRAN,
@@ -1702,9 +1687,7 @@ inline hipsolverStatus_t hipsolver_gesvd(bool                    FORTRAN,
                                          int*                    info,
                                          int                     bc)
 {
-    switch(bool2marshal(FORTRAN, bc != 1))
-    {
-    case C_NORMAL:
+    if(!FORTRAN)
         return hipsolverZgesvd(handle,
                                jobu,
                                jobv,
@@ -1721,7 +1704,7 @@ inline hipsolverStatus_t hipsolver_gesvd(bool                    FORTRAN,
                                lwork,
                                rwork,
                                info);
-    case FORTRAN_NORMAL:
+    else
         return hipsolverZgesvdFortran(handle,
                                       jobu,
                                       jobv,
@@ -1738,9 +1721,6 @@ inline hipsolverStatus_t hipsolver_gesvd(bool                    FORTRAN,
                                       lwork,
                                       rwork,
                                       info);
-    default:
-        return HIPSOLVER_STATUS_NOT_SUPPORTED;
-    }
 }
 /********************************************************/
 

--- a/clients/include/hipsolver_datatype2string.hpp
+++ b/clients/include/hipsolver_datatype2string.hpp
@@ -4,9 +4,11 @@
 
 #pragma once
 
-#include "hipsolver.h"
 #include <ostream>
 #include <string>
+
+#include "complex.hpp"
+#include "hipsolver.h"
 
 // Complex output
 inline std::ostream& operator<<(std::ostream& os, const hipsolverComplex& x)

--- a/clients/include/hipsolver_fortran.hpp
+++ b/clients/include/hipsolver_fortran.hpp
@@ -48,20 +48,20 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungbr_bufferSizeFortran(hipsolverHa
                                                                      int                 m,
                                                                      int                 n,
                                                                      int                 k,
-                                                                     hipsolverComplex*   A,
+                                                                     hipFloatComplex*    A,
                                                                      int                 lda,
-                                                                     hipsolverComplex*   tau,
+                                                                     hipFloatComplex*    tau,
                                                                      int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungbr_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     hipsolverSideMode_t     side,
-                                                                     int                     m,
-                                                                     int                     n,
-                                                                     int                     k,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     hipsolverDoubleComplex* tau,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungbr_bufferSizeFortran(hipsolverHandle_t   handle,
+                                                                     hipsolverSideMode_t side,
+                                                                     int                 m,
+                                                                     int                 n,
+                                                                     int                 k,
+                                                                     hipDoubleComplex*   A,
+                                                                     int                 lda,
+                                                                     hipDoubleComplex*   tau,
+                                                                     int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgbrFortran(hipsolverHandle_t   handle,
                                                           hipsolverSideMode_t side,
@@ -92,24 +92,24 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungbrFortran(hipsolverHandle_t   ha
                                                           int                 m,
                                                           int                 n,
                                                           int                 k,
-                                                          hipsolverComplex*   A,
+                                                          hipFloatComplex*    A,
                                                           int                 lda,
-                                                          hipsolverComplex*   tau,
-                                                          hipsolverComplex*   work,
+                                                          hipFloatComplex*    tau,
+                                                          hipFloatComplex*    work,
                                                           int                 lwork,
                                                           int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungbrFortran(hipsolverHandle_t       handle,
-                                                          hipsolverSideMode_t     side,
-                                                          int                     m,
-                                                          int                     n,
-                                                          int                     k,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* tau,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungbrFortran(hipsolverHandle_t   handle,
+                                                          hipsolverSideMode_t side,
+                                                          int                 m,
+                                                          int                 n,
+                                                          int                 k,
+                                                          hipDoubleComplex*   A,
+                                                          int                 lda,
+                                                          hipDoubleComplex*   tau,
+                                                          hipDoubleComplex*   work,
+                                                          int                 lwork,
+                                                          int*                devInfo);
 
 // orgqr/ungqr
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgqr_bufferSizeFortran(
@@ -122,19 +122,19 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungqr_bufferSizeFortran(hipsolverHa
                                                                      int               m,
                                                                      int               n,
                                                                      int               k,
-                                                                     hipsolverComplex* A,
+                                                                     hipFloatComplex*  A,
                                                                      int               lda,
-                                                                     hipsolverComplex* tau,
+                                                                     hipFloatComplex*  tau,
                                                                      int*              lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungqr_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     int                     m,
-                                                                     int                     n,
-                                                                     int                     k,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     hipsolverDoubleComplex* tau,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungqr_bufferSizeFortran(hipsolverHandle_t handle,
+                                                                     int               m,
+                                                                     int               n,
+                                                                     int               k,
+                                                                     hipDoubleComplex* A,
+                                                                     int               lda,
+                                                                     hipDoubleComplex* tau,
+                                                                     int*              lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgqrFortran(hipsolverHandle_t handle,
                                                           int               m,
@@ -162,23 +162,23 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungqrFortran(hipsolverHandle_t hand
                                                           int               m,
                                                           int               n,
                                                           int               k,
-                                                          hipsolverComplex* A,
+                                                          hipFloatComplex*  A,
                                                           int               lda,
-                                                          hipsolverComplex* tau,
-                                                          hipsolverComplex* work,
+                                                          hipFloatComplex*  tau,
+                                                          hipFloatComplex*  work,
                                                           int               lwork,
                                                           int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungqrFortran(hipsolverHandle_t       handle,
-                                                          int                     m,
-                                                          int                     n,
-                                                          int                     k,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* tau,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungqrFortran(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          int               k,
+                                                          hipDoubleComplex* A,
+                                                          int               lda,
+                                                          hipDoubleComplex* tau,
+                                                          hipDoubleComplex* work,
+                                                          int               lwork,
+                                                          int*              devInfo);
 
 // orgtr/ungtr
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgtr_bufferSizeFortran(hipsolverHandle_t   handle,
@@ -200,18 +200,18 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDorgtr_bufferSizeFortran(hipsolverHa
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungtr_bufferSizeFortran(hipsolverHandle_t   handle,
                                                                      hipsolverFillMode_t uplo,
                                                                      int                 n,
-                                                                     hipsolverComplex*   A,
+                                                                     hipFloatComplex*    A,
                                                                      int                 lda,
-                                                                     hipsolverComplex*   tau,
+                                                                     hipFloatComplex*    tau,
                                                                      int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungtr_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     hipsolverFillMode_t     uplo,
-                                                                     int                     n,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     hipsolverDoubleComplex* tau,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungtr_bufferSizeFortran(hipsolverHandle_t   handle,
+                                                                     hipsolverFillMode_t uplo,
+                                                                     int                 n,
+                                                                     hipDoubleComplex*   A,
+                                                                     int                 lda,
+                                                                     hipDoubleComplex*   tau,
+                                                                     int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgtrFortran(hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
@@ -236,22 +236,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDorgtrFortran(hipsolverHandle_t   ha
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungtrFortran(hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
-                                                          hipsolverComplex*   A,
+                                                          hipFloatComplex*    A,
                                                           int                 lda,
-                                                          hipsolverComplex*   tau,
-                                                          hipsolverComplex*   work,
+                                                          hipFloatComplex*    tau,
+                                                          hipFloatComplex*    work,
                                                           int                 lwork,
                                                           int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungtrFortran(hipsolverHandle_t       handle,
-                                                          hipsolverFillMode_t     uplo,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* tau,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungtrFortran(hipsolverHandle_t   handle,
+                                                          hipsolverFillMode_t uplo,
+                                                          int                 n,
+                                                          hipDoubleComplex*   A,
+                                                          int                 lda,
+                                                          hipDoubleComplex*   tau,
+                                                          hipDoubleComplex*   work,
+                                                          int                 lwork,
+                                                          int*                devInfo);
 
 // ormqr/unmqr
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSormqr_bufferSizeFortran(hipsolverHandle_t    handle,
@@ -286,25 +286,25 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCunmqr_bufferSizeFortran(hipsolverHa
                                                                      int                  m,
                                                                      int                  n,
                                                                      int                  k,
-                                                                     hipsolverComplex*    A,
+                                                                     hipFloatComplex*     A,
                                                                      int                  lda,
-                                                                     hipsolverComplex*    tau,
-                                                                     hipsolverComplex*    C,
+                                                                     hipFloatComplex*     tau,
+                                                                     hipFloatComplex*     C,
                                                                      int                  ldc,
                                                                      int*                 lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmqr_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     hipsolverSideMode_t     side,
-                                                                     hipsolverOperation_t    trans,
-                                                                     int                     m,
-                                                                     int                     n,
-                                                                     int                     k,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     hipsolverDoubleComplex* tau,
-                                                                     hipsolverDoubleComplex* C,
-                                                                     int                     ldc,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmqr_bufferSizeFortran(hipsolverHandle_t    handle,
+                                                                     hipsolverSideMode_t  side,
+                                                                     hipsolverOperation_t trans,
+                                                                     int                  m,
+                                                                     int                  n,
+                                                                     int                  k,
+                                                                     hipDoubleComplex*    A,
+                                                                     int                  lda,
+                                                                     hipDoubleComplex*    tau,
+                                                                     hipDoubleComplex*    C,
+                                                                     int                  ldc,
+                                                                     int*                 lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSormqrFortran(hipsolverHandle_t    handle,
                                                           hipsolverSideMode_t  side,
@@ -342,29 +342,29 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCunmqrFortran(hipsolverHandle_t    h
                                                           int                  m,
                                                           int                  n,
                                                           int                  k,
-                                                          hipsolverComplex*    A,
+                                                          hipFloatComplex*     A,
                                                           int                  lda,
-                                                          hipsolverComplex*    tau,
-                                                          hipsolverComplex*    C,
+                                                          hipFloatComplex*     tau,
+                                                          hipFloatComplex*     C,
                                                           int                  ldc,
-                                                          hipsolverComplex*    work,
+                                                          hipFloatComplex*     work,
                                                           int                  lwork,
                                                           int*                 devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmqrFortran(hipsolverHandle_t       handle,
-                                                          hipsolverSideMode_t     side,
-                                                          hipsolverOperation_t    trans,
-                                                          int                     m,
-                                                          int                     n,
-                                                          int                     k,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* tau,
-                                                          hipsolverDoubleComplex* C,
-                                                          int                     ldc,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmqrFortran(hipsolverHandle_t    handle,
+                                                          hipsolverSideMode_t  side,
+                                                          hipsolverOperation_t trans,
+                                                          int                  m,
+                                                          int                  n,
+                                                          int                  k,
+                                                          hipDoubleComplex*    A,
+                                                          int                  lda,
+                                                          hipDoubleComplex*    tau,
+                                                          hipDoubleComplex*    C,
+                                                          int                  ldc,
+                                                          hipDoubleComplex*    work,
+                                                          int                  lwork,
+                                                          int*                 devInfo);
 
 // ormtr/unmtr
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSormtr_bufferSizeFortran(hipsolverHandle_t    handle,
@@ -399,25 +399,25 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCunmtr_bufferSizeFortran(hipsolverHa
                                                                      hipsolverOperation_t trans,
                                                                      int                  m,
                                                                      int                  n,
-                                                                     hipsolverComplex*    A,
+                                                                     hipFloatComplex*     A,
                                                                      int                  lda,
-                                                                     hipsolverComplex*    tau,
-                                                                     hipsolverComplex*    C,
+                                                                     hipFloatComplex*     tau,
+                                                                     hipFloatComplex*     C,
                                                                      int                  ldc,
                                                                      int*                 lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmtr_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     hipsolverSideMode_t     side,
-                                                                     hipsolverFillMode_t     uplo,
-                                                                     hipsolverOperation_t    trans,
-                                                                     int                     m,
-                                                                     int                     n,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     hipsolverDoubleComplex* tau,
-                                                                     hipsolverDoubleComplex* C,
-                                                                     int                     ldc,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmtr_bufferSizeFortran(hipsolverHandle_t    handle,
+                                                                     hipsolverSideMode_t  side,
+                                                                     hipsolverFillMode_t  uplo,
+                                                                     hipsolverOperation_t trans,
+                                                                     int                  m,
+                                                                     int                  n,
+                                                                     hipDoubleComplex*    A,
+                                                                     int                  lda,
+                                                                     hipDoubleComplex*    tau,
+                                                                     hipDoubleComplex*    C,
+                                                                     int                  ldc,
+                                                                     int*                 lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSormtrFortran(hipsolverHandle_t    handle,
                                                           hipsolverSideMode_t  side,
@@ -455,29 +455,29 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCunmtrFortran(hipsolverHandle_t    h
                                                           hipsolverOperation_t trans,
                                                           int                  m,
                                                           int                  n,
-                                                          hipsolverComplex*    A,
+                                                          hipFloatComplex*     A,
                                                           int                  lda,
-                                                          hipsolverComplex*    tau,
-                                                          hipsolverComplex*    C,
+                                                          hipFloatComplex*     tau,
+                                                          hipFloatComplex*     C,
                                                           int                  ldc,
-                                                          hipsolverComplex*    work,
+                                                          hipFloatComplex*     work,
                                                           int                  lwork,
                                                           int*                 devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmtrFortran(hipsolverHandle_t       handle,
-                                                          hipsolverSideMode_t     side,
-                                                          hipsolverFillMode_t     uplo,
-                                                          hipsolverOperation_t    trans,
-                                                          int                     m,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* tau,
-                                                          hipsolverDoubleComplex* C,
-                                                          int                     ldc,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmtrFortran(hipsolverHandle_t    handle,
+                                                          hipsolverSideMode_t  side,
+                                                          hipsolverFillMode_t  uplo,
+                                                          hipsolverOperation_t trans,
+                                                          int                  m,
+                                                          int                  n,
+                                                          hipDoubleComplex*    A,
+                                                          int                  lda,
+                                                          hipDoubleComplex*    tau,
+                                                          hipDoubleComplex*    C,
+                                                          int                  ldc,
+                                                          hipDoubleComplex*    work,
+                                                          int                  lwork,
+                                                          int*                 devInfo);
 
 // gebrd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgebrd_bufferSizeFortran(hipsolverHandle_t handle,
@@ -529,28 +529,28 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgebrdFortran(hipsolverHandle_t hand
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgebrdFortran(hipsolverHandle_t handle,
                                                           int               m,
                                                           int               n,
-                                                          hipsolverComplex* A,
+                                                          hipFloatComplex*  A,
                                                           int               lda,
                                                           float*            D,
                                                           float*            E,
-                                                          hipsolverComplex* tauq,
-                                                          hipsolverComplex* taup,
-                                                          hipsolverComplex* work,
+                                                          hipFloatComplex*  tauq,
+                                                          hipFloatComplex*  taup,
+                                                          hipFloatComplex*  work,
                                                           int               lwork,
                                                           int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgebrdFortran(hipsolverHandle_t       handle,
-                                                          int                     m,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          double*                 D,
-                                                          double*                 E,
-                                                          hipsolverDoubleComplex* tauq,
-                                                          hipsolverDoubleComplex* taup,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgebrdFortran(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          hipDoubleComplex* A,
+                                                          int               lda,
+                                                          double*           D,
+                                                          double*           E,
+                                                          hipDoubleComplex* tauq,
+                                                          hipDoubleComplex* taup,
+                                                          hipDoubleComplex* work,
+                                                          int               lwork,
+                                                          int*              devInfo);
 
 // geqrf
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgeqrf_bufferSizeFortran(
@@ -560,10 +560,10 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgeqrf_bufferSizeFortran(
     hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgeqrf_bufferSizeFortran(
-    hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork);
+    hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgeqrf_bufferSizeFortran(
-    hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex* A, int lda, int* lwork);
+    hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgeqrfFortran(hipsolverHandle_t handle,
                                                           int               m,
@@ -588,22 +588,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgeqrfFortran(hipsolverHandle_t hand
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgeqrfFortran(hipsolverHandle_t handle,
                                                           int               m,
                                                           int               n,
-                                                          hipsolverComplex* A,
+                                                          hipFloatComplex*  A,
                                                           int               lda,
-                                                          hipsolverComplex* tau,
-                                                          hipsolverComplex* work,
+                                                          hipFloatComplex*  tau,
+                                                          hipFloatComplex*  work,
                                                           int               lwork,
                                                           int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgeqrfFortran(hipsolverHandle_t       handle,
-                                                          int                     m,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* tau,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgeqrfFortran(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          hipDoubleComplex* A,
+                                                          int               lda,
+                                                          hipDoubleComplex* tau,
+                                                          hipDoubleComplex* work,
+                                                          int               lwork,
+                                                          int*              devInfo);
 
 // gesvd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgesvd_bufferSizeFortran(
@@ -657,34 +657,34 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgesvdFortran(hipsolverHandle_t hand
                                                           signed char       jobv,
                                                           int               m,
                                                           int               n,
-                                                          hipsolverComplex* A,
+                                                          hipFloatComplex*  A,
                                                           int               lda,
                                                           float*            S,
-                                                          hipsolverComplex* U,
+                                                          hipFloatComplex*  U,
                                                           int               ldu,
-                                                          hipsolverComplex* V,
+                                                          hipFloatComplex*  V,
                                                           int               ldv,
-                                                          hipsolverComplex* work,
+                                                          hipFloatComplex*  work,
                                                           int               lwork,
                                                           float*            rwork,
                                                           int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgesvdFortran(hipsolverHandle_t       handle,
-                                                          signed char             jobu,
-                                                          signed char             jobv,
-                                                          int                     m,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          double*                 S,
-                                                          hipsolverDoubleComplex* U,
-                                                          int                     ldu,
-                                                          hipsolverDoubleComplex* V,
-                                                          int                     ldv,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          double*                 rwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgesvdFortran(hipsolverHandle_t handle,
+                                                          signed char       jobu,
+                                                          signed char       jobv,
+                                                          int               m,
+                                                          int               n,
+                                                          hipDoubleComplex* A,
+                                                          int               lda,
+                                                          double*           S,
+                                                          hipDoubleComplex* U,
+                                                          int               ldu,
+                                                          hipDoubleComplex* V,
+                                                          int               ldv,
+                                                          hipDoubleComplex* work,
+                                                          int               lwork,
+                                                          double*           rwork,
+                                                          int*              devInfo);
 
 // getrf
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrf_bufferSizeFortran(
@@ -694,10 +694,10 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrf_bufferSizeFortran(
     hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrf_bufferSizeFortran(
-    hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork);
+    hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrf_bufferSizeFortran(
-    hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex* A, int lda, int* lwork);
+    hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrfFortran(hipsolverHandle_t handle,
                                                           int               m,
@@ -722,22 +722,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrfFortran(hipsolverHandle_t hand
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrfFortran(hipsolverHandle_t handle,
                                                           int               m,
                                                           int               n,
-                                                          hipsolverComplex* A,
+                                                          hipFloatComplex*  A,
                                                           int               lda,
-                                                          hipsolverComplex* work,
+                                                          hipFloatComplex*  work,
                                                           int               lwork,
                                                           int*              devIpiv,
                                                           int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrfFortran(hipsolverHandle_t       handle,
-                                                          int                     m,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devIpiv,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrfFortran(hipsolverHandle_t handle,
+                                                          int               m,
+                                                          int               n,
+                                                          hipDoubleComplex* A,
+                                                          int               lda,
+                                                          hipDoubleComplex* work,
+                                                          int               lwork,
+                                                          int*              devIpiv,
+                                                          int*              devInfo);
 
 // getrs
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrs_bufferSizeFortran(hipsolverHandle_t    handle,
@@ -766,23 +766,23 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrs_bufferSizeFortran(hipsolverHa
                                                                      hipsolverOperation_t trans,
                                                                      int                  n,
                                                                      int                  nrhs,
-                                                                     hipsolverComplex*    A,
+                                                                     hipFloatComplex*     A,
                                                                      int                  lda,
                                                                      int*                 devIpiv,
-                                                                     hipsolverComplex*    B,
+                                                                     hipFloatComplex*     B,
                                                                      int                  ldb,
                                                                      int*                 lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     hipsolverOperation_t    trans,
-                                                                     int                     n,
-                                                                     int                     nrhs,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     int* devIpiv,
-                                                                     hipsolverDoubleComplex* B,
-                                                                     int                     ldb,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs_bufferSizeFortran(hipsolverHandle_t    handle,
+                                                                     hipsolverOperation_t trans,
+                                                                     int                  n,
+                                                                     int                  nrhs,
+                                                                     hipDoubleComplex*    A,
+                                                                     int                  lda,
+                                                                     int*                 devIpiv,
+                                                                     hipDoubleComplex*    B,
+                                                                     int                  ldb,
+                                                                     int*                 lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrsFortran(hipsolverHandle_t    handle,
                                                           hipsolverOperation_t trans,
@@ -814,27 +814,27 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrsFortran(hipsolverHandle_t    h
                                                           hipsolverOperation_t trans,
                                                           int                  n,
                                                           int                  nrhs,
-                                                          hipsolverComplex*    A,
+                                                          hipFloatComplex*     A,
                                                           int                  lda,
                                                           int*                 devIpiv,
-                                                          hipsolverComplex*    B,
+                                                          hipFloatComplex*     B,
                                                           int                  ldb,
-                                                          hipsolverComplex*    work,
+                                                          hipFloatComplex*     work,
                                                           int                  lwork,
                                                           int*                 devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrsFortran(hipsolverHandle_t       handle,
-                                                          hipsolverOperation_t    trans,
-                                                          int                     n,
-                                                          int                     nrhs,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          int*                    devIpiv,
-                                                          hipsolverDoubleComplex* B,
-                                                          int                     ldb,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrsFortran(hipsolverHandle_t    handle,
+                                                          hipsolverOperation_t trans,
+                                                          int                  n,
+                                                          int                  nrhs,
+                                                          hipDoubleComplex*    A,
+                                                          int                  lda,
+                                                          int*                 devIpiv,
+                                                          hipDoubleComplex*    B,
+                                                          int                  ldb,
+                                                          hipDoubleComplex*    work,
+                                                          int                  lwork,
+                                                          int*                 devInfo);
 
 // potrf
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrf_bufferSizeFortran(
@@ -846,16 +846,16 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrf_bufferSizeFortran(
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrf_bufferSizeFortran(hipsolverHandle_t   handle,
                                                                      hipsolverFillMode_t uplo,
                                                                      int                 n,
-                                                                     hipsolverComplex*   A,
+                                                                     hipFloatComplex*    A,
                                                                      int                 lda,
                                                                      int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrf_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     hipsolverFillMode_t     uplo,
-                                                                     int                     n,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrf_bufferSizeFortran(hipsolverHandle_t   handle,
+                                                                     hipsolverFillMode_t uplo,
+                                                                     int                 n,
+                                                                     hipDoubleComplex*   A,
+                                                                     int                 lda,
+                                                                     int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrfFortran(hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
@@ -878,20 +878,20 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrfFortran(hipsolverHandle_t   ha
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrfFortran(hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
-                                                          hipsolverComplex*   A,
+                                                          hipFloatComplex*    A,
                                                           int                 lda,
-                                                          hipsolverComplex*   work,
+                                                          hipFloatComplex*    work,
                                                           int                 lwork,
                                                           int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfFortran(hipsolverHandle_t       handle,
-                                                          hipsolverFillMode_t     uplo,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfFortran(hipsolverHandle_t   handle,
+                                                          hipsolverFillMode_t uplo,
+                                                          int                 n,
+                                                          hipDoubleComplex*   A,
+                                                          int                 lda,
+                                                          hipDoubleComplex*   work,
+                                                          int                 lwork,
+                                                          int*                devInfo);
 
 // potrf_batched
 HIPSOLVER_EXPORT hipsolverStatus_t
@@ -916,19 +916,19 @@ HIPSOLVER_EXPORT hipsolverStatus_t
     hipsolverCpotrfBatched_bufferSizeFortran(hipsolverHandle_t   handle,
                                              hipsolverFillMode_t uplo,
                                              int                 n,
-                                             hipsolverComplex*   A[],
+                                             hipFloatComplex*    A[],
                                              int                 lda,
                                              int*                lwork,
                                              int                 batch_count);
 
 HIPSOLVER_EXPORT hipsolverStatus_t
-    hipsolverZpotrfBatched_bufferSizeFortran(hipsolverHandle_t       handle,
-                                             hipsolverFillMode_t     uplo,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A[],
-                                             int                     lda,
-                                             int*                    lwork,
-                                             int                     batch_count);
+    hipsolverZpotrfBatched_bufferSizeFortran(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipDoubleComplex*   A[],
+                                             int                 lda,
+                                             int*                lwork,
+                                             int                 batch_count);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrfBatchedFortran(hipsolverHandle_t   handle,
                                                                  hipsolverFillMode_t uplo,
@@ -953,22 +953,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrfBatchedFortran(hipsolverHandle
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrfBatchedFortran(hipsolverHandle_t   handle,
                                                                  hipsolverFillMode_t uplo,
                                                                  int                 n,
-                                                                 hipsolverComplex*   A[],
+                                                                 hipFloatComplex*    A[],
                                                                  int                 lda,
-                                                                 hipsolverComplex*   work,
+                                                                 hipFloatComplex*    work,
                                                                  int                 lwork,
                                                                  int*                devInfo,
                                                                  int                 batch_count);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfBatchedFortran(hipsolverHandle_t       handle,
-                                                                 hipsolverFillMode_t     uplo,
-                                                                 int                     n,
-                                                                 hipsolverDoubleComplex* A[],
-                                                                 int                     lda,
-                                                                 hipsolverDoubleComplex* work,
-                                                                 int                     lwork,
-                                                                 int*                    devInfo,
-                                                                 int batch_count);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfBatchedFortran(hipsolverHandle_t   handle,
+                                                                 hipsolverFillMode_t uplo,
+                                                                 int                 n,
+                                                                 hipDoubleComplex*   A[],
+                                                                 int                 lda,
+                                                                 hipDoubleComplex*   work,
+                                                                 int                 lwork,
+                                                                 int*                devInfo,
+                                                                 int                 batch_count);
 
 // syevd/heevd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsyevd_bufferSizeFortran(hipsolverHandle_t   handle,
@@ -993,19 +993,19 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCheevd_bufferSizeFortran(hipsolverHa
                                                                      hipsolverEigMode_t  jobz,
                                                                      hipsolverFillMode_t uplo,
                                                                      int                 n,
-                                                                     hipsolverComplex*   A,
+                                                                     hipFloatComplex*    A,
                                                                      int                 lda,
                                                                      float*              D,
                                                                      int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZheevd_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     hipsolverEigMode_t      jobz,
-                                                                     hipsolverFillMode_t     uplo,
-                                                                     int                     n,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     double*                 D,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZheevd_bufferSizeFortran(hipsolverHandle_t   handle,
+                                                                     hipsolverEigMode_t  jobz,
+                                                                     hipsolverFillMode_t uplo,
+                                                                     int                 n,
+                                                                     hipDoubleComplex*   A,
+                                                                     int                 lda,
+                                                                     double*             D,
+                                                                     int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsyevdFortran(hipsolverHandle_t   handle,
                                                           hipsolverEigMode_t  jobz,
@@ -1033,23 +1033,23 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCheevdFortran(hipsolverHandle_t   ha
                                                           hipsolverEigMode_t  jobz,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
-                                                          hipsolverComplex*   A,
+                                                          hipFloatComplex*    A,
                                                           int                 lda,
                                                           float*              D,
-                                                          hipsolverComplex*   work,
+                                                          hipFloatComplex*    work,
                                                           int                 lwork,
                                                           int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZheevdFortran(hipsolverHandle_t       handle,
-                                                          hipsolverEigMode_t      jobz,
-                                                          hipsolverFillMode_t     uplo,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          double*                 D,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZheevdFortran(hipsolverHandle_t   handle,
+                                                          hipsolverEigMode_t  jobz,
+                                                          hipsolverFillMode_t uplo,
+                                                          int                 n,
+                                                          hipDoubleComplex*   A,
+                                                          int                 lda,
+                                                          double*             D,
+                                                          hipDoubleComplex*   work,
+                                                          int                 lwork,
+                                                          int*                devInfo);
 
 // sygvd/hegvd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvd_bufferSizeFortran(hipsolverHandle_t   handle,
@@ -1081,24 +1081,24 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd_bufferSizeFortran(hipsolverHa
                                                                      hipsolverEigMode_t  jobz,
                                                                      hipsolverFillMode_t uplo,
                                                                      int                 n,
-                                                                     hipsolverComplex*   A,
+                                                                     hipFloatComplex*    A,
                                                                      int                 lda,
-                                                                     hipsolverComplex*   B,
+                                                                     hipFloatComplex*    B,
                                                                      int                 ldb,
                                                                      float*              D,
                                                                      int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     hipsolverEigType_t      itype,
-                                                                     hipsolverEigMode_t      jobz,
-                                                                     hipsolverFillMode_t     uplo,
-                                                                     int                     n,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     hipsolverDoubleComplex* B,
-                                                                     int                     ldb,
-                                                                     double*                 D,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSizeFortran(hipsolverHandle_t   handle,
+                                                                     hipsolverEigType_t  itype,
+                                                                     hipsolverEigMode_t  jobz,
+                                                                     hipsolverFillMode_t uplo,
+                                                                     int                 n,
+                                                                     hipDoubleComplex*   A,
+                                                                     int                 lda,
+                                                                     hipDoubleComplex*   B,
+                                                                     int                 ldb,
+                                                                     double*             D,
+                                                                     int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvdFortran(hipsolverHandle_t   handle,
                                                           hipsolverEigType_t  itype,
@@ -1133,28 +1133,28 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvdFortran(hipsolverHandle_t   ha
                                                           hipsolverEigMode_t  jobz,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
-                                                          hipsolverComplex*   A,
+                                                          hipFloatComplex*    A,
                                                           int                 lda,
-                                                          hipsolverComplex*   B,
+                                                          hipFloatComplex*    B,
                                                           int                 ldb,
                                                           float*              D,
-                                                          hipsolverComplex*   work,
+                                                          hipFloatComplex*    work,
                                                           int                 lwork,
                                                           int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvdFortran(hipsolverHandle_t       handle,
-                                                          hipsolverEigType_t      itype,
-                                                          hipsolverEigMode_t      jobz,
-                                                          hipsolverFillMode_t     uplo,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* B,
-                                                          int                     ldb,
-                                                          double*                 D,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvdFortran(hipsolverHandle_t   handle,
+                                                          hipsolverEigType_t  itype,
+                                                          hipsolverEigMode_t  jobz,
+                                                          hipsolverFillMode_t uplo,
+                                                          int                 n,
+                                                          hipDoubleComplex*   A,
+                                                          int                 lda,
+                                                          hipDoubleComplex*   B,
+                                                          int                 ldb,
+                                                          double*             D,
+                                                          hipDoubleComplex*   work,
+                                                          int                 lwork,
+                                                          int*                devInfo);
 
 // sytrd/hetrd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsytrd_bufferSizeFortran(hipsolverHandle_t   handle,
@@ -1180,22 +1180,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsytrd_bufferSizeFortran(hipsolverHa
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChetrd_bufferSizeFortran(hipsolverHandle_t   handle,
                                                                      hipsolverFillMode_t uplo,
                                                                      int                 n,
-                                                                     hipsolverComplex*   A,
+                                                                     hipFloatComplex*    A,
                                                                      int                 lda,
                                                                      float*              D,
                                                                      float*              E,
-                                                                     hipsolverComplex*   tau,
+                                                                     hipFloatComplex*    tau,
                                                                      int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhetrd_bufferSizeFortran(hipsolverHandle_t       handle,
-                                                                     hipsolverFillMode_t     uplo,
-                                                                     int                     n,
-                                                                     hipsolverDoubleComplex* A,
-                                                                     int                     lda,
-                                                                     double*                 D,
-                                                                     double*                 E,
-                                                                     hipsolverDoubleComplex* tau,
-                                                                     int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhetrd_bufferSizeFortran(hipsolverHandle_t   handle,
+                                                                     hipsolverFillMode_t uplo,
+                                                                     int                 n,
+                                                                     hipDoubleComplex*   A,
+                                                                     int                 lda,
+                                                                     double*             D,
+                                                                     double*             E,
+                                                                     hipDoubleComplex*   tau,
+                                                                     int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsytrdFortran(hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
@@ -1224,24 +1224,24 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsytrdFortran(hipsolverHandle_t   ha
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChetrdFortran(hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
-                                                          hipsolverComplex*   A,
+                                                          hipFloatComplex*    A,
                                                           int                 lda,
                                                           float*              D,
                                                           float*              E,
-                                                          hipsolverComplex*   tau,
-                                                          hipsolverComplex*   work,
+                                                          hipFloatComplex*    tau,
+                                                          hipFloatComplex*    work,
                                                           int                 lwork,
                                                           int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhetrdFortran(hipsolverHandle_t       handle,
-                                                          hipsolverFillMode_t     uplo,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A,
-                                                          int                     lda,
-                                                          double*                 D,
-                                                          double*                 E,
-                                                          hipsolverDoubleComplex* tau,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhetrdFortran(hipsolverHandle_t   handle,
+                                                          hipsolverFillMode_t uplo,
+                                                          int                 n,
+                                                          hipDoubleComplex*   A,
+                                                          int                 lda,
+                                                          double*             D,
+                                                          double*             E,
+                                                          hipDoubleComplex*   tau,
+                                                          hipDoubleComplex*   work,
+                                                          int                 lwork,
+                                                          int*                devInfo);
 }

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -140,6 +140,15 @@ inline bool hipsolver_isnan(hipsolverDoubleComplex arg)
 template <typename T>
 static constexpr bool is_complex = false;
 
+/* Workaround for clang bug:
+   https://bugs.llvm.org/show_bug.cgi?id=35863
+*/
+#if __clang__
+#define HIPSOLVER_CLANG_STATIC static
+#else
+#define HIPSOLVER_CLANG_STATIC
+#endif
+
 template <>
 HIPSOLVER_CLANG_STATIC constexpr bool is_complex<hipsolverComplex> = true;
 

--- a/clients/samples/example_basic.c
+++ b/clients/samples/example_basic.c
@@ -73,7 +73,7 @@ int main()
     double* dWork;
     int     size_work; // size of workspace to pass to getrf
     hipsolverDgetrf_bufferSize(handle, M, N, dA, lda, &size_work);
-    hipMalloc((void**)&dWork, sizeof(double) * size_work);
+    hipMalloc((void**)&dWork, size_work);
 
     // compute the LU factorization on the GPU
     hipsolverStatus_t status

--- a/clients/samples/example_basic.cpp
+++ b/clients/samples/example_basic.cpp
@@ -71,7 +71,7 @@ int main()
     double* dWork;
     int     size_work; // size of workspace to pass to getrf
     hipsolverDgetrf_bufferSize(handle, M, N, dA, lda, &size_work);
-    hipMalloc(&dWork, sizeof(double) * size_work);
+    hipMalloc(&dWork, size_work);
 
     // compute the LU factorization on the GPU
     hipsolverStatus_t status

--- a/library/include/hipsolver.h
+++ b/library/include/hipsolver.h
@@ -15,6 +15,7 @@
 
 #include "hipsolver-export.h"
 #include "hipsolver-version.h"
+#include <hip/hip_complex.h>
 #include <hip/hip_runtime_api.h>
 #include <stdint.h>
 
@@ -40,112 +41,6 @@
 #endif
 
 typedef void* hipsolverHandle_t;
-
-typedef struct hipsolverComplex
-{
-#ifndef __cplusplus
-
-    float x, y;
-
-#else
-
-private:
-    float x, y;
-
-public:
-#if __cplusplus >= 201103L
-    hipsolverComplex() = default;
-#else
-    hipsolverComplex() {}
-#endif
-
-    hipsolverComplex(float r, float i = 0)
-        : x(r)
-        , y(i)
-    {
-    }
-
-    float real() const
-    {
-        return x;
-    }
-    float imag() const
-    {
-        return y;
-    }
-    void real(float r)
-    {
-        x = r;
-    }
-    void imag(float i)
-    {
-        y = i;
-    }
-
-#endif
-} hipsolverComplex;
-
-typedef struct hipsolverDoubleComplex
-{
-#ifndef __cplusplus
-
-    double x, y;
-
-#else
-
-private:
-    double x, y;
-
-public:
-
-#if __cplusplus >= 201103L
-    hipsolverDoubleComplex() = default;
-#else
-    hipsolverDoubleComplex() {}
-#endif
-
-    hipsolverDoubleComplex(double r, double i = 0)
-        : x(r)
-        , y(i)
-    {
-    }
-
-    double real() const
-    {
-        return x;
-    }
-    double imag() const
-    {
-        return y;
-    }
-    void real(double r)
-    {
-        x = r;
-    }
-    void imag(double i)
-    {
-        y = i;
-    }
-
-#endif
-} hipsolverDoubleComplex;
-
-#if __cplusplus >= 201103L
-#include <type_traits>
-static_assert(std::is_standard_layout<hipsolverComplex>{},
-              "hipsolverComplex is not a standard layout type, and thus is incompatible with C.");
-static_assert(
-    std::is_standard_layout<hipsolverDoubleComplex>{},
-    "hipsolverDoubleComplex is not a standard layout type, and thus is incompatible with C.");
-static_assert(std::is_trivial<hipsolverComplex>{},
-              "hipsolverComplex is not a trivial type, and thus is incompatible with C.");
-static_assert(std::is_trivial<hipsolverDoubleComplex>{},
-              "hipsolverDoubleComplex is not a trivial type, and thus is incompatible with C.");
-static_assert(sizeof(hipsolverComplex) == sizeof(float) * 2
-                  && sizeof(hipsolverDoubleComplex) == sizeof(double) * 2
-                  && sizeof(hipsolverDoubleComplex) == sizeof(hipsolverComplex) * 2,
-              "Sizes of hipsolverComplex or hipsolverDoubleComplex are inconsistent");
-#endif
 
 typedef enum
 {
@@ -236,20 +131,20 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungbr_bufferSize(hipsolverHandle_t 
                                                               int                 m,
                                                               int                 n,
                                                               int                 k,
-                                                              hipsolverComplex*   A,
+                                                              hipFloatComplex*    A,
                                                               int                 lda,
-                                                              hipsolverComplex*   tau,
+                                                              hipFloatComplex*    tau,
                                                               int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungbr_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverSideMode_t     side,
-                                                              int                     m,
-                                                              int                     n,
-                                                              int                     k,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              hipsolverDoubleComplex* tau,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungbr_bufferSize(hipsolverHandle_t   handle,
+                                                              hipsolverSideMode_t side,
+                                                              int                 m,
+                                                              int                 n,
+                                                              int                 k,
+                                                              hipDoubleComplex*   A,
+                                                              int                 lda,
+                                                              hipDoubleComplex*   tau,
+                                                              int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgbr(hipsolverHandle_t   handle,
                                                    hipsolverSideMode_t side,
@@ -280,24 +175,24 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungbr(hipsolverHandle_t   handle,
                                                    int                 m,
                                                    int                 n,
                                                    int                 k,
-                                                   hipsolverComplex*   A,
+                                                   hipFloatComplex*    A,
                                                    int                 lda,
-                                                   hipsolverComplex*   tau,
-                                                   hipsolverComplex*   work,
+                                                   hipFloatComplex*    tau,
+                                                   hipFloatComplex*    work,
                                                    int                 lwork,
                                                    int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungbr(hipsolverHandle_t       handle,
-                                                   hipsolverSideMode_t     side,
-                                                   int                     m,
-                                                   int                     n,
-                                                   int                     k,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* tau,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungbr(hipsolverHandle_t   handle,
+                                                   hipsolverSideMode_t side,
+                                                   int                 m,
+                                                   int                 n,
+                                                   int                 k,
+                                                   hipDoubleComplex*   A,
+                                                   int                 lda,
+                                                   hipDoubleComplex*   tau,
+                                                   hipDoubleComplex*   work,
+                                                   int                 lwork,
+                                                   int*                devInfo);
 
 // orgqr/ungqr
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgqr_bufferSize(
@@ -310,19 +205,19 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungqr_bufferSize(hipsolverHandle_t 
                                                               int               m,
                                                               int               n,
                                                               int               k,
-                                                              hipsolverComplex* A,
+                                                              hipFloatComplex*  A,
                                                               int               lda,
-                                                              hipsolverComplex* tau,
+                                                              hipFloatComplex*  tau,
                                                               int*              lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungqr_bufferSize(hipsolverHandle_t       handle,
-                                                              int                     m,
-                                                              int                     n,
-                                                              int                     k,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              hipsolverDoubleComplex* tau,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungqr_bufferSize(hipsolverHandle_t handle,
+                                                              int               m,
+                                                              int               n,
+                                                              int               k,
+                                                              hipDoubleComplex* A,
+                                                              int               lda,
+                                                              hipDoubleComplex* tau,
+                                                              int*              lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgqr(hipsolverHandle_t handle,
                                                    int               m,
@@ -350,23 +245,23 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungqr(hipsolverHandle_t handle,
                                                    int               m,
                                                    int               n,
                                                    int               k,
-                                                   hipsolverComplex* A,
+                                                   hipFloatComplex*  A,
                                                    int               lda,
-                                                   hipsolverComplex* tau,
-                                                   hipsolverComplex* work,
+                                                   hipFloatComplex*  tau,
+                                                   hipFloatComplex*  work,
                                                    int               lwork,
                                                    int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungqr(hipsolverHandle_t       handle,
-                                                   int                     m,
-                                                   int                     n,
-                                                   int                     k,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* tau,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungqr(hipsolverHandle_t handle,
+                                                   int               m,
+                                                   int               n,
+                                                   int               k,
+                                                   hipDoubleComplex* A,
+                                                   int               lda,
+                                                   hipDoubleComplex* tau,
+                                                   hipDoubleComplex* work,
+                                                   int               lwork,
+                                                   int*              devInfo);
 
 // orgtr/ungtr
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgtr_bufferSize(hipsolverHandle_t   handle,
@@ -388,18 +283,18 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDorgtr_bufferSize(hipsolverHandle_t 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungtr_bufferSize(hipsolverHandle_t   handle,
                                                               hipsolverFillMode_t uplo,
                                                               int                 n,
-                                                              hipsolverComplex*   A,
+                                                              hipFloatComplex*    A,
                                                               int                 lda,
-                                                              hipsolverComplex*   tau,
+                                                              hipFloatComplex*    tau,
                                                               int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungtr_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverFillMode_t     uplo,
-                                                              int                     n,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              hipsolverDoubleComplex* tau,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungtr_bufferSize(hipsolverHandle_t   handle,
+                                                              hipsolverFillMode_t uplo,
+                                                              int                 n,
+                                                              hipDoubleComplex*   A,
+                                                              int                 lda,
+                                                              hipDoubleComplex*   tau,
+                                                              int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSorgtr(hipsolverHandle_t   handle,
                                                    hipsolverFillMode_t uplo,
@@ -424,22 +319,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDorgtr(hipsolverHandle_t   handle,
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCungtr(hipsolverHandle_t   handle,
                                                    hipsolverFillMode_t uplo,
                                                    int                 n,
-                                                   hipsolverComplex*   A,
+                                                   hipFloatComplex*    A,
                                                    int                 lda,
-                                                   hipsolverComplex*   tau,
-                                                   hipsolverComplex*   work,
+                                                   hipFloatComplex*    tau,
+                                                   hipFloatComplex*    work,
                                                    int                 lwork,
                                                    int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungtr(hipsolverHandle_t       handle,
-                                                   hipsolverFillMode_t     uplo,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* tau,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZungtr(hipsolverHandle_t   handle,
+                                                   hipsolverFillMode_t uplo,
+                                                   int                 n,
+                                                   hipDoubleComplex*   A,
+                                                   int                 lda,
+                                                   hipDoubleComplex*   tau,
+                                                   hipDoubleComplex*   work,
+                                                   int                 lwork,
+                                                   int*                devInfo);
 
 // ormqr/unmqr
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSormqr_bufferSize(hipsolverHandle_t    handle,
@@ -474,25 +369,25 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCunmqr_bufferSize(hipsolverHandle_t 
                                                               int                  m,
                                                               int                  n,
                                                               int                  k,
-                                                              hipsolverComplex*    A,
+                                                              hipFloatComplex*     A,
                                                               int                  lda,
-                                                              hipsolverComplex*    tau,
-                                                              hipsolverComplex*    C,
+                                                              hipFloatComplex*     tau,
+                                                              hipFloatComplex*     C,
                                                               int                  ldc,
                                                               int*                 lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmqr_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverSideMode_t     side,
-                                                              hipsolverOperation_t    trans,
-                                                              int                     m,
-                                                              int                     n,
-                                                              int                     k,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              hipsolverDoubleComplex* tau,
-                                                              hipsolverDoubleComplex* C,
-                                                              int                     ldc,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmqr_bufferSize(hipsolverHandle_t    handle,
+                                                              hipsolverSideMode_t  side,
+                                                              hipsolverOperation_t trans,
+                                                              int                  m,
+                                                              int                  n,
+                                                              int                  k,
+                                                              hipDoubleComplex*    A,
+                                                              int                  lda,
+                                                              hipDoubleComplex*    tau,
+                                                              hipDoubleComplex*    C,
+                                                              int                  ldc,
+                                                              int*                 lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSormqr(hipsolverHandle_t    handle,
                                                    hipsolverSideMode_t  side,
@@ -530,29 +425,29 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCunmqr(hipsolverHandle_t    handle,
                                                    int                  m,
                                                    int                  n,
                                                    int                  k,
-                                                   hipsolverComplex*    A,
+                                                   hipFloatComplex*     A,
                                                    int                  lda,
-                                                   hipsolverComplex*    tau,
-                                                   hipsolverComplex*    C,
+                                                   hipFloatComplex*     tau,
+                                                   hipFloatComplex*     C,
                                                    int                  ldc,
-                                                   hipsolverComplex*    work,
+                                                   hipFloatComplex*     work,
                                                    int                  lwork,
                                                    int*                 devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmqr(hipsolverHandle_t       handle,
-                                                   hipsolverSideMode_t     side,
-                                                   hipsolverOperation_t    trans,
-                                                   int                     m,
-                                                   int                     n,
-                                                   int                     k,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* tau,
-                                                   hipsolverDoubleComplex* C,
-                                                   int                     ldc,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmqr(hipsolverHandle_t    handle,
+                                                   hipsolverSideMode_t  side,
+                                                   hipsolverOperation_t trans,
+                                                   int                  m,
+                                                   int                  n,
+                                                   int                  k,
+                                                   hipDoubleComplex*    A,
+                                                   int                  lda,
+                                                   hipDoubleComplex*    tau,
+                                                   hipDoubleComplex*    C,
+                                                   int                  ldc,
+                                                   hipDoubleComplex*    work,
+                                                   int                  lwork,
+                                                   int*                 devInfo);
 
 // ormtr/unmtr
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSormtr_bufferSize(hipsolverHandle_t    handle,
@@ -587,25 +482,25 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCunmtr_bufferSize(hipsolverHandle_t 
                                                               hipsolverOperation_t trans,
                                                               int                  m,
                                                               int                  n,
-                                                              hipsolverComplex*    A,
+                                                              hipFloatComplex*     A,
                                                               int                  lda,
-                                                              hipsolverComplex*    tau,
-                                                              hipsolverComplex*    C,
+                                                              hipFloatComplex*     tau,
+                                                              hipFloatComplex*     C,
                                                               int                  ldc,
                                                               int*                 lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmtr_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverSideMode_t     side,
-                                                              hipsolverFillMode_t     uplo,
-                                                              hipsolverOperation_t    trans,
-                                                              int                     m,
-                                                              int                     n,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              hipsolverDoubleComplex* tau,
-                                                              hipsolverDoubleComplex* C,
-                                                              int                     ldc,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmtr_bufferSize(hipsolverHandle_t    handle,
+                                                              hipsolverSideMode_t  side,
+                                                              hipsolverFillMode_t  uplo,
+                                                              hipsolverOperation_t trans,
+                                                              int                  m,
+                                                              int                  n,
+                                                              hipDoubleComplex*    A,
+                                                              int                  lda,
+                                                              hipDoubleComplex*    tau,
+                                                              hipDoubleComplex*    C,
+                                                              int                  ldc,
+                                                              int*                 lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSormtr(hipsolverHandle_t    handle,
                                                    hipsolverSideMode_t  side,
@@ -643,29 +538,29 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCunmtr(hipsolverHandle_t    handle,
                                                    hipsolverOperation_t trans,
                                                    int                  m,
                                                    int                  n,
-                                                   hipsolverComplex*    A,
+                                                   hipFloatComplex*     A,
                                                    int                  lda,
-                                                   hipsolverComplex*    tau,
-                                                   hipsolverComplex*    C,
+                                                   hipFloatComplex*     tau,
+                                                   hipFloatComplex*     C,
                                                    int                  ldc,
-                                                   hipsolverComplex*    work,
+                                                   hipFloatComplex*     work,
                                                    int                  lwork,
                                                    int*                 devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmtr(hipsolverHandle_t       handle,
-                                                   hipsolverSideMode_t     side,
-                                                   hipsolverFillMode_t     uplo,
-                                                   hipsolverOperation_t    trans,
-                                                   int                     m,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* tau,
-                                                   hipsolverDoubleComplex* C,
-                                                   int                     ldc,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZunmtr(hipsolverHandle_t    handle,
+                                                   hipsolverSideMode_t  side,
+                                                   hipsolverFillMode_t  uplo,
+                                                   hipsolverOperation_t trans,
+                                                   int                  m,
+                                                   int                  n,
+                                                   hipDoubleComplex*    A,
+                                                   int                  lda,
+                                                   hipDoubleComplex*    tau,
+                                                   hipDoubleComplex*    C,
+                                                   int                  ldc,
+                                                   hipDoubleComplex*    work,
+                                                   int                  lwork,
+                                                   int*                 devInfo);
 
 // gebrd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgebrd_bufferSize(hipsolverHandle_t handle,
@@ -717,28 +612,28 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgebrd(hipsolverHandle_t handle,
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgebrd(hipsolverHandle_t handle,
                                                    int               m,
                                                    int               n,
-                                                   hipsolverComplex* A,
+                                                   hipFloatComplex*  A,
                                                    int               lda,
                                                    float*            D,
                                                    float*            E,
-                                                   hipsolverComplex* tauq,
-                                                   hipsolverComplex* taup,
-                                                   hipsolverComplex* work,
+                                                   hipFloatComplex*  tauq,
+                                                   hipFloatComplex*  taup,
+                                                   hipFloatComplex*  work,
                                                    int               lwork,
                                                    int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgebrd(hipsolverHandle_t       handle,
-                                                   int                     m,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   double*                 D,
-                                                   double*                 E,
-                                                   hipsolverDoubleComplex* tauq,
-                                                   hipsolverDoubleComplex* taup,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgebrd(hipsolverHandle_t handle,
+                                                   int               m,
+                                                   int               n,
+                                                   hipDoubleComplex* A,
+                                                   int               lda,
+                                                   double*           D,
+                                                   double*           E,
+                                                   hipDoubleComplex* tauq,
+                                                   hipDoubleComplex* taup,
+                                                   hipDoubleComplex* work,
+                                                   int               lwork,
+                                                   int*              devInfo);
 
 // geqrf
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgeqrf_bufferSize(
@@ -748,10 +643,10 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgeqrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgeqrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork);
+    hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgeqrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex* A, int lda, int* lwork);
+    hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgeqrf(hipsolverHandle_t handle,
                                                    int               m,
@@ -776,22 +671,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgeqrf(hipsolverHandle_t handle,
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgeqrf(hipsolverHandle_t handle,
                                                    int               m,
                                                    int               n,
-                                                   hipsolverComplex* A,
+                                                   hipFloatComplex*  A,
                                                    int               lda,
-                                                   hipsolverComplex* tau,
-                                                   hipsolverComplex* work,
+                                                   hipFloatComplex*  tau,
+                                                   hipFloatComplex*  work,
                                                    int               lwork,
                                                    int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgeqrf(hipsolverHandle_t       handle,
-                                                   int                     m,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* tau,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgeqrf(hipsolverHandle_t handle,
+                                                   int               m,
+                                                   int               n,
+                                                   hipDoubleComplex* A,
+                                                   int               lda,
+                                                   hipDoubleComplex* tau,
+                                                   hipDoubleComplex* work,
+                                                   int               lwork,
+                                                   int*              devInfo);
 
 // gesvd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgesvd_bufferSize(
@@ -845,34 +740,34 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgesvd(hipsolverHandle_t handle,
                                                    signed char       jobv,
                                                    int               m,
                                                    int               n,
-                                                   hipsolverComplex* A,
+                                                   hipFloatComplex*  A,
                                                    int               lda,
                                                    float*            S,
-                                                   hipsolverComplex* U,
+                                                   hipFloatComplex*  U,
                                                    int               ldu,
-                                                   hipsolverComplex* V,
+                                                   hipFloatComplex*  V,
                                                    int               ldv,
-                                                   hipsolverComplex* work,
+                                                   hipFloatComplex*  work,
                                                    int               lwork,
                                                    float*            rwork,
                                                    int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgesvd(hipsolverHandle_t       handle,
-                                                   signed char             jobu,
-                                                   signed char             jobv,
-                                                   int                     m,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   double*                 S,
-                                                   hipsolverDoubleComplex* U,
-                                                   int                     ldu,
-                                                   hipsolverDoubleComplex* V,
-                                                   int                     ldv,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   double*                 rwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgesvd(hipsolverHandle_t handle,
+                                                   signed char       jobu,
+                                                   signed char       jobv,
+                                                   int               m,
+                                                   int               n,
+                                                   hipDoubleComplex* A,
+                                                   int               lda,
+                                                   double*           S,
+                                                   hipDoubleComplex* U,
+                                                   int               ldu,
+                                                   hipDoubleComplex* V,
+                                                   int               ldv,
+                                                   hipDoubleComplex* work,
+                                                   int               lwork,
+                                                   double*           rwork,
+                                                   int*              devInfo);
 
 // getrf
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrf_bufferSize(
@@ -882,10 +777,10 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork);
+    hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex* A, int lda, int* lwork);
+    hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrf(hipsolverHandle_t handle,
                                                    int               m,
@@ -910,22 +805,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDgetrf(hipsolverHandle_t handle,
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrf(hipsolverHandle_t handle,
                                                    int               m,
                                                    int               n,
-                                                   hipsolverComplex* A,
+                                                   hipFloatComplex*  A,
                                                    int               lda,
-                                                   hipsolverComplex* work,
+                                                   hipFloatComplex*  work,
                                                    int               lwork,
                                                    int*              devIpiv,
                                                    int*              devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t       handle,
-                                                   int                     m,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devIpiv,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t handle,
+                                                   int               m,
+                                                   int               n,
+                                                   hipDoubleComplex* A,
+                                                   int               lda,
+                                                   hipDoubleComplex* work,
+                                                   int               lwork,
+                                                   int*              devIpiv,
+                                                   int*              devInfo);
 
 // getrs
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,
@@ -954,23 +849,23 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrs_bufferSize(hipsolverHandle_t 
                                                               hipsolverOperation_t trans,
                                                               int                  n,
                                                               int                  nrhs,
-                                                              hipsolverComplex*    A,
+                                                              hipFloatComplex*     A,
                                                               int                  lda,
                                                               int*                 devIpiv,
-                                                              hipsolverComplex*    B,
+                                                              hipFloatComplex*     B,
                                                               int                  ldb,
                                                               int*                 lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverOperation_t    trans,
-                                                              int                     n,
-                                                              int                     nrhs,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              int*                    devIpiv,
-                                                              hipsolverDoubleComplex* B,
-                                                              int                     ldb,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t    handle,
+                                                              hipsolverOperation_t trans,
+                                                              int                  n,
+                                                              int                  nrhs,
+                                                              hipDoubleComplex*    A,
+                                                              int                  lda,
+                                                              int*                 devIpiv,
+                                                              hipDoubleComplex*    B,
+                                                              int                  ldb,
+                                                              int*                 lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSgetrs(hipsolverHandle_t    handle,
                                                    hipsolverOperation_t trans,
@@ -1002,27 +897,27 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCgetrs(hipsolverHandle_t    handle,
                                                    hipsolverOperation_t trans,
                                                    int                  n,
                                                    int                  nrhs,
-                                                   hipsolverComplex*    A,
+                                                   hipFloatComplex*     A,
                                                    int                  lda,
                                                    int*                 devIpiv,
-                                                   hipsolverComplex*    B,
+                                                   hipFloatComplex*     B,
                                                    int                  ldb,
-                                                   hipsolverComplex*    work,
+                                                   hipFloatComplex*     work,
                                                    int                  lwork,
                                                    int*                 devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t       handle,
-                                                   hipsolverOperation_t    trans,
-                                                   int                     n,
-                                                   int                     nrhs,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   int*                    devIpiv,
-                                                   hipsolverDoubleComplex* B,
-                                                   int                     ldb,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t    handle,
+                                                   hipsolverOperation_t trans,
+                                                   int                  n,
+                                                   int                  nrhs,
+                                                   hipDoubleComplex*    A,
+                                                   int                  lda,
+                                                   int*                 devIpiv,
+                                                   hipDoubleComplex*    B,
+                                                   int                  ldb,
+                                                   hipDoubleComplex*    work,
+                                                   int                  lwork,
+                                                   int*                 devInfo);
 
 // potrf
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrf_bufferSize(
@@ -1034,16 +929,16 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrf_bufferSize(
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrf_bufferSize(hipsolverHandle_t   handle,
                                                               hipsolverFillMode_t uplo,
                                                               int                 n,
-                                                              hipsolverComplex*   A,
+                                                              hipFloatComplex*    A,
                                                               int                 lda,
                                                               int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrf_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverFillMode_t     uplo,
-                                                              int                     n,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrf_bufferSize(hipsolverHandle_t   handle,
+                                                              hipsolverFillMode_t uplo,
+                                                              int                 n,
+                                                              hipDoubleComplex*   A,
+                                                              int                 lda,
+                                                              int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrf(hipsolverHandle_t   handle,
                                                    hipsolverFillMode_t uplo,
@@ -1066,20 +961,20 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrf(hipsolverHandle_t   handle,
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrf(hipsolverHandle_t   handle,
                                                    hipsolverFillMode_t uplo,
                                                    int                 n,
-                                                   hipsolverComplex*   A,
+                                                   hipFloatComplex*    A,
                                                    int                 lda,
-                                                   hipsolverComplex*   work,
+                                                   hipFloatComplex*    work,
                                                    int                 lwork,
                                                    int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrf(hipsolverHandle_t       handle,
-                                                   hipsolverFillMode_t     uplo,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrf(hipsolverHandle_t   handle,
+                                                   hipsolverFillMode_t uplo,
+                                                   int                 n,
+                                                   hipDoubleComplex*   A,
+                                                   int                 lda,
+                                                   hipDoubleComplex*   work,
+                                                   int                 lwork,
+                                                   int*                devInfo);
 
 // potrf_batched
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrfBatched_bufferSize(hipsolverHandle_t   handle,
@@ -1101,17 +996,17 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrfBatched_bufferSize(hipsolverHa
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                                      hipsolverFillMode_t uplo,
                                                                      int                 n,
-                                                                     hipsolverComplex*   A[],
+                                                                     hipFloatComplex*    A[],
                                                                      int                 lda,
                                                                      int*                lwork,
                                                                      int batch_count);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t       handle,
-                                                                     hipsolverFillMode_t     uplo,
-                                                                     int                     n,
-                                                                     hipsolverDoubleComplex* A[],
-                                                                     int                     lda,
-                                                                     int*                    lwork,
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                                     hipsolverFillMode_t uplo,
+                                                                     int                 n,
+                                                                     hipDoubleComplex*   A[],
+                                                                     int                 lda,
+                                                                     int*                lwork,
                                                                      int batch_count);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpotrfBatched(hipsolverHandle_t   handle,
@@ -1137,22 +1032,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDpotrfBatched(hipsolverHandle_t   ha
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCpotrfBatched(hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
-                                                          hipsolverComplex*   A[],
+                                                          hipFloatComplex*    A[],
                                                           int                 lda,
-                                                          hipsolverComplex*   work,
+                                                          hipFloatComplex*    work,
                                                           int                 lwork,
                                                           int*                devInfo,
                                                           int                 batch_count);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t       handle,
-                                                          hipsolverFillMode_t     uplo,
-                                                          int                     n,
-                                                          hipsolverDoubleComplex* A[],
-                                                          int                     lda,
-                                                          hipsolverDoubleComplex* work,
-                                                          int                     lwork,
-                                                          int*                    devInfo,
-                                                          int                     batch_count);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t   handle,
+                                                          hipsolverFillMode_t uplo,
+                                                          int                 n,
+                                                          hipDoubleComplex*   A[],
+                                                          int                 lda,
+                                                          hipDoubleComplex*   work,
+                                                          int                 lwork,
+                                                          int*                devInfo,
+                                                          int                 batch_count);
 
 // syevd/heevd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsyevd_bufferSize(hipsolverHandle_t   handle,
@@ -1177,19 +1072,19 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCheevd_bufferSize(hipsolverHandle_t 
                                                               hipsolverEigMode_t  jobz,
                                                               hipsolverFillMode_t uplo,
                                                               int                 n,
-                                                              hipsolverComplex*   A,
+                                                              hipFloatComplex*    A,
                                                               int                 lda,
                                                               float*              D,
                                                               int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZheevd_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverEigMode_t      jobz,
-                                                              hipsolverFillMode_t     uplo,
-                                                              int                     n,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              double*                 D,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZheevd_bufferSize(hipsolverHandle_t   handle,
+                                                              hipsolverEigMode_t  jobz,
+                                                              hipsolverFillMode_t uplo,
+                                                              int                 n,
+                                                              hipDoubleComplex*   A,
+                                                              int                 lda,
+                                                              double*             D,
+                                                              int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsyevd(hipsolverHandle_t   handle,
                                                    hipsolverEigMode_t  jobz,
@@ -1217,23 +1112,23 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCheevd(hipsolverHandle_t   handle,
                                                    hipsolverEigMode_t  jobz,
                                                    hipsolverFillMode_t uplo,
                                                    int                 n,
-                                                   hipsolverComplex*   A,
+                                                   hipFloatComplex*    A,
                                                    int                 lda,
                                                    float*              D,
-                                                   hipsolverComplex*   work,
+                                                   hipFloatComplex*    work,
                                                    int                 lwork,
                                                    int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZheevd(hipsolverHandle_t       handle,
-                                                   hipsolverEigMode_t      jobz,
-                                                   hipsolverFillMode_t     uplo,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   double*                 D,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZheevd(hipsolverHandle_t   handle,
+                                                   hipsolverEigMode_t  jobz,
+                                                   hipsolverFillMode_t uplo,
+                                                   int                 n,
+                                                   hipDoubleComplex*   A,
+                                                   int                 lda,
+                                                   double*             D,
+                                                   hipDoubleComplex*   work,
+                                                   int                 lwork,
+                                                   int*                devInfo);
 
 // sygvd/hegvd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvd_bufferSize(hipsolverHandle_t   handle,
@@ -1265,24 +1160,24 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd_bufferSize(hipsolverHandle_t 
                                                               hipsolverEigMode_t  jobz,
                                                               hipsolverFillMode_t uplo,
                                                               int                 n,
-                                                              hipsolverComplex*   A,
+                                                              hipFloatComplex*    A,
                                                               int                 lda,
-                                                              hipsolverComplex*   B,
+                                                              hipFloatComplex*    B,
                                                               int                 ldb,
                                                               float*              D,
                                                               int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverEigType_t      itype,
-                                                              hipsolverEigMode_t      jobz,
-                                                              hipsolverFillMode_t     uplo,
-                                                              int                     n,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              hipsolverDoubleComplex* B,
-                                                              int                     ldb,
-                                                              double*                 D,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSize(hipsolverHandle_t   handle,
+                                                              hipsolverEigType_t  itype,
+                                                              hipsolverEigMode_t  jobz,
+                                                              hipsolverFillMode_t uplo,
+                                                              int                 n,
+                                                              hipDoubleComplex*   A,
+                                                              int                 lda,
+                                                              hipDoubleComplex*   B,
+                                                              int                 ldb,
+                                                              double*             D,
+                                                              int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvd(hipsolverHandle_t   handle,
                                                    hipsolverEigType_t  itype,
@@ -1317,28 +1212,28 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd(hipsolverHandle_t   handle,
                                                    hipsolverEigMode_t  jobz,
                                                    hipsolverFillMode_t uplo,
                                                    int                 n,
-                                                   hipsolverComplex*   A,
+                                                   hipFloatComplex*    A,
                                                    int                 lda,
-                                                   hipsolverComplex*   B,
+                                                   hipFloatComplex*    B,
                                                    int                 ldb,
                                                    float*              D,
-                                                   hipsolverComplex*   work,
+                                                   hipFloatComplex*    work,
                                                    int                 lwork,
                                                    int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd(hipsolverHandle_t       handle,
-                                                   hipsolverEigType_t      itype,
-                                                   hipsolverEigMode_t      jobz,
-                                                   hipsolverFillMode_t     uplo,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* B,
-                                                   int                     ldb,
-                                                   double*                 D,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd(hipsolverHandle_t   handle,
+                                                   hipsolverEigType_t  itype,
+                                                   hipsolverEigMode_t  jobz,
+                                                   hipsolverFillMode_t uplo,
+                                                   int                 n,
+                                                   hipDoubleComplex*   A,
+                                                   int                 lda,
+                                                   hipDoubleComplex*   B,
+                                                   int                 ldb,
+                                                   double*             D,
+                                                   hipDoubleComplex*   work,
+                                                   int                 lwork,
+                                                   int*                devInfo);
 
 // sytrd/hetrd
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsytrd_bufferSize(hipsolverHandle_t   handle,
@@ -1364,22 +1259,22 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsytrd_bufferSize(hipsolverHandle_t 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChetrd_bufferSize(hipsolverHandle_t   handle,
                                                               hipsolverFillMode_t uplo,
                                                               int                 n,
-                                                              hipsolverComplex*   A,
+                                                              hipFloatComplex*    A,
                                                               int                 lda,
                                                               float*              D,
                                                               float*              E,
-                                                              hipsolverComplex*   tau,
+                                                              hipFloatComplex*    tau,
                                                               int*                lwork);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhetrd_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverFillMode_t     uplo,
-                                                              int                     n,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              double*                 D,
-                                                              double*                 E,
-                                                              hipsolverDoubleComplex* tau,
-                                                              int*                    lwork);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhetrd_bufferSize(hipsolverHandle_t   handle,
+                                                              hipsolverFillMode_t uplo,
+                                                              int                 n,
+                                                              hipDoubleComplex*   A,
+                                                              int                 lda,
+                                                              double*             D,
+                                                              double*             E,
+                                                              hipDoubleComplex*   tau,
+                                                              int*                lwork);
 
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsytrd(hipsolverHandle_t   handle,
                                                    hipsolverFillMode_t uplo,
@@ -1408,26 +1303,26 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsytrd(hipsolverHandle_t   handle,
 HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChetrd(hipsolverHandle_t   handle,
                                                    hipsolverFillMode_t uplo,
                                                    int                 n,
-                                                   hipsolverComplex*   A,
+                                                   hipFloatComplex*    A,
                                                    int                 lda,
                                                    float*              D,
                                                    float*              E,
-                                                   hipsolverComplex*   tau,
-                                                   hipsolverComplex*   work,
+                                                   hipFloatComplex*    tau,
+                                                   hipFloatComplex*    work,
                                                    int                 lwork,
                                                    int*                devInfo);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhetrd(hipsolverHandle_t       handle,
-                                                   hipsolverFillMode_t     uplo,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   double*                 D,
-                                                   double*                 E,
-                                                   hipsolverDoubleComplex* tau,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo);
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhetrd(hipsolverHandle_t   handle,
+                                                   hipsolverFillMode_t uplo,
+                                                   int                 n,
+                                                   hipDoubleComplex*   A,
+                                                   int                 lda,
+                                                   double*             D,
+                                                   double*             E,
+                                                   hipDoubleComplex*   tau,
+                                                   hipDoubleComplex*   work,
+                                                   int                 lwork,
+                                                   int*                devInfo);
 
 #ifdef __cplusplus
 }

--- a/library/include/hipsolver.h
+++ b/library/include/hipsolver.h
@@ -19,27 +19,6 @@
 #include <hip/hip_runtime_api.h>
 #include <stdint.h>
 
-/* Workaround clang bug:
-
-   https://bugs.llvm.org/show_bug.cgi?id=35863
-
-   This macro expands to static if clang is used; otherwise it expands empty.
-   It is intended to be used in variable template specializations, where clang
-   requires static in order for the specializations to have internal linkage,
-   while technically, storage class specifiers besides thread_local are not
-   allowed in template specializations, and static in the primary template
-   definition should imply internal linkage for all specializations.
-
-   If clang shows an error for improperly using a storage class specifier in
-   a specialization, then HIPSOLVER_CLANG_STATIC should be redefined as empty,
-   and perhaps removed entirely, if the above bug has been fixed.
-*/
-#if __clang__
-#define HIPSOLVER_CLANG_STATIC static
-#else
-#define HIPSOLVER_CLANG_STATIC
-#endif
-
 typedef void* hipsolverHandle_t;
 
 typedef enum

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -362,9 +362,9 @@ hipsolverStatus_t hipsolverCungbr_bufferSize(hipsolverHandle_t   handle,
                                              int                 m,
                                              int                 n,
                                              int                 k,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
-                                             hipsolverComplex*   tau,
+                                             hipFloatComplex*    tau,
                                              int*                lwork)
 try
 {
@@ -388,15 +388,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungbr_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverSideMode_t     side,
-                                             int                     m,
-                                             int                     n,
-                                             int                     k,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZungbr_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverSideMode_t side,
+                                             int                 m,
+                                             int                 n,
+                                             int                 k,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             hipDoubleComplex*   tau,
+                                             int*                lwork)
 try
 {
     size_t sz;
@@ -484,10 +484,10 @@ hipsolverStatus_t hipsolverCungbr(hipsolverHandle_t   handle,
                                   int                 m,
                                   int                 n,
                                   int                 k,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
-                                  hipsolverComplex*   tau,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    tau,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -515,17 +515,17 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungbr(hipsolverHandle_t       handle,
-                                  hipsolverSideMode_t     side,
-                                  int                     m,
-                                  int                     n,
-                                  int                     k,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZungbr(hipsolverHandle_t   handle,
+                                  hipsolverSideMode_t side,
+                                  int                 m,
+                                  int                 n,
+                                  int                 k,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  hipDoubleComplex*   tau,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     if(work != nullptr)
@@ -604,9 +604,9 @@ hipsolverStatus_t hipsolverCungqr_bufferSize(hipsolverHandle_t handle,
                                              int               m,
                                              int               n,
                                              int               k,
-                                             hipsolverComplex* A,
+                                             hipFloatComplex*  A,
                                              int               lda,
-                                             hipsolverComplex* tau,
+                                             hipFloatComplex*  tau,
                                              int*              lwork)
 try
 {
@@ -630,14 +630,14 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungqr_bufferSize(hipsolverHandle_t       handle,
-                                             int                     m,
-                                             int                     n,
-                                             int                     k,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZungqr_bufferSize(hipsolverHandle_t handle,
+                                             int               m,
+                                             int               n,
+                                             int               k,
+                                             hipDoubleComplex* A,
+                                             int               lda,
+                                             hipDoubleComplex* tau,
+                                             int*              lwork)
 try
 {
     size_t sz;
@@ -720,10 +720,10 @@ hipsolverStatus_t hipsolverCungqr(hipsolverHandle_t handle,
                                   int               m,
                                   int               n,
                                   int               k,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
-                                  hipsolverComplex* tau,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  tau,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   int*              devInfo)
 try
@@ -750,16 +750,16 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungqr(hipsolverHandle_t       handle,
-                                  int                     m,
-                                  int                     n,
-                                  int                     k,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZungqr(hipsolverHandle_t handle,
+                                  int               m,
+                                  int               n,
+                                  int               k,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  hipDoubleComplex* tau,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  int*              devInfo)
 try
 {
     if(work != nullptr)
@@ -846,9 +846,9 @@ catch(...)
 hipsolverStatus_t hipsolverCungtr_bufferSize(hipsolverHandle_t   handle,
                                              hipsolverFillMode_t uplo,
                                              int                 n,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
-                                             hipsolverComplex*   tau,
+                                             hipFloatComplex*    tau,
                                              int*                lwork)
 try
 {
@@ -872,13 +872,13 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungtr_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverFillMode_t     uplo,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZungtr_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             hipDoubleComplex*   tau,
+                                             int*                lwork)
 try
 {
     size_t sz;
@@ -960,10 +960,10 @@ catch(...)
 hipsolverStatus_t hipsolverCungtr(hipsolverHandle_t   handle,
                                   hipsolverFillMode_t uplo,
                                   int                 n,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
-                                  hipsolverComplex*   tau,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    tau,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -989,15 +989,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungtr(hipsolverHandle_t       handle,
-                                  hipsolverFillMode_t     uplo,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZungtr(hipsolverHandle_t   handle,
+                                  hipsolverFillMode_t uplo,
+                                  int                 n,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  hipDoubleComplex*   tau,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     if(work != nullptr)
@@ -1114,10 +1114,10 @@ hipsolverStatus_t hipsolverCunmqr_bufferSize(hipsolverHandle_t    handle,
                                              int                  m,
                                              int                  n,
                                              int                  k,
-                                             hipsolverComplex*    A,
+                                             hipFloatComplex*     A,
                                              int                  lda,
-                                             hipsolverComplex*    tau,
-                                             hipsolverComplex*    C,
+                                             hipFloatComplex*     tau,
+                                             hipFloatComplex*     C,
                                              int                  ldc,
                                              int*                 lwork)
 try
@@ -1151,18 +1151,18 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZunmqr_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverSideMode_t     side,
-                                             hipsolverOperation_t    trans,
-                                             int                     m,
-                                             int                     n,
-                                             int                     k,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             hipsolverDoubleComplex* C,
-                                             int                     ldc,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZunmqr_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverSideMode_t  side,
+                                             hipsolverOperation_t trans,
+                                             int                  m,
+                                             int                  n,
+                                             int                  k,
+                                             hipDoubleComplex*    A,
+                                             int                  lda,
+                                             hipDoubleComplex*    tau,
+                                             hipDoubleComplex*    C,
+                                             int                  ldc,
+                                             int*                 lwork)
 try
 {
     size_t sz;
@@ -1284,12 +1284,12 @@ hipsolverStatus_t hipsolverCunmqr(hipsolverHandle_t    handle,
                                   int                  m,
                                   int                  n,
                                   int                  k,
-                                  hipsolverComplex*    A,
+                                  hipFloatComplex*     A,
                                   int                  lda,
-                                  hipsolverComplex*    tau,
-                                  hipsolverComplex*    C,
+                                  hipFloatComplex*     tau,
+                                  hipFloatComplex*     C,
                                   int                  ldc,
-                                  hipsolverComplex*    work,
+                                  hipFloatComplex*     work,
                                   int                  lwork,
                                   int*                 devInfo)
 try
@@ -1320,20 +1320,20 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZunmqr(hipsolverHandle_t       handle,
-                                  hipsolverSideMode_t     side,
-                                  hipsolverOperation_t    trans,
-                                  int                     m,
-                                  int                     n,
-                                  int                     k,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* C,
-                                  int                     ldc,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZunmqr(hipsolverHandle_t    handle,
+                                  hipsolverSideMode_t  side,
+                                  hipsolverOperation_t trans,
+                                  int                  m,
+                                  int                  n,
+                                  int                  k,
+                                  hipDoubleComplex*    A,
+                                  int                  lda,
+                                  hipDoubleComplex*    tau,
+                                  hipDoubleComplex*    C,
+                                  int                  ldc,
+                                  hipDoubleComplex*    work,
+                                  int                  lwork,
+                                  int*                 devInfo)
 try
 {
     if(work != nullptr)
@@ -1455,10 +1455,10 @@ hipsolverStatus_t hipsolverCunmtr_bufferSize(hipsolverHandle_t    handle,
                                              hipsolverOperation_t trans,
                                              int                  m,
                                              int                  n,
-                                             hipsolverComplex*    A,
+                                             hipFloatComplex*     A,
                                              int                  lda,
-                                             hipsolverComplex*    tau,
-                                             hipsolverComplex*    C,
+                                             hipFloatComplex*     tau,
+                                             hipFloatComplex*     C,
                                              int                  ldc,
                                              int*                 lwork)
 try
@@ -1492,18 +1492,18 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZunmtr_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverSideMode_t     side,
-                                             hipsolverFillMode_t     uplo,
-                                             hipsolverOperation_t    trans,
-                                             int                     m,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             hipsolverDoubleComplex* C,
-                                             int                     ldc,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZunmtr_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverSideMode_t  side,
+                                             hipsolverFillMode_t  uplo,
+                                             hipsolverOperation_t trans,
+                                             int                  m,
+                                             int                  n,
+                                             hipDoubleComplex*    A,
+                                             int                  lda,
+                                             hipDoubleComplex*    tau,
+                                             hipDoubleComplex*    C,
+                                             int                  ldc,
+                                             int*                 lwork)
 try
 {
     size_t sz;
@@ -1625,12 +1625,12 @@ hipsolverStatus_t hipsolverCunmtr(hipsolverHandle_t    handle,
                                   hipsolverOperation_t trans,
                                   int                  m,
                                   int                  n,
-                                  hipsolverComplex*    A,
+                                  hipFloatComplex*     A,
                                   int                  lda,
-                                  hipsolverComplex*    tau,
-                                  hipsolverComplex*    C,
+                                  hipFloatComplex*     tau,
+                                  hipFloatComplex*     C,
                                   int                  ldc,
-                                  hipsolverComplex*    work,
+                                  hipFloatComplex*     work,
                                   int                  lwork,
                                   int*                 devInfo)
 try
@@ -1661,20 +1661,20 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZunmtr(hipsolverHandle_t       handle,
-                                  hipsolverSideMode_t     side,
-                                  hipsolverFillMode_t     uplo,
-                                  hipsolverOperation_t    trans,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* C,
-                                  int                     ldc,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZunmtr(hipsolverHandle_t    handle,
+                                  hipsolverSideMode_t  side,
+                                  hipsolverFillMode_t  uplo,
+                                  hipsolverOperation_t trans,
+                                  int                  m,
+                                  int                  n,
+                                  hipDoubleComplex*    A,
+                                  int                  lda,
+                                  hipDoubleComplex*    tau,
+                                  hipDoubleComplex*    C,
+                                  int                  ldc,
+                                  hipDoubleComplex*    work,
+                                  int                  lwork,
+                                  int*                 devInfo)
 try
 {
     if(work != nullptr)
@@ -1859,13 +1859,13 @@ catch(...)
 hipsolverStatus_t hipsolverCgebrd(hipsolverHandle_t handle,
                                   int               m,
                                   int               n,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
                                   float*            D,
                                   float*            E,
-                                  hipsolverComplex* tauq,
-                                  hipsolverComplex* taup,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  tauq,
+                                  hipFloatComplex*  taup,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   int*              devInfo)
 try
@@ -1893,18 +1893,18 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgebrd(hipsolverHandle_t       handle,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  double*                 D,
-                                  double*                 E,
-                                  hipsolverDoubleComplex* tauq,
-                                  hipsolverDoubleComplex* taup,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgebrd(hipsolverHandle_t handle,
+                                  int               m,
+                                  int               n,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  double*           D,
+                                  double*           E,
+                                  hipDoubleComplex* tauq,
+                                  hipDoubleComplex* taup,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  int*              devInfo)
 try
 {
     if(work != nullptr)
@@ -1978,7 +1978,7 @@ catch(...)
 }
 
 hipsolverStatus_t hipsolverCgeqrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
+    hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
     size_t sz;
@@ -2001,7 +2001,7 @@ catch(...)
 }
 
 hipsolverStatus_t hipsolverZgeqrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex* A, int lda, int* lwork)
+    hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
     size_t sz;
@@ -2080,10 +2080,10 @@ catch(...)
 hipsolverStatus_t hipsolverCgeqrf(hipsolverHandle_t handle,
                                   int               m,
                                   int               n,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
-                                  hipsolverComplex* tau,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  tau,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   int*              devInfo)
 try
@@ -2105,15 +2105,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgeqrf(hipsolverHandle_t       handle,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgeqrf(hipsolverHandle_t handle,
+                                  int               m,
+                                  int               n,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  hipDoubleComplex* tau,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  int*              devInfo)
 try
 {
     if(work != nullptr)
@@ -2387,14 +2387,14 @@ hipsolverStatus_t hipsolverCgesvd(hipsolverHandle_t handle,
                                   signed char       jobv,
                                   int               m,
                                   int               n,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
                                   float*            S,
-                                  hipsolverComplex* U,
+                                  hipFloatComplex*  U,
                                   int               ldu,
-                                  hipsolverComplex* V,
+                                  hipFloatComplex*  V,
                                   int               ldv,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   float*            rwork,
                                   int*              devInfo)
@@ -2430,22 +2430,22 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgesvd(hipsolverHandle_t       handle,
-                                  signed char             jobu,
-                                  signed char             jobv,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  double*                 S,
-                                  hipsolverDoubleComplex* U,
-                                  int                     ldu,
-                                  hipsolverDoubleComplex* V,
-                                  int                     ldv,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  double*                 rwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgesvd(hipsolverHandle_t handle,
+                                  signed char       jobu,
+                                  signed char       jobv,
+                                  int               m,
+                                  int               n,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  double*           S,
+                                  hipDoubleComplex* U,
+                                  int               ldu,
+                                  hipDoubleComplex* V,
+                                  int               ldv,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  double*           rwork,
+                                  int*              devInfo)
 try
 {
     if(work != nullptr)
@@ -2530,7 +2530,7 @@ catch(...)
 }
 
 hipsolverStatus_t hipsolverCgetrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
+    hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
     size_t sz;
@@ -2555,7 +2555,7 @@ catch(...)
 }
 
 hipsolverStatus_t hipsolverZgetrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex* A, int lda, int* lwork)
+    hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
     size_t sz;
@@ -2646,9 +2646,9 @@ catch(...)
 hipsolverStatus_t hipsolverCgetrf(hipsolverHandle_t handle,
                                   int               m,
                                   int               n,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   int*              devIpiv,
                                   int*              devInfo)
@@ -2675,15 +2675,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t       handle,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devIpiv,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t handle,
+                                  int               m,
+                                  int               n,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  int*              devIpiv,
+                                  int*              devInfo)
 try
 {
     if(work != nullptr)
@@ -2790,10 +2790,10 @@ hipsolverStatus_t hipsolverCgetrs_bufferSize(hipsolverHandle_t    handle,
                                              hipsolverOperation_t trans,
                                              int                  n,
                                              int                  nrhs,
-                                             hipsolverComplex*    A,
+                                             hipFloatComplex*     A,
                                              int                  lda,
                                              int*                 devIpiv,
-                                             hipsolverComplex*    B,
+                                             hipFloatComplex*     B,
                                              int                  ldb,
                                              int*                 lwork)
 try
@@ -2825,16 +2825,16 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverOperation_t    trans,
-                                             int                     n,
-                                             int                     nrhs,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             int*                    devIpiv,
-                                             hipsolverDoubleComplex* B,
-                                             int                     ldb,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverOperation_t trans,
+                                             int                  n,
+                                             int                  nrhs,
+                                             hipDoubleComplex*    A,
+                                             int                  lda,
+                                             int*                 devIpiv,
+                                             hipDoubleComplex*    B,
+                                             int                  ldb,
+                                             int*                 lwork)
 try
 {
     size_t sz;
@@ -2930,12 +2930,12 @@ hipsolverStatus_t hipsolverCgetrs(hipsolverHandle_t    handle,
                                   hipsolverOperation_t trans,
                                   int                  n,
                                   int                  nrhs,
-                                  hipsolverComplex*    A,
+                                  hipFloatComplex*     A,
                                   int                  lda,
                                   int*                 devIpiv,
-                                  hipsolverComplex*    B,
+                                  hipFloatComplex*     B,
                                   int                  ldb,
-                                  hipsolverComplex*    work,
+                                  hipFloatComplex*     work,
                                   int                  lwork,
                                   int*                 devInfo)
 try
@@ -2964,18 +2964,18 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t       handle,
-                                  hipsolverOperation_t    trans,
-                                  int                     n,
-                                  int                     nrhs,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  int*                    devIpiv,
-                                  hipsolverDoubleComplex* B,
-                                  int                     ldb,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t    handle,
+                                  hipsolverOperation_t trans,
+                                  int                  n,
+                                  int                  nrhs,
+                                  hipDoubleComplex*    A,
+                                  int                  lda,
+                                  int*                 devIpiv,
+                                  hipDoubleComplex*    B,
+                                  int                  ldb,
+                                  hipDoubleComplex*    work,
+                                  int                  lwork,
+                                  int*                 devInfo)
 try
 {
     if(work != nullptr)
@@ -3054,7 +3054,7 @@ catch(...)
 hipsolverStatus_t hipsolverCpotrf_bufferSize(hipsolverHandle_t   handle,
                                              hipsolverFillMode_t uplo,
                                              int                 n,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
                                              int*                lwork)
 try
@@ -3079,12 +3079,12 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZpotrf_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverFillMode_t     uplo,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZpotrf_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             int*                lwork)
 try
 {
     size_t sz;
@@ -3164,9 +3164,9 @@ catch(...)
 hipsolverStatus_t hipsolverCpotrf(hipsolverHandle_t   handle,
                                   hipsolverFillMode_t uplo,
                                   int                 n,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -3192,14 +3192,14 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZpotrf(hipsolverHandle_t       handle,
-                                  hipsolverFillMode_t     uplo,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZpotrf(hipsolverHandle_t   handle,
+                                  hipsolverFillMode_t uplo,
+                                  int                 n,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     if(work != nullptr)
@@ -3285,7 +3285,7 @@ catch(...)
 hipsolverStatus_t hipsolverCpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     hipsolverFillMode_t uplo,
                                                     int                 n,
-                                                    hipsolverComplex*   A[],
+                                                    hipFloatComplex*    A[],
                                                     int                 lda,
                                                     int*                lwork,
                                                     int                 batch_count)
@@ -3311,13 +3311,13 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t       handle,
-                                                    hipsolverFillMode_t     uplo,
-                                                    int                     n,
-                                                    hipsolverDoubleComplex* A[],
-                                                    int                     lda,
-                                                    int*                    lwork,
-                                                    int                     batch_count)
+hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    hipDoubleComplex*   A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 batch_count)
 try
 {
     size_t sz;
@@ -3399,9 +3399,9 @@ catch(...)
 hipsolverStatus_t hipsolverCpotrfBatched(hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
-                                         hipsolverComplex*   A[],
+                                         hipFloatComplex*    A[],
                                          int                 lda,
-                                         hipsolverComplex*   work,
+                                         hipFloatComplex*    work,
                                          int                 lwork,
                                          int*                devInfo,
                                          int                 batch_count)
@@ -3429,15 +3429,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t       handle,
-                                         hipsolverFillMode_t     uplo,
-                                         int                     n,
-                                         hipsolverDoubleComplex* A[],
-                                         int                     lda,
-                                         hipsolverDoubleComplex* work,
-                                         int                     lwork,
-                                         int*                    devInfo,
-                                         int                     batch_count)
+hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t   handle,
+                                         hipsolverFillMode_t uplo,
+                                         int                 n,
+                                         hipDoubleComplex*   A[],
+                                         int                 lda,
+                                         hipDoubleComplex*   work,
+                                         int                 lwork,
+                                         int*                devInfo,
+                                         int                 batch_count)
 try
 {
     if(work != nullptr)
@@ -3547,7 +3547,7 @@ hipsolverStatus_t hipsolverCheevd_bufferSize(hipsolverHandle_t   handle,
                                              hipsolverEigMode_t  jobz,
                                              hipsolverFillMode_t uplo,
                                              int                 n,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
                                              float*              D,
                                              int*                lwork)
@@ -3583,14 +3583,14 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZheevd_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverEigMode_t      jobz,
-                                             hipsolverFillMode_t     uplo,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             double*                 D,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZheevd_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverEigMode_t  jobz,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             double*             D,
+                                             int*                lwork)
 try
 {
     size_t sz;
@@ -3741,10 +3741,10 @@ hipsolverStatus_t hipsolverCheevd(hipsolverHandle_t   handle,
                                   hipsolverEigMode_t  jobz,
                                   hipsolverFillMode_t uplo,
                                   int                 n,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
                                   float*              D,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -3752,7 +3752,7 @@ try
     if(work != nullptr)
     {
         float* E = (float*)work;
-        work     = (hipsolverComplex*)(E + n);
+        work     = (hipFloatComplex*)(E + n);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
 
@@ -3794,22 +3794,22 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZheevd(hipsolverHandle_t       handle,
-                                  hipsolverEigMode_t      jobz,
-                                  hipsolverFillMode_t     uplo,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  double*                 D,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZheevd(hipsolverHandle_t   handle,
+                                  hipsolverEigMode_t  jobz,
+                                  hipsolverFillMode_t uplo,
+                                  int                 n,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  double*             D,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     if(work != nullptr)
     {
         double* E = (double*)work;
-        work      = (hipsolverDoubleComplex*)(E + n);
+        work      = (hipDoubleComplex*)(E + n);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
 
@@ -3949,9 +3949,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd_bufferSize(hipsolverHandle_t 
                                                               hipsolverEigMode_t  jobz,
                                                               hipsolverFillMode_t uplo,
                                                               int                 n,
-                                                              hipsolverComplex*   A,
+                                                              hipFloatComplex*    A,
                                                               int                 lda,
-                                                              hipsolverComplex*   B,
+                                                              hipFloatComplex*    B,
                                                               int                 ldb,
                                                               float*              D,
                                                               int*                lwork)
@@ -3990,17 +3990,17 @@ catch(...)
     return exception2hip_status();
 }
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverEigType_t      itype,
-                                                              hipsolverEigMode_t      jobz,
-                                                              hipsolverFillMode_t     uplo,
-                                                              int                     n,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              hipsolverDoubleComplex* B,
-                                                              int                     ldb,
-                                                              double*                 D,
-                                                              int*                    lwork)
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSize(hipsolverHandle_t   handle,
+                                                              hipsolverEigType_t  itype,
+                                                              hipsolverEigMode_t  jobz,
+                                                              hipsolverFillMode_t uplo,
+                                                              int                 n,
+                                                              hipDoubleComplex*   A,
+                                                              int                 lda,
+                                                              hipDoubleComplex*   B,
+                                                              int                 ldb,
+                                                              double*             D,
+                                                              int*                lwork)
 try
 {
     size_t sz;
@@ -4173,12 +4173,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd(hipsolverHandle_t   handle,
                                                    hipsolverEigMode_t  jobz,
                                                    hipsolverFillMode_t uplo,
                                                    int                 n,
-                                                   hipsolverComplex*   A,
+                                                   hipFloatComplex*    A,
                                                    int                 lda,
-                                                   hipsolverComplex*   B,
+                                                   hipFloatComplex*    B,
                                                    int                 ldb,
                                                    float*              D,
-                                                   hipsolverComplex*   work,
+                                                   hipFloatComplex*    work,
                                                    int                 lwork,
                                                    int*                devInfo)
 try
@@ -4186,7 +4186,7 @@ try
     if(work != nullptr)
     {
         float* E = (float*)work;
-        work     = (hipsolverComplex*)(E + n);
+        work     = (hipFloatComplex*)(E + n);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
 
@@ -4234,25 +4234,25 @@ catch(...)
     return exception2hip_status();
 }
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd(hipsolverHandle_t       handle,
-                                                   hipsolverEigType_t      itype,
-                                                   hipsolverEigMode_t      jobz,
-                                                   hipsolverFillMode_t     uplo,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* B,
-                                                   int                     ldb,
-                                                   double*                 D,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo)
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd(hipsolverHandle_t   handle,
+                                                   hipsolverEigType_t  itype,
+                                                   hipsolverEigMode_t  jobz,
+                                                   hipsolverFillMode_t uplo,
+                                                   int                 n,
+                                                   hipDoubleComplex*   A,
+                                                   int                 lda,
+                                                   hipDoubleComplex*   B,
+                                                   int                 ldb,
+                                                   double*             D,
+                                                   hipDoubleComplex*   work,
+                                                   int                 lwork,
+                                                   int*                devInfo)
 try
 {
     if(work != nullptr)
     {
         double* E = (double*)work;
-        work      = (hipsolverDoubleComplex*)(E + n);
+        work      = (hipDoubleComplex*)(E + n);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
 
@@ -4366,11 +4366,11 @@ catch(...)
 hipsolverStatus_t hipsolverChetrd_bufferSize(hipsolverHandle_t   handle,
                                              hipsolverFillMode_t uplo,
                                              int                 n,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
                                              float*              D,
                                              float*              E,
-                                             hipsolverComplex*   tau,
+                                             hipFloatComplex*    tau,
                                              int*                lwork)
 try
 {
@@ -4394,15 +4394,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZhetrd_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverFillMode_t     uplo,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             double*                 D,
-                                             double*                 E,
-                                             hipsolverDoubleComplex* tau,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZhetrd_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             double*             D,
+                                             double*             E,
+                                             hipDoubleComplex*   tau,
+                                             int*                lwork)
 try
 {
     size_t sz;
@@ -4488,12 +4488,12 @@ catch(...)
 hipsolverStatus_t hipsolverChetrd(hipsolverHandle_t   handle,
                                   hipsolverFillMode_t uplo,
                                   int                 n,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
                                   float*              D,
                                   float*              E,
-                                  hipsolverComplex*   tau,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    tau,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -4521,17 +4521,17 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZhetrd(hipsolverHandle_t       handle,
-                                  hipsolverFillMode_t     uplo,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  double*                 D,
-                                  double*                 E,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZhetrd(hipsolverHandle_t   handle,
+                                  hipsolverFillMode_t uplo,
+                                  int                 n,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  double*             D,
+                                  double*             E,
+                                  hipDoubleComplex*   tau,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     if(work != nullptr)

--- a/library/src/nvcc_detail/hipsolver.cpp
+++ b/library/src/nvcc_detail/hipsolver.cpp
@@ -261,9 +261,9 @@ hipsolverStatus_t hipsolverCungbr_bufferSize(hipsolverHandle_t   handle,
                                              int                 m,
                                              int                 n,
                                              int                 k,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
-                                             hipsolverComplex*   tau,
+                                             hipFloatComplex*    tau,
                                              int*                lwork)
 try
 {
@@ -282,15 +282,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungbr_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverSideMode_t     side,
-                                             int                     m,
-                                             int                     n,
-                                             int                     k,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZungbr_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverSideMode_t side,
+                                             int                 m,
+                                             int                 n,
+                                             int                 k,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             hipDoubleComplex*   tau,
+                                             int*                lwork)
 try
 {
     return cuda2hip_status(cusolverDnZungbr_bufferSize((cusolverDnHandle_t)handle,
@@ -373,10 +373,10 @@ hipsolverStatus_t hipsolverCungbr(hipsolverHandle_t   handle,
                                   int                 m,
                                   int                 n,
                                   int                 k,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
-                                  hipsolverComplex*   tau,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    tau,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -398,17 +398,17 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungbr(hipsolverHandle_t       handle,
-                                  hipsolverSideMode_t     side,
-                                  int                     m,
-                                  int                     n,
-                                  int                     k,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZungbr(hipsolverHandle_t   handle,
+                                  hipsolverSideMode_t side,
+                                  int                 m,
+                                  int                 n,
+                                  int                 k,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  hipDoubleComplex*   tau,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZungbr((cusolverDnHandle_t)handle,
@@ -457,9 +457,9 @@ hipsolverStatus_t hipsolverCungqr_bufferSize(hipsolverHandle_t handle,
                                              int               m,
                                              int               n,
                                              int               k,
-                                             hipsolverComplex* A,
+                                             hipFloatComplex*  A,
                                              int               lda,
-                                             hipsolverComplex* tau,
+                                             hipFloatComplex*  tau,
                                              int*              lwork)
 try
 {
@@ -471,14 +471,14 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungqr_bufferSize(hipsolverHandle_t       handle,
-                                             int                     m,
-                                             int                     n,
-                                             int                     k,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZungqr_bufferSize(hipsolverHandle_t handle,
+                                             int               m,
+                                             int               n,
+                                             int               k,
+                                             hipDoubleComplex* A,
+                                             int               lda,
+                                             hipDoubleComplex* tau,
+                                             int*              lwork)
 try
 {
     return cuda2hip_status(cusolverDnZungqr_bufferSize((cusolverDnHandle_t)handle,
@@ -539,10 +539,10 @@ hipsolverStatus_t hipsolverCungqr(hipsolverHandle_t handle,
                                   int               m,
                                   int               n,
                                   int               k,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
-                                  hipsolverComplex* tau,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  tau,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   int*              devInfo)
 try
@@ -563,16 +563,16 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungqr(hipsolverHandle_t       handle,
-                                  int                     m,
-                                  int                     n,
-                                  int                     k,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZungqr(hipsolverHandle_t handle,
+                                  int               m,
+                                  int               n,
+                                  int               k,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  hipDoubleComplex* tau,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  int*              devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZungqr((cusolverDnHandle_t)handle,
@@ -629,9 +629,9 @@ catch(...)
 hipsolverStatus_t hipsolverCungtr_bufferSize(hipsolverHandle_t   handle,
                                              hipsolverFillMode_t uplo,
                                              int                 n,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
-                                             hipsolverComplex*   tau,
+                                             hipFloatComplex*    tau,
                                              int*                lwork)
 try
 {
@@ -648,13 +648,13 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungtr_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverFillMode_t     uplo,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZungtr_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             hipDoubleComplex*   tau,
+                                             int*                lwork)
 try
 {
     return cuda2hip_status(cusolverDnZungtr_bufferSize((cusolverDnHandle_t)handle,
@@ -711,10 +711,10 @@ catch(...)
 hipsolverStatus_t hipsolverCungtr(hipsolverHandle_t   handle,
                                   hipsolverFillMode_t uplo,
                                   int                 n,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
-                                  hipsolverComplex*   tau,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    tau,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -734,15 +734,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZungtr(hipsolverHandle_t       handle,
-                                  hipsolverFillMode_t     uplo,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZungtr(hipsolverHandle_t   handle,
+                                  hipsolverFillMode_t uplo,
+                                  int                 n,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  hipDoubleComplex*   tau,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZungtr((cusolverDnHandle_t)handle,
@@ -831,10 +831,10 @@ hipsolverStatus_t hipsolverCunmqr_bufferSize(hipsolverHandle_t    handle,
                                              int                  m,
                                              int                  n,
                                              int                  k,
-                                             hipsolverComplex*    A,
+                                             hipFloatComplex*     A,
                                              int                  lda,
-                                             hipsolverComplex*    tau,
-                                             hipsolverComplex*    C,
+                                             hipFloatComplex*     tau,
+                                             hipFloatComplex*     C,
                                              int                  ldc,
                                              int*                 lwork)
 try
@@ -857,18 +857,18 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZunmqr_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverSideMode_t     side,
-                                             hipsolverOperation_t    trans,
-                                             int                     m,
-                                             int                     n,
-                                             int                     k,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             hipsolverDoubleComplex* C,
-                                             int                     ldc,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZunmqr_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverSideMode_t  side,
+                                             hipsolverOperation_t trans,
+                                             int                  m,
+                                             int                  n,
+                                             int                  k,
+                                             hipDoubleComplex*    A,
+                                             int                  lda,
+                                             hipDoubleComplex*    tau,
+                                             hipDoubleComplex*    C,
+                                             int                  ldc,
+                                             int*                 lwork)
 try
 {
     return cuda2hip_status(cusolverDnZunmqr_bufferSize((cusolverDnHandle_t)handle,
@@ -967,12 +967,12 @@ hipsolverStatus_t hipsolverCunmqr(hipsolverHandle_t    handle,
                                   int                  m,
                                   int                  n,
                                   int                  k,
-                                  hipsolverComplex*    A,
+                                  hipFloatComplex*     A,
                                   int                  lda,
-                                  hipsolverComplex*    tau,
-                                  hipsolverComplex*    C,
+                                  hipFloatComplex*     tau,
+                                  hipFloatComplex*     C,
                                   int                  ldc,
-                                  hipsolverComplex*    work,
+                                  hipFloatComplex*     work,
                                   int                  lwork,
                                   int*                 devInfo)
 try
@@ -997,20 +997,20 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZunmqr(hipsolverHandle_t       handle,
-                                  hipsolverSideMode_t     side,
-                                  hipsolverOperation_t    trans,
-                                  int                     m,
-                                  int                     n,
-                                  int                     k,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* C,
-                                  int                     ldc,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZunmqr(hipsolverHandle_t    handle,
+                                  hipsolverSideMode_t  side,
+                                  hipsolverOperation_t trans,
+                                  int                  m,
+                                  int                  n,
+                                  int                  k,
+                                  hipDoubleComplex*    A,
+                                  int                  lda,
+                                  hipDoubleComplex*    tau,
+                                  hipDoubleComplex*    C,
+                                  int                  ldc,
+                                  hipDoubleComplex*    work,
+                                  int                  lwork,
+                                  int*                 devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZunmqr((cusolverDnHandle_t)handle,
@@ -1104,10 +1104,10 @@ hipsolverStatus_t hipsolverCunmtr_bufferSize(hipsolverHandle_t    handle,
                                              hipsolverOperation_t trans,
                                              int                  m,
                                              int                  n,
-                                             hipsolverComplex*    A,
+                                             hipFloatComplex*     A,
                                              int                  lda,
-                                             hipsolverComplex*    tau,
-                                             hipsolverComplex*    C,
+                                             hipFloatComplex*     tau,
+                                             hipFloatComplex*     C,
                                              int                  ldc,
                                              int*                 lwork)
 try
@@ -1130,18 +1130,18 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZunmtr_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverSideMode_t     side,
-                                             hipsolverFillMode_t     uplo,
-                                             hipsolverOperation_t    trans,
-                                             int                     m,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             hipsolverDoubleComplex* tau,
-                                             hipsolverDoubleComplex* C,
-                                             int                     ldc,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZunmtr_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverSideMode_t  side,
+                                             hipsolverFillMode_t  uplo,
+                                             hipsolverOperation_t trans,
+                                             int                  m,
+                                             int                  n,
+                                             hipDoubleComplex*    A,
+                                             int                  lda,
+                                             hipDoubleComplex*    tau,
+                                             hipDoubleComplex*    C,
+                                             int                  ldc,
+                                             int*                 lwork)
 try
 {
     return cuda2hip_status(cusolverDnZunmtr_bufferSize((cusolverDnHandle_t)handle,
@@ -1240,12 +1240,12 @@ hipsolverStatus_t hipsolverCunmtr(hipsolverHandle_t    handle,
                                   hipsolverOperation_t trans,
                                   int                  m,
                                   int                  n,
-                                  hipsolverComplex*    A,
+                                  hipFloatComplex*     A,
                                   int                  lda,
-                                  hipsolverComplex*    tau,
-                                  hipsolverComplex*    C,
+                                  hipFloatComplex*     tau,
+                                  hipFloatComplex*     C,
                                   int                  ldc,
-                                  hipsolverComplex*    work,
+                                  hipFloatComplex*     work,
                                   int                  lwork,
                                   int*                 devInfo)
 try
@@ -1270,20 +1270,20 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZunmtr(hipsolverHandle_t       handle,
-                                  hipsolverSideMode_t     side,
-                                  hipsolverFillMode_t     uplo,
-                                  hipsolverOperation_t    trans,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* C,
-                                  int                     ldc,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZunmtr(hipsolverHandle_t    handle,
+                                  hipsolverSideMode_t  side,
+                                  hipsolverFillMode_t  uplo,
+                                  hipsolverOperation_t trans,
+                                  int                  m,
+                                  int                  n,
+                                  hipDoubleComplex*    A,
+                                  int                  lda,
+                                  hipDoubleComplex*    tau,
+                                  hipDoubleComplex*    C,
+                                  int                  ldc,
+                                  hipDoubleComplex*    work,
+                                  int                  lwork,
+                                  int*                 devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZunmtr((cusolverDnHandle_t)handle,
@@ -1394,13 +1394,13 @@ catch(...)
 hipsolverStatus_t hipsolverCgebrd(hipsolverHandle_t handle,
                                   int               m,
                                   int               n,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
                                   float*            D,
                                   float*            E,
-                                  hipsolverComplex* tauq,
-                                  hipsolverComplex* taup,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  tauq,
+                                  hipFloatComplex*  taup,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   int*              devInfo)
 try
@@ -1423,18 +1423,18 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgebrd(hipsolverHandle_t       handle,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  double*                 D,
-                                  double*                 E,
-                                  hipsolverDoubleComplex* tauq,
-                                  hipsolverDoubleComplex* taup,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgebrd(hipsolverHandle_t handle,
+                                  int               m,
+                                  int               n,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  double*           D,
+                                  double*           E,
+                                  hipDoubleComplex* tauq,
+                                  hipDoubleComplex* taup,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  int*              devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZgebrd((cusolverDnHandle_t)handle,
@@ -1481,7 +1481,7 @@ catch(...)
 }
 
 hipsolverStatus_t hipsolverCgeqrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
+    hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
     return cuda2hip_status(
@@ -1493,7 +1493,7 @@ catch(...)
 }
 
 hipsolverStatus_t hipsolverZgeqrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex* A, int lda, int* lwork)
+    hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
     return cuda2hip_status(cusolverDnZgeqrf_bufferSize(
@@ -1545,10 +1545,10 @@ catch(...)
 hipsolverStatus_t hipsolverCgeqrf(hipsolverHandle_t handle,
                                   int               m,
                                   int               n,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
-                                  hipsolverComplex* tau,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  tau,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   int*              devInfo)
 try
@@ -1568,15 +1568,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgeqrf(hipsolverHandle_t       handle,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgeqrf(hipsolverHandle_t handle,
+                                  int               m,
+                                  int               n,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  hipDoubleComplex* tau,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  int*              devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZgeqrf((cusolverDnHandle_t)handle,
@@ -1724,14 +1724,14 @@ hipsolverStatus_t hipsolverCgesvd(hipsolverHandle_t handle,
                                   signed char       jobv,
                                   int               m,
                                   int               n,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
                                   float*            S,
-                                  hipsolverComplex* U,
+                                  hipFloatComplex*  U,
                                   int               ldu,
-                                  hipsolverComplex* V,
+                                  hipFloatComplex*  V,
                                   int               ldv,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   float*            rwork,
                                   int*              devInfo)
@@ -1759,22 +1759,22 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgesvd(hipsolverHandle_t       handle,
-                                  signed char             jobu,
-                                  signed char             jobv,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  double*                 S,
-                                  hipsolverDoubleComplex* U,
-                                  int                     ldu,
-                                  hipsolverDoubleComplex* V,
-                                  int                     ldv,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  double*                 rwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgesvd(hipsolverHandle_t handle,
+                                  signed char       jobu,
+                                  signed char       jobv,
+                                  int               m,
+                                  int               n,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  double*           S,
+                                  hipDoubleComplex* U,
+                                  int               ldu,
+                                  hipDoubleComplex* V,
+                                  int               ldv,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  double*           rwork,
+                                  int*              devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZgesvd((cusolverDnHandle_t)handle,
@@ -1825,7 +1825,7 @@ catch(...)
 }
 
 hipsolverStatus_t hipsolverCgetrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
+    hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
     return cuda2hip_status(
@@ -1837,7 +1837,7 @@ catch(...)
 }
 
 hipsolverStatus_t hipsolverZgetrf_bufferSize(
-    hipsolverHandle_t handle, int m, int n, hipsolverDoubleComplex* A, int lda, int* lwork)
+    hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
     return cuda2hip_status(cusolverDnZgetrf_bufferSize(
@@ -1889,9 +1889,9 @@ catch(...)
 hipsolverStatus_t hipsolverCgetrf(hipsolverHandle_t handle,
                                   int               m,
                                   int               n,
-                                  hipsolverComplex* A,
+                                  hipFloatComplex*  A,
                                   int               lda,
-                                  hipsolverComplex* work,
+                                  hipFloatComplex*  work,
                                   int               lwork,
                                   int*              devIpiv,
                                   int*              devInfo)
@@ -1905,15 +1905,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t       handle,
-                                  int                     m,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devIpiv,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t handle,
+                                  int               m,
+                                  int               n,
+                                  hipDoubleComplex* A,
+                                  int               lda,
+                                  hipDoubleComplex* work,
+                                  int               lwork,
+                                  int*              devIpiv,
+                                  int*              devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZgetrf((cusolverDnHandle_t)handle,
@@ -1975,10 +1975,10 @@ hipsolverStatus_t hipsolverCgetrs_bufferSize(hipsolverHandle_t    handle,
                                              hipsolverOperation_t trans,
                                              int                  n,
                                              int                  nrhs,
-                                             hipsolverComplex*    A,
+                                             hipFloatComplex*     A,
                                              int                  lda,
                                              int*                 devIpiv,
-                                             hipsolverComplex*    B,
+                                             hipFloatComplex*     B,
                                              int                  ldb,
                                              int*                 lwork)
 try
@@ -1991,16 +1991,16 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverOperation_t    trans,
-                                             int                     n,
-                                             int                     nrhs,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             int*                    devIpiv,
-                                             hipsolverDoubleComplex* B,
-                                             int                     ldb,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t    handle,
+                                             hipsolverOperation_t trans,
+                                             int                  n,
+                                             int                  nrhs,
+                                             hipDoubleComplex*    A,
+                                             int                  lda,
+                                             int*                 devIpiv,
+                                             hipDoubleComplex*    B,
+                                             int                  ldb,
+                                             int*                 lwork)
 try
 {
     *lwork = 0;
@@ -2075,12 +2075,12 @@ hipsolverStatus_t hipsolverCgetrs(hipsolverHandle_t    handle,
                                   hipsolverOperation_t trans,
                                   int                  n,
                                   int                  nrhs,
-                                  hipsolverComplex*    A,
+                                  hipFloatComplex*     A,
                                   int                  lda,
                                   int*                 devIpiv,
-                                  hipsolverComplex*    B,
+                                  hipFloatComplex*     B,
                                   int                  ldb,
-                                  hipsolverComplex*    work,
+                                  hipFloatComplex*     work,
                                   int                  lwork,
                                   int*                 devInfo)
 try
@@ -2101,18 +2101,18 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t       handle,
-                                  hipsolverOperation_t    trans,
-                                  int                     n,
-                                  int                     nrhs,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  int*                    devIpiv,
-                                  hipsolverDoubleComplex* B,
-                                  int                     ldb,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t    handle,
+                                  hipsolverOperation_t trans,
+                                  int                  n,
+                                  int                  nrhs,
+                                  hipDoubleComplex*    A,
+                                  int                  lda,
+                                  int*                 devIpiv,
+                                  hipDoubleComplex*    B,
+                                  int                  ldb,
+                                  hipDoubleComplex*    work,
+                                  int                  lwork,
+                                  int*                 devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZgetrs((cusolverDnHandle_t)handle,
@@ -2159,7 +2159,7 @@ catch(...)
 hipsolverStatus_t hipsolverCpotrf_bufferSize(hipsolverHandle_t   handle,
                                              hipsolverFillMode_t uplo,
                                              int                 n,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
                                              int*                lwork)
 try
@@ -2172,12 +2172,12 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZpotrf_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverFillMode_t     uplo,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZpotrf_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             int*                lwork)
 try
 {
     return cuda2hip_status(cusolverDnZpotrf_bufferSize(
@@ -2227,9 +2227,9 @@ catch(...)
 hipsolverStatus_t hipsolverCpotrf(hipsolverHandle_t   handle,
                                   hipsolverFillMode_t uplo,
                                   int                 n,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -2248,14 +2248,14 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZpotrf(hipsolverHandle_t       handle,
-                                  hipsolverFillMode_t     uplo,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZpotrf(hipsolverHandle_t   handle,
+                                  hipsolverFillMode_t uplo,
+                                  int                 n,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZpotrf((cusolverDnHandle_t)handle,
@@ -2310,7 +2310,7 @@ catch(...)
 hipsolverStatus_t hipsolverCpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     hipsolverFillMode_t uplo,
                                                     int                 n,
-                                                    hipsolverComplex*   A[],
+                                                    hipFloatComplex*    A[],
                                                     int                 lda,
                                                     int*                lwork,
                                                     int                 batch_count)
@@ -2324,13 +2324,13 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t       handle,
-                                                    hipsolverFillMode_t     uplo,
-                                                    int                     n,
-                                                    hipsolverDoubleComplex* A[],
-                                                    int                     lda,
-                                                    int*                    lwork,
-                                                    int                     batch_count)
+hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t   handle,
+                                                    hipsolverFillMode_t uplo,
+                                                    int                 n,
+                                                    hipDoubleComplex*   A[],
+                                                    int                 lda,
+                                                    int*                lwork,
+                                                    int                 batch_count)
 try
 {
     *lwork = 0;
@@ -2382,9 +2382,9 @@ catch(...)
 hipsolverStatus_t hipsolverCpotrfBatched(hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
-                                         hipsolverComplex*   A[],
+                                         hipFloatComplex*    A[],
                                          int                 lda,
-                                         hipsolverComplex*   work,
+                                         hipFloatComplex*    work,
                                          int                 lwork,
                                          int*                devInfo,
                                          int                 batch_count)
@@ -2403,15 +2403,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t       handle,
-                                         hipsolverFillMode_t     uplo,
-                                         int                     n,
-                                         hipsolverDoubleComplex* A[],
-                                         int                     lda,
-                                         hipsolverDoubleComplex* work,
-                                         int                     lwork,
-                                         int*                    devInfo,
-                                         int                     batch_count)
+hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t   handle,
+                                         hipsolverFillMode_t uplo,
+                                         int                 n,
+                                         hipDoubleComplex*   A[],
+                                         int                 lda,
+                                         hipDoubleComplex*   work,
+                                         int                 lwork,
+                                         int*                devInfo,
+                                         int                 batch_count)
 try
 {
     return cuda2hip_status(cusolverDnZpotrfBatched((cusolverDnHandle_t)handle,
@@ -2480,7 +2480,7 @@ hipsolverStatus_t hipsolverCheevd_bufferSize(hipsolverHandle_t   handle,
                                              hipsolverEigMode_t  jobz,
                                              hipsolverFillMode_t uplo,
                                              int                 n,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
                                              float*              D,
                                              int*                lwork)
@@ -2500,14 +2500,14 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZheevd_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverEigMode_t      jobz,
-                                             hipsolverFillMode_t     uplo,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             double*                 D,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZheevd_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverEigMode_t  jobz,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             double*             D,
+                                             int*                lwork)
 try
 {
     return cuda2hip_status(cusolverDnZheevd_bufferSize((cusolverDnHandle_t)handle,
@@ -2584,10 +2584,10 @@ hipsolverStatus_t hipsolverCheevd(hipsolverHandle_t   handle,
                                   hipsolverEigMode_t  jobz,
                                   hipsolverFillMode_t uplo,
                                   int                 n,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
                                   float*              D,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -2608,16 +2608,16 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZheevd(hipsolverHandle_t       handle,
-                                  hipsolverEigMode_t      jobz,
-                                  hipsolverFillMode_t     uplo,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  double*                 D,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZheevd(hipsolverHandle_t   handle,
+                                  hipsolverEigMode_t  jobz,
+                                  hipsolverFillMode_t uplo,
+                                  int                 n,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  double*             D,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZheevd((cusolverDnHandle_t)handle,
@@ -2702,9 +2702,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd_bufferSize(hipsolverHandle_t 
                                                               hipsolverEigMode_t  jobz,
                                                               hipsolverFillMode_t uplo,
                                                               int                 n,
-                                                              hipsolverComplex*   A,
+                                                              hipFloatComplex*    A,
                                                               int                 lda,
-                                                              hipsolverComplex*   B,
+                                                              hipFloatComplex*    B,
                                                               int                 ldb,
                                                               float*              D,
                                                               int*                lwork)
@@ -2727,17 +2727,17 @@ catch(...)
     return exception2hip_status();
 }
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSize(hipsolverHandle_t       handle,
-                                                              hipsolverEigType_t      itype,
-                                                              hipsolverEigMode_t      jobz,
-                                                              hipsolverFillMode_t     uplo,
-                                                              int                     n,
-                                                              hipsolverDoubleComplex* A,
-                                                              int                     lda,
-                                                              hipsolverDoubleComplex* B,
-                                                              int                     ldb,
-                                                              double*                 D,
-                                                              int*                    lwork)
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSize(hipsolverHandle_t   handle,
+                                                              hipsolverEigType_t  itype,
+                                                              hipsolverEigMode_t  jobz,
+                                                              hipsolverFillMode_t uplo,
+                                                              int                 n,
+                                                              hipDoubleComplex*   A,
+                                                              int                 lda,
+                                                              hipDoubleComplex*   B,
+                                                              int                 ldb,
+                                                              double*             D,
+                                                              int*                lwork)
 try
 {
     return cuda2hip_status(cusolverDnZhegvd_bufferSize((cusolverDnHandle_t)handle,
@@ -2830,12 +2830,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd(hipsolverHandle_t   handle,
                                                    hipsolverEigMode_t  jobz,
                                                    hipsolverFillMode_t uplo,
                                                    int                 n,
-                                                   hipsolverComplex*   A,
+                                                   hipFloatComplex*    A,
                                                    int                 lda,
-                                                   hipsolverComplex*   B,
+                                                   hipFloatComplex*    B,
                                                    int                 ldb,
                                                    float*              D,
-                                                   hipsolverComplex*   work,
+                                                   hipFloatComplex*    work,
                                                    int                 lwork,
                                                    int*                devInfo)
 try
@@ -2859,19 +2859,19 @@ catch(...)
     return exception2hip_status();
 }
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd(hipsolverHandle_t       handle,
-                                                   hipsolverEigType_t      itype,
-                                                   hipsolverEigMode_t      jobz,
-                                                   hipsolverFillMode_t     uplo,
-                                                   int                     n,
-                                                   hipsolverDoubleComplex* A,
-                                                   int                     lda,
-                                                   hipsolverDoubleComplex* B,
-                                                   int                     ldb,
-                                                   double*                 D,
-                                                   hipsolverDoubleComplex* work,
-                                                   int                     lwork,
-                                                   int*                    devInfo)
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd(hipsolverHandle_t   handle,
+                                                   hipsolverEigType_t  itype,
+                                                   hipsolverEigMode_t  jobz,
+                                                   hipsolverFillMode_t uplo,
+                                                   int                 n,
+                                                   hipDoubleComplex*   A,
+                                                   int                 lda,
+                                                   hipDoubleComplex*   B,
+                                                   int                 ldb,
+                                                   double*             D,
+                                                   hipDoubleComplex*   work,
+                                                   int                 lwork,
+                                                   int*                devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZhegvd((cusolverDnHandle_t)handle,
@@ -2935,11 +2935,11 @@ catch(...)
 hipsolverStatus_t hipsolverChetrd_bufferSize(hipsolverHandle_t   handle,
                                              hipsolverFillMode_t uplo,
                                              int                 n,
-                                             hipsolverComplex*   A,
+                                             hipFloatComplex*    A,
                                              int                 lda,
                                              float*              D,
                                              float*              E,
-                                             hipsolverComplex*   tau,
+                                             hipFloatComplex*    tau,
                                              int*                lwork)
 try
 {
@@ -2958,15 +2958,15 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZhetrd_bufferSize(hipsolverHandle_t       handle,
-                                             hipsolverFillMode_t     uplo,
-                                             int                     n,
-                                             hipsolverDoubleComplex* A,
-                                             int                     lda,
-                                             double*                 D,
-                                             double*                 E,
-                                             hipsolverDoubleComplex* tau,
-                                             int*                    lwork)
+hipsolverStatus_t hipsolverZhetrd_bufferSize(hipsolverHandle_t   handle,
+                                             hipsolverFillMode_t uplo,
+                                             int                 n,
+                                             hipDoubleComplex*   A,
+                                             int                 lda,
+                                             double*             D,
+                                             double*             E,
+                                             hipDoubleComplex*   tau,
+                                             int*                lwork)
 try
 {
     return cuda2hip_status(cusolverDnZhetrd_bufferSize((cusolverDnHandle_t)handle,
@@ -3047,12 +3047,12 @@ catch(...)
 hipsolverStatus_t hipsolverChetrd(hipsolverHandle_t   handle,
                                   hipsolverFillMode_t uplo,
                                   int                 n,
-                                  hipsolverComplex*   A,
+                                  hipFloatComplex*    A,
                                   int                 lda,
                                   float*              D,
                                   float*              E,
-                                  hipsolverComplex*   tau,
-                                  hipsolverComplex*   work,
+                                  hipFloatComplex*    tau,
+                                  hipFloatComplex*    work,
                                   int                 lwork,
                                   int*                devInfo)
 try
@@ -3074,17 +3074,17 @@ catch(...)
     return exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverZhetrd(hipsolverHandle_t       handle,
-                                  hipsolverFillMode_t     uplo,
-                                  int                     n,
-                                  hipsolverDoubleComplex* A,
-                                  int                     lda,
-                                  double*                 D,
-                                  double*                 E,
-                                  hipsolverDoubleComplex* tau,
-                                  hipsolverDoubleComplex* work,
-                                  int                     lwork,
-                                  int*                    devInfo)
+hipsolverStatus_t hipsolverZhetrd(hipsolverHandle_t   handle,
+                                  hipsolverFillMode_t uplo,
+                                  int                 n,
+                                  hipDoubleComplex*   A,
+                                  int                 lda,
+                                  double*             D,
+                                  double*             E,
+                                  hipDoubleComplex*   tau,
+                                  hipDoubleComplex*   work,
+                                  int                 lwork,
+                                  int*                devInfo)
 try
 {
     return cuda2hip_status(cusolverDnZhetrd((cusolverDnHandle_t)handle,


### PR DESCRIPTION
Replaces `hipsolverComplex` with `hipFloatComplex` and `hipsolverDoubleComplex` with `hipDoubleComplex` in the library. I was not able to replace these in the client code, so `hipsolverComplex` and `hipsolverDoubleComplex` have been moved to `complex.hpp`. `hipsolver.hpp` now casts pointers of the original complex types to pointers of the hip complex types.