### PR TITLE
Initial Windows 10 Support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# By default, convert all text files to Unix line endings on check-in
+# and native line endings on check-out
+*          text=auto
+
+# Override the default behavior for specific files
+*.sh       text eol=lf
+*.bat      text eol=crlf
+
+# Reduce merge conflicts in changelog
+/CHANGELOG.md merge=union

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,10 @@ if ( NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC} )
   set( CMAKE_Fortran_COMPILER  "gfortran" )
 endif()
 
-project( hipsolver LANGUAGES CXX Fortran )
+project( hipsolver LANGUAGES CXX )
+if( UNIX )
+  enable_language( Fortran )
+endif( )
 
 # This finds the rocm-cmake project, and installs it if not found
 # rocm-cmake contains common cmake code for rocm projects to help setup and install
@@ -94,7 +97,7 @@ endif()
 if( USE_CUDA)
     find_package( HIP MODULE REQUIRED )
 else( )
-    find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
+    find_package( hip REQUIRED PATHS ${HIP_PATH} ${ROCM_PATH} /opt/rocm )
 endif( )
 
 if( USE_CUDA )
@@ -106,6 +109,14 @@ option(BUILD_CODE_COVERAGE "Build hipSOLVER with code coverage enabled" OFF)
 if(BUILD_CODE_COVERAGE)
   add_compile_options(-fprofile-arcs -ftest-coverage)
   add_link_options(--coverage)
+endif()
+
+if( WIN32 )
+  add_compile_definitions(
+    WIN32_LEAN_AND_MEAN
+    _CRT_SECURE_NO_WARNINGS
+    NOMINMAX
+  )
 endif()
 
 add_subdirectory( library )

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -1,9 +1,6 @@
 # ########################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc.
+# Copyright 2016-2021 Advanced Micro Devices, Inc.
 # ########################################################################
-
-# The ROCm platform requires Ubuntu 16.04 or Fedora 24, which has cmake 3.5
-cmake_minimum_required( VERSION 3.5 )
 
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
@@ -20,7 +17,10 @@ if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
 endif()
 
 # This project may compile dependencies for clients
-project( hipsolver-clients LANGUAGES CXX Fortran )
+project( hipsolver-clients LANGUAGES CXX )
+if( UNIX )
+  enable_language( Fortran )
+endif( )
 
 # We use C++14 features, this will add compile option: -std=c++14
 set( CMAKE_CXX_STANDARD 14 )
@@ -29,14 +29,18 @@ list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 
 include( build-options )
 
-set(hipsolver_f90_source_clients
-  include/hipsolver_fortran.f90
-)
+if( UNIX )
+  set(hipsolver_f90_source_clients
+    include/hipsolver_fortran.f90
+  )
+endif( )
 
 if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_SAMPLES )
-  add_library(hipsolver_fortran_client ${hipsolver_f90_source_clients})
-  add_dependencies(hipsolver_fortran_client hipsolver_fortran)
-  include_directories(${CMAKE_BINARY_DIR}/include)
+  if( UNIX )
+    add_library(hipsolver_fortran_client ${hipsolver_f90_source_clients})
+    add_dependencies(hipsolver_fortran_client hipsolver_fortran)
+    include_directories(${CMAKE_BINARY_DIR}/include)
+  endif( )
 endif( )
 
 if( BUILD_CLIENTS_TESTS )

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -6,18 +6,10 @@ set( THREADS_PREFER_PTHREAD_FLAG ON )
 find_package( Threads REQUIRED )
 
 # Linking lapack library requires fortran flags
-enable_language( Fortran )
-find_package( cblas CONFIG REQUIRED )
-if( NOT cblas_FOUND )
-  message( FATAL_ERROR "cblas is a required dependency and is not found;  try adding cblas path to CMAKE_PREFIX_PATH" )
-endif( )
+find_package( cblas REQUIRED CONFIG )
 
 if( NOT TARGET hipsolver )
-  find_package( hipsolver CONFIG PATHS /opt/rocm/hipsolver )
-
-  if( NOT hipsolver_FOUND )
-    message( FATAL_ERROR "hipSOLVER is a required dependency and is not found; try adding hipsolver path to CMAKE_PREFIX_PATH")
-  endif( )
+  find_package( hipsolver REQUIRED CONFIG PATHS /opt/rocm/hipsolver )
 endif( )
 
 set(hipsolver_benchmark_common
@@ -27,9 +19,6 @@ set(hipsolver_benchmark_common
 )
 
 add_executable( hipsolver-bench client.cpp ${hipsolver_benchmark_common} )
-
-
-target_compile_features( hipsolver-bench PRIVATE cxx_static_assert cxx_nullptr cxx_auto_type )
 
 # Internal header includes
 target_include_directories( hipsolver-bench
@@ -44,7 +33,10 @@ target_include_directories( hipsolver-bench
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
 )
 
-target_link_libraries( hipsolver-bench PRIVATE hipsolver_fortran_client roc::hipsolver cblas lapack)
+target_link_libraries( hipsolver-bench PRIVATE cblas lapack blas roc::hipsolver )
+if( UNIX )
+  target_link_libraries( hipsolver-bench PRIVATE hipsolver_fortran_client )
+endif( )
 
 add_armor_flags( hipsolver-bench "${ARMOR_LEVEL}" )
 
@@ -58,7 +50,7 @@ if( NOT USE_CUDA )
     target_link_libraries( hipsolver-bench PRIVATE hip::${CUSTOM_TARGET} )
   endif( )
 
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
+  if( UNIX AND CMAKE_CXX_COMPILER MATCHES ".*/hcc$|.*/hipcc$" )
     # hip-clang needs specific flag to turn on pthread and m
     target_link_libraries( hipsolver-bench PRIVATE -lpthread -lm )
   endif()

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -4,8 +4,8 @@
 
 #include <chrono>
 
-#include "utility.hpp"
 #include "hipsolver.h"
+#include "utility.hpp"
 
 hipsolver_rng_t hipsolver_rng(69069);
 hipsolver_rng_t hipsolver_seed(hipsolver_rng);
@@ -69,7 +69,7 @@ extern "C" {
  */
 double get_time_us_no_sync()
 {
-    namespace sc = std::chrono;
+    namespace sc                         = std::chrono;
     const sc::steady_clock::time_point t = sc::steady_clock::now();
     return double(sc::duration_cast<sc::microseconds>(t.time_since_epoch()).count());
 }

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -2,9 +2,10 @@
  * Copyright 2020-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
+#include <chrono>
+
 #include "utility.hpp"
 #include "hipsolver.h"
-#include <sys/time.h>
 
 hipsolver_rng_t hipsolver_rng(69069);
 hipsolver_rng_t hipsolver_seed(hipsolver_rng);
@@ -57,25 +58,6 @@ int type2int<hipsolverDoubleComplex>(hipsolverDoubleComplex val)
     return (int)val.real();
 }
 
-/* ============================================================================================ */
-// Return path of this executable
-std::string hipsolver_exepath()
-{
-    std::string pathstr;
-    char*       path = realpath("/proc/self/exe", 0);
-    if(path)
-    {
-        char* p = strrchr(path, '/');
-        if(p)
-        {
-            p[1]    = 0;
-            pathstr = path;
-        }
-        free(path);
-    }
-    return pathstr;
-}
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -83,32 +65,29 @@ extern "C" {
 /* ============================================================================================ */
 /*  timing:*/
 
-/*! \brief  CPU Timer(in microsecond): synchronize with the default device and
- * return wall time */
+/* CPU Timer (in microseconds): no GPU synchronization
+ */
+double get_time_us_no_sync()
+{
+    namespace sc = std::chrono;
+    const sc::steady_clock::time_point t = sc::steady_clock::now();
+    return double(sc::duration_cast<sc::microseconds>(t.time_since_epoch()).count());
+}
+
+/* CPU Timer (in microseconds): synchronize with the default device and return wall time
+ */
 double get_time_us()
 {
     hipDeviceSynchronize();
-    struct timespec tv;
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-    return tv.tv_sec * 1'000'000llu + (tv.tv_nsec + 500llu) / 1000;
+    return get_time_us_no_sync();
 }
 
-/*! \brief  CPU Timer(in microsecond): synchronize with given queue/stream and
- * return wall time */
+/* CPU Timer (in microseconds): synchronize with given queue/stream and return wall time
+ */
 double get_time_us_sync(hipStream_t stream)
 {
     hipStreamSynchronize(stream);
-    struct timespec tv;
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-    return tv.tv_sec * 1'000'000llu + (tv.tv_nsec + 500llu) / 1000;
-}
-
-/*! \brief  CPU Timer(in microsecond): no GPU synchronization */
-double get_time_us_no_sync()
-{
-    struct timespec tv;
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-    return tv.tv_sec * 1'000'000llu + (tv.tv_nsec + 500llu) / 1000;
+    return get_time_us_no_sync();
 }
 
 /* ============================================================================================ */

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -3,22 +3,13 @@
 # ########################################################################
 
 # Linking lapack library requires fortran flags
-enable_language( Fortran )
-find_package( cblas CONFIG REQUIRED )
-if( NOT cblas_FOUND )
-  message( FATAL_ERROR "cblas is a required dependency and is not found;  try adding cblas path to CMAKE_PREFIX_PATH" )
-endif( )
+find_package( cblas REQUIRED CONFIG )
 
 if( NOT TARGET hipsolver )
-  find_package( hipsolver CONFIG PATHS /opt/rocm/hipsolver )
-
-  if( NOT hipsolver_FOUND )
-    message( FATAL_ERROR "hipSOLVER is a required dependency and is not found; try adding hipsolver path to CMAKE_PREFIX_PATH")
-  endif( )
+  find_package( hipsolver REQUIRED CONFIG PATHS /opt/rocm/hipsolver )
 endif( )
 
 find_package( GTest REQUIRED )
-include_directories(${GTEST_INCLUDE_DIRS})
 
 set(hipsolver_test_source
   hipsolver_gtest_main.cpp
@@ -47,7 +38,10 @@ set( hipsolver_test_common
   ../common/utility.cpp
 )
 
-add_executable( hipsolver-test ${hipsolver_f90_source} ${hipsolver_test_source} ${hipsolver_test_common} )
+add_executable( hipsolver-test ${hipsolver_test_source} ${hipsolver_test_common} )
+if( UNIX )
+  target_sources( hipsolver-test PRIVATE ${hipsolver_f90_source} )
+endif( )
 
 target_include_directories( hipsolver-test
   PRIVATE
@@ -56,7 +50,6 @@ target_include_directories( hipsolver-test
 
 set( THREADS_PREFER_PTHREAD_FLAG ON )
 find_package( Threads REQUIRED )
-target_link_libraries( hipsolver-test PRIVATE Threads::Threads )
 
 add_armor_flags( hipsolver-test "${ARMOR_LEVEL}" )
 
@@ -66,12 +59,14 @@ target_compile_definitions( hipsolver-test PRIVATE GOOGLE_TEST )
 target_include_directories( hipsolver-test
   SYSTEM PRIVATE
     $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
-    $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
     ${ROCM_PATH}/hsa/include
 )
 
-target_link_libraries( hipsolver-test PRIVATE roc::hipsolver cblas lapack ${GTEST_LIBRARIES} ${Boost_LIBRARIES} hipsolver_fortran_client )
+target_link_libraries( hipsolver-test PRIVATE cblas lapack blas GTest::GTest Threads::Threads roc::hipsolver )
+if( UNIX )
+  target_link_libraries( hipsolver-test PRIVATE hipsolver_fortran_client )
+endif( )
 
 # need mf16c flag for float->half convertion
 target_compile_options( hipsolver-test PRIVATE -mf16c )
@@ -100,3 +95,29 @@ endif( )
 
 set_target_properties( hipsolver-test PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO )
 set_target_properties( hipsolver-test PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
+
+if(WIN32)
+  file(GLOB third_party_dlls
+    LIST_DIRECTORIES OFF
+    CONFIGURE_DEPENDS
+    ${cblas_DIR}/bin/*.dll
+    ${GTest_DIR}/bin/*.dll
+    $ENV{rocblas_DIR}/bin/*.dll
+	$ENV{rocsolver_DIR}/bin/*.dll
+    $ENV{HIP_DIR}/bin/*.dll
+    $ENV{HIP_DIR}/bin/hipinfo.exe
+    ${CMAKE_SOURCE_DIR}/rtest.*
+  )
+  foreach(file_i ${third_party_dlls})
+    add_custom_command(TARGET hipsolver-test
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND}
+      ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/staging/
+    )
+  endforeach()
+  add_custom_command(TARGET hipsolver-test
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND}
+    ARGS -E copy_directory $ENV{rocblas_DIR}/bin/library ${PROJECT_BINARY_DIR}/staging/library
+  )
+endif()

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -103,7 +103,7 @@ if(WIN32)
     ${cblas_DIR}/bin/*.dll
     ${GTest_DIR}/bin/*.dll
     $ENV{rocblas_DIR}/bin/*.dll
-	$ENV{rocsolver_DIR}/bin/*.dll
+    $ENV{rocsolver_DIR}/bin/*.dll
     $ENV{HIP_DIR}/bin/*.dll
     $ENV{HIP_DIR}/bin/hipinfo.exe
     ${CMAKE_SOURCE_DIR}/rtest.*

--- a/clients/include/hipsolver.hpp
+++ b/clients/include/hipsolver.hpp
@@ -5,7 +5,11 @@
 #pragma once
 
 #include "hipsolver.h"
+#ifdef _WIN32
+#include "hipsolver_no_fortran.hpp"
+#else
 #include "hipsolver_fortran.hpp"
+#endif
 
 // Most functions within this file exist to provide a consistent interface for our templated tests.
 // Function overloading is used to select between the float, double, rocblas_float_complex

--- a/clients/include/hipsolver_no_fortran.hpp
+++ b/clients/include/hipsolver_no_fortran.hpp
@@ -73,6 +73,15 @@
 #define hipsolverDgeqrfFortran hipsolverDgeqrf
 #define hipsolverCgeqrfFortran hipsolverCgeqrf
 #define hipsolverZgeqrfFortran hipsolverZgeqrf
+// gesv
+#define hipsolverSSgesv_bufferSizeFortran hipsolverSSgesv_bufferSize
+#define hipsolverDDgesv_bufferSizeFortran hipsolverDDgesv_bufferSize
+#define hipsolverCCgesv_bufferSizeFortran hipsolverCCgesv_bufferSize
+#define hipsolverZZgesv_bufferSizeFortran hipsolverZZgesv_bufferSize
+#define hipsolverSSgesvFortran hipsolverSSgesv
+#define hipsolverDDgesvFortran hipsolverDDgesv
+#define hipsolverCCgesvFortran hipsolverCCgesv
+#define hipsolverZZgesvFortran hipsolverZZgesv
 // gesvd
 #define hipsolverSgesvd_bufferSizeFortran hipsolverSgesvd_bufferSize
 #define hipsolverDgesvd_bufferSizeFortran hipsolverDgesvd_bufferSize

--- a/clients/include/hipsolver_no_fortran.hpp
+++ b/clients/include/hipsolver_no_fortran.hpp
@@ -1,0 +1,174 @@
+/* ************************************************************************
+ * Copyright 2020-2021 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+#pragma once
+/*
+ * ============================================================================
+ *     Redirect Fortran API to C API
+ * ============================================================================
+ */
+/* ==========
+ *   LAPACK
+ * ========== */
+// orgbr/ungbr
+#define hipsolverSorgbr_bufferSizeFortran hipsolverSorgbr_bufferSize
+#define hipsolverDorgbr_bufferSizeFortran hipsolverDorgbr_bufferSize
+#define hipsolverCungbr_bufferSizeFortran hipsolverCungbr_bufferSize
+#define hipsolverZungbr_bufferSizeFortran hipsolverZungbr_bufferSize
+#define hipsolverSorgbrFortran hipsolverSorgbr
+#define hipsolverDorgbrFortran hipsolverDorgbr
+#define hipsolverCungbrFortran hipsolverCungbr
+#define hipsolverZungbrFortran hipsolverZungbr
+// orgqr/ungqr
+#define hipsolverSorgqr_bufferSizeFortran hipsolverSorgqr_bufferSize
+#define hipsolverDorgqr_bufferSizeFortran hipsolverDorgqr_bufferSize
+#define hipsolverCungqr_bufferSizeFortran hipsolverCungqr_bufferSize
+#define hipsolverZungqr_bufferSizeFortran hipsolverZungqr_bufferSize
+#define hipsolverSorgqrFortran hipsolverSorgqr
+#define hipsolverDorgqrFortran hipsolverDorgqr
+#define hipsolverCungqrFortran hipsolverCungqr
+#define hipsolverZungqrFortran hipsolverZungqr
+// orgtr/ungtr
+#define hipsolverSorgtr_bufferSizeFortran hipsolverSorgtr_bufferSize
+#define hipsolverDorgtr_bufferSizeFortran hipsolverDorgtr_bufferSize
+#define hipsolverCungtr_bufferSizeFortran hipsolverCungtr_bufferSize
+#define hipsolverZungtr_bufferSizeFortran hipsolverZungtr_bufferSize
+#define hipsolverSorgtrFortran hipsolverSorgtr
+#define hipsolverDorgtrFortran hipsolverDorgtr
+#define hipsolverCungtrFortran hipsolverCungtr
+#define hipsolverZungtrFortran hipsolverZungtr
+// ormqr/unmqr
+#define hipsolverSormqr_bufferSizeFortran hipsolverSormqr_bufferSize
+#define hipsolverDormqr_bufferSizeFortran hipsolverDormqr_bufferSize
+#define hipsolverCunmqr_bufferSizeFortran hipsolverCunmqr_bufferSize
+#define hipsolverZunmqr_bufferSizeFortran hipsolverZunmqr_bufferSize
+#define hipsolverSormqrFortran hipsolverSormqr
+#define hipsolverDormqrFortran hipsolverDormqr
+#define hipsolverCunmqrFortran hipsolverCunmqr
+#define hipsolverZunmqrFortran hipsolverZunmqr
+// ormtr/unmtr
+#define hipsolverSormtr_bufferSizeFortran hipsolverSormtr_bufferSize
+#define hipsolverDormtr_bufferSizeFortran hipsolverDormtr_bufferSize
+#define hipsolverCunmtr_bufferSizeFortran hipsolverCunmtr_bufferSize
+#define hipsolverZunmtr_bufferSizeFortran hipsolverZunmtr_bufferSize
+#define hipsolverSormtrFortran hipsolverSormtr
+#define hipsolverDormtrFortran hipsolverDormtr
+#define hipsolverCunmtrFortran hipsolverCunmtr
+#define hipsolverZunmtrFortran hipsolverZunmtr
+// gebrd
+#define hipsolverSgebrd_bufferSizeFortran hipsolverSgebrd_bufferSize
+#define hipsolverDgebrd_bufferSizeFortran hipsolverDgebrd_bufferSize
+#define hipsolverCgebrd_bufferSizeFortran hipsolverCgebrd_bufferSize
+#define hipsolverZgebrd_bufferSizeFortran hipsolverZgebrd_bufferSize
+#define hipsolverSgebrdFortran hipsolverSgebrd
+#define hipsolverDgebrdFortran hipsolverDgebrd
+#define hipsolverCgebrdFortran hipsolverCgebrd
+#define hipsolverZgebrdFortran hipsolverZgebrd
+// geqrf
+#define hipsolverSgeqrf_bufferSizeFortran hipsolverSgeqrf_bufferSize
+#define hipsolverDgeqrf_bufferSizeFortran hipsolverDgeqrf_bufferSize
+#define hipsolverCgeqrf_bufferSizeFortran hipsolverCgeqrf_bufferSize
+#define hipsolverZgeqrf_bufferSizeFortran hipsolverZgeqrf_bufferSize
+#define hipsolverSgeqrfFortran hipsolverSgeqrf
+#define hipsolverDgeqrfFortran hipsolverDgeqrf
+#define hipsolverCgeqrfFortran hipsolverCgeqrf
+#define hipsolverZgeqrfFortran hipsolverZgeqrf
+// gesvd
+#define hipsolverSgesvd_bufferSizeFortran hipsolverSgesvd_bufferSize
+#define hipsolverDgesvd_bufferSizeFortran hipsolverDgesvd_bufferSize
+#define hipsolverCgesvd_bufferSizeFortran hipsolverCgesvd_bufferSize
+#define hipsolverZgesvd_bufferSizeFortran hipsolverZgesvd_bufferSize
+#define hipsolverSgesvdFortran hipsolverSgesvd
+#define hipsolverDgesvdFortran hipsolverDgesvd
+#define hipsolverCgesvdFortran hipsolverCgesvd
+#define hipsolverZgesvdFortran hipsolverZgesvd
+// getrf
+#define hipsolverSgetrf_bufferSizeFortran hipsolverSgetrf_bufferSize
+#define hipsolverDgetrf_bufferSizeFortran hipsolverDgetrf_bufferSize
+#define hipsolverCgetrf_bufferSizeFortran hipsolverCgetrf_bufferSize
+#define hipsolverZgetrf_bufferSizeFortran hipsolverZgetrf_bufferSize
+#define hipsolverSgetrfFortran hipsolverSgetrf
+#define hipsolverDgetrfFortran hipsolverDgetrf
+#define hipsolverCgetrfFortran hipsolverCgetrf
+#define hipsolverZgetrfFortran hipsolverZgetrf
+// getrs
+#define hipsolverSgetrs_bufferSizeFortran hipsolverSgetrs_bufferSize
+#define hipsolverDgetrs_bufferSizeFortran hipsolverDgetrs_bufferSize
+#define hipsolverCgetrs_bufferSizeFortran hipsolverCgetrs_bufferSize
+#define hipsolverZgetrs_bufferSizeFortran hipsolverZgetrs_bufferSize
+#define hipsolverSgetrsFortran hipsolverSgetrs
+#define hipsolverDgetrsFortran hipsolverDgetrs
+#define hipsolverCgetrsFortran hipsolverCgetrs
+#define hipsolverZgetrsFortran hipsolverZgetrs
+// potrf
+#define hipsolverSpotrf_bufferSizeFortran hipsolverSpotrf_bufferSize
+#define hipsolverDpotrf_bufferSizeFortran hipsolverDpotrf_bufferSize
+#define hipsolverCpotrf_bufferSizeFortran hipsolverCpotrf_bufferSize
+#define hipsolverZpotrf_bufferSizeFortran hipsolverZpotrf_bufferSize
+#define hipsolverSpotrfFortran hipsolverSpotrf
+#define hipsolverDpotrfFortran hipsolverDpotrf
+#define hipsolverCpotrfFortran hipsolverCpotrf
+#define hipsolverZpotrfFortran hipsolverZpotrf
+// potrf_batched
+#define hipsolverSpotrfBatched_bufferSizeFortran hipsolverSpotrfBatched_bufferSize
+#define hipsolverDpotrfBatched_bufferSizeFortran hipsolverDpotrfBatched_bufferSize
+#define hipsolverCpotrfBatched_bufferSizeFortran hipsolverCpotrfBatched_bufferSize
+#define hipsolverZpotrfBatched_bufferSizeFortran hipsolverZpotrfBatched_bufferSize
+#define hipsolverSpotrfBatchedFortran hipsolverSpotrfBatched
+#define hipsolverDpotrfBatchedFortran hipsolverDpotrfBatched
+#define hipsolverCpotrfBatchedFortran hipsolverCpotrfBatched
+#define hipsolverZpotrfBatchedFortran hipsolverZpotrfBatched
+// potri
+#define hipsolverSpotri_bufferSizeFortran hipsolverSpotri_bufferSize
+#define hipsolverDpotri_bufferSizeFortran hipsolverDpotri_bufferSize
+#define hipsolverCpotri_bufferSizeFortran hipsolverCpotri_bufferSize
+#define hipsolverZpotri_bufferSizeFortran hipsolverZpotri_bufferSize
+#define hipsolverSpotriFortran hipsolverSpotri
+#define hipsolverDpotriFortran hipsolverDpotri
+#define hipsolverCpotriFortran hipsolverCpotri
+#define hipsolverZpotriFortran hipsolverZpotri
+// potrs
+#define hipsolverSpotrs_bufferSizeFortran hipsolverSpotrs_bufferSize
+#define hipsolverDpotrs_bufferSizeFortran hipsolverDpotrs_bufferSize
+#define hipsolverCpotrs_bufferSizeFortran hipsolverCpotrs_bufferSize
+#define hipsolverZpotrs_bufferSizeFortran hipsolverZpotrs_bufferSize
+#define hipsolverSpotrsFortran hipsolverSpotrs
+#define hipsolverDpotrsFortran hipsolverDpotrs
+#define hipsolverCpotrsFortran hipsolverCpotrs
+#define hipsolverZpotrsFortran hipsolverZpotrs
+// potrs_batched
+#define hipsolverSpotrsBatched_bufferSizeFortran hipsolverSpotrsBatched_bufferSize
+#define hipsolverDpotrsBatched_bufferSizeFortran hipsolverDpotrsBatched_bufferSize
+#define hipsolverCpotrsBatched_bufferSizeFortran hipsolverCpotrsBatched_bufferSize
+#define hipsolverZpotrsBatched_bufferSizeFortran hipsolverZpotrsBatched_bufferSize
+#define hipsolverSpotrsBatchedFortran hipsolverSpotrsBatched
+#define hipsolverDpotrsBatchedFortran hipsolverDpotrsBatched
+#define hipsolverCpotrsBatchedFortran hipsolverCpotrsBatched
+#define hipsolverZpotrsBatchedFortran hipsolverZpotrsBatched
+// syevd/heevd
+#define hipsolverSsyevd_bufferSizeFortran hipsolverSsyevd_bufferSize
+#define hipsolverDsyevd_bufferSizeFortran hipsolverDsyevd_bufferSize
+#define hipsolverCheevd_bufferSizeFortran hipsolverCheevd_bufferSize
+#define hipsolverZheevd_bufferSizeFortran hipsolverZheevd_bufferSize
+#define hipsolverSsyevdFortran hipsolverSsyevd
+#define hipsolverDsyevdFortran hipsolverDsyevd
+#define hipsolverCheevdFortran hipsolverCheevd
+#define hipsolverZheevdFortran hipsolverZheevd
+// sygvd/hegvd
+#define hipsolverSsygvd_bufferSizeFortran hipsolverSsygvd_bufferSize
+#define hipsolverDsygvd_bufferSizeFortran hipsolverDsygvd_bufferSize
+#define hipsolverChegvd_bufferSizeFortran hipsolverChegvd_bufferSize
+#define hipsolverZhegvd_bufferSizeFortran hipsolverZhegvd_bufferSize
+#define hipsolverSsygvdFortran hipsolverSsygvd
+#define hipsolverDsygvdFortran hipsolverDsygvd
+#define hipsolverChegvdFortran hipsolverChegvd
+#define hipsolverZhegvdFortran hipsolverZhegvd
+// sytrd/hetrd
+#define hipsolverSsytrd_bufferSizeFortran hipsolverSsytrd_bufferSize
+#define hipsolverDsytrd_bufferSizeFortran hipsolverDsytrd_bufferSize
+#define hipsolverChetrd_bufferSizeFortran hipsolverChetrd_bufferSize
+#define hipsolverZhetrd_bufferSizeFortran hipsolverZhetrd_bufferSize
+#define hipsolverSsytrdFortran hipsolverSsytrd
+#define hipsolverDsytrdFortran hipsolverDsytrd
+#define hipsolverChetrdFortran hipsolverChetrd
+#define hipsolverZhetrdFortran hipsolverZhetrd

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -18,7 +18,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/time.h>
 
 /*!\file
  * \brief provide data initialization, timing, hipsolver type <-> lapack char conversion utilities.
@@ -352,8 +351,6 @@ void print_matrix(T* CPU_result, T* GPU_result, int m, int n, int lda)
 /* =============================================================================================== */
 
 /* ============================================================================================ */
-// Return path of this executable
-std::string hipsolver_exepath();
 
 #endif // __cplusplus
 

--- a/clients/rocblascommon/device_batch_vector.hpp
+++ b/clients/rocblascommon/device_batch_vector.hpp
@@ -165,6 +165,7 @@ public:
         return this->m_data[batch_index];
     }
 
+    // clang-format off
     //!
     //! @brief Const cast of the data on host.
     //!
@@ -173,7 +174,6 @@ public:
         return this->m_data;
     }
 
-    // clang-format off
     //!
     //! @brief Cast of the data on host.
     //!

--- a/clients/rocblascommon/device_batch_vector.hpp
+++ b/clients/rocblascommon/device_batch_vector.hpp
@@ -168,7 +168,7 @@ public:
     //!
     //! @brief Const cast of the data on host.
     //!
-    operator const T* const *() const
+    operator const T* const*() const
     {
         return this->m_data;
     }

--- a/clients/rocblascommon/host_batch_vector.hpp
+++ b/clients/rocblascommon/host_batch_vector.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2018-2020 Advanced Micro Devices, Inc.
+ * Copyright 2018-2021 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 #pragma once
 
@@ -134,7 +134,7 @@ public:
     //!
     //! @brief Constant cast to a double pointer.
     //!
-    operator const T* const *()
+    operator const T* const*()
     {
         return this->m_data;
     }

--- a/clients/rocblascommon/host_batch_vector.hpp
+++ b/clients/rocblascommon/host_batch_vector.hpp
@@ -129,7 +129,6 @@ public:
     {
         return this->m_data;
     }
-    // clang-format on
 
     //!
     //! @brief Constant cast to a double pointer.
@@ -138,6 +137,7 @@ public:
     {
         return this->m_data;
     }
+    // clang-format on
 
     //!
     //! @brief Copy from a host batched vector.

--- a/clients/rocblascommon/program_options.hpp
+++ b/clients/rocblascommon/program_options.hpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <map>
 #include <ostream>
+#include <sstream>
 #include <regex>
 #include <stdexcept>
 #include <string>

--- a/clients/rocblascommon/program_options.hpp
+++ b/clients/rocblascommon/program_options.hpp
@@ -10,8 +10,8 @@
 #include <iomanip>
 #include <map>
 #include <ostream>
-#include <sstream>
 #include <regex>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/clients/rocsolvercommon/norm.hpp
+++ b/clients/rocsolvercommon/norm.hpp
@@ -6,7 +6,7 @@
 
 // #include "clientcommon.hpp"
 // #include "rocblas.h"
-#include "../include/complex.h"
+#include "../include/complex.hpp"
 #include "hipsolver.h"
 
 using rocblas_float_complex  = hipsolverComplex;

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -9,8 +9,8 @@ add_executable( example-cpp-basic example_basic.cpp )
 set_source_files_properties(example_basic.c PROPERTIES LANGUAGE CXX)
 set_source_files_properties(example_basic.c PROPERTIES COMPILE_FLAGS "-xc -std=c99")
 
-# We test for C++11 compatibility in one of the samples
-set_source_files_properties(example_basic.cpp PROPERTIES COMPILE_FLAGS "-std=c++11")
+# Test for C++11 compatibility in one of the samples
+set_property(TARGET example-cpp-basic PROPERTY CXX_STANDARD 11)
 
 if( NOT TARGET hipsolver )
   find_package( hipsolver CONFIG PATHS ${ROCM_PATH}/hipsolver )

--- a/cmake/armor-config.cmake
+++ b/cmake/armor-config.cmake
@@ -9,7 +9,7 @@
 #           with optimizations enabled. e.g. -Og
 # 2 - Expensive correctness checks (debug iterators)
 macro( add_armor_flags target level )
-  if( "${level}" GREATER "0" )
+  if( UNIX AND "${level}" GREATER "0" )
     if( "${level}" GREATER "1" )
       # Building with std debug iterators is enabled by the defines below, but
       # requires building C++ dependencies with the same defines.

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -27,7 +27,11 @@ if( BUILD_VERBOSE )
   message( STATUS "\t==>CMAKE_EXE_LINKER link flags: " ${CMAKE_EXE_LINKER_FLAGS} )
 endif( )
 
-find_package( HIP REQUIRED )
+if( NOT USE_CUDA )
+  find_package( hip REQUIRED PATHS ${HIP_PATH} )
+else()
+  find_package( HIP REQUIRED )
+endif()
 
 # configure a header file to pass the CMake version settings to the source, and package the header files in the output archive
 configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/hipsolver-version.h.in" "${PROJECT_BINARY_DIR}/include/hipsolver-version.h" )
@@ -67,9 +71,20 @@ endif( )
 
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md" )
 
-if( NOT CPACK_PACKAGING_INSTALL_PREFIX )
-  set( CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" )
-endif( )
+if(WIN32)
+  set(CPACK_SOURCE_GENERATOR "ZIP")
+  set(CPACK_GENERATOR "ZIP")
+  set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path" FORCE)
+  set(INSTALL_PREFIX "C:/hipSDK")
+  set(CPACK_SET_DESTDIR OFF)
+  set(CPACK_PACKAGE_INSTALL_DIRECTORY "C:/hipSDK")
+  set(CPACK_PACKAGING_INSTALL_PREFIX "")
+  set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+else()
+  if(NOT CPACK_PACKAGING_INSTALL_PREFIX)
+    set(CPACK_PACKAGING_INSTALL_PREFIX "${ROCM_PATH}")
+  endif()
+endif()
 
 set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib" )
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -31,8 +31,10 @@ set (hipsolver_f90_source
   hipsolver_module.f90
 )
 
-# Create hipSOLVER Fortran module
-add_library(hipsolver_fortran ${hipsolver_f90_source})
+if( UNIX )
+  # Create hipSOLVER Fortran module
+  add_library(hipsolver_fortran ${hipsolver_f90_source})
+endif( )
 
 if(BUILD_ADDRESS_SANITIZER)
   add_link_options(-fuse-ld=lld)
@@ -125,7 +127,6 @@ rocm_install_targets(
     ${CMAKE_BINARY_DIR}/include
   PREFIX hipsolver
 )
-#         PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
 
 if ( NOT USE_CUDA )
   rocm_export_targets(
@@ -143,8 +144,10 @@ else( )
   )
 endif( )
 
-# Force installation of .f90 module files
-install(FILES "hipsolver_module.f90"
-        DESTINATION "hipsolver/include")
+if( UNIX )
+  # Force installation of .f90 module files
+  install(FILES "hipsolver_module.f90"
+          DESTINATION "hipsolver/include")
+endif( )
 
 rocm_install_symlink_subdir( hipsolver )

--- a/rmake.py
+++ b/rmake.py
@@ -1,0 +1,232 @@
+#!/usr/bin/python3
+"""Copyright 2020-2021 Advanced Micro Devices, Inc.
+Manage build and installation"""
+
+import re
+import sys
+import os
+import platform
+import subprocess
+import argparse
+import pathlib
+from fnmatch import fnmatchcase
+
+args = {}
+param = {}
+OS_info = {}
+
+def parse_args():
+    """Parse command-line arguments"""
+    parser = argparse.ArgumentParser(description="""Checks build arguments""")
+
+    # common
+    parser.add_argument('-g', '--debug', required=False, default = False,  action='store_true',
+                        help='Generate Debug build (optional, default: False)')
+    parser.add_argument(      '--build_dir', type=str, required=False, default = "build",
+                        help='Build directory path (optional, default: build)')
+    parser.add_argument(      '--skip_ld_conf_entry', required=False, default=False)
+    parser.add_argument(      '--static', required=False, default = False, dest='static_lib', action='store_true',
+                        help='Generate static library build (optional, default: False)')
+    parser.add_argument('-c', '--clients', required=False, default = False, dest='build_clients', action='store_true',
+                        help='Generate all client builds (optional, default: False)')
+    parser.add_argument('-i', '--install', required=False, default = False, dest='install', action='store_true',
+                        help='Install after build (optional, default: False)')
+    parser.add_argument(      '--cmake-darg', required=False, dest='cmake_dargs', action='append', default=[],
+                        help='List of additional cmake defines for builds (optional, e.g. CMAKE)')
+    parser.add_argument('-v', '--verbose', required=False, default = False, action='store_true',
+                        help='Verbose build (optional, default: False)')
+    # hipsolver
+    parser.add_argument(     '--rocblas-path', dest='rocblas_path', type=str, required=False, default = "",
+                        help='Set specific path to custom built rocblas (optional, default: /opt/rocm/rocblas)')
+    parser.add_argument(     '--rocsolver-path', dest='rocsolver_path', type=str, required=False, default = "",
+                        help='Set specific path to custom built rocsolver (optional, default: /opt/rocm/rocsolver)')
+
+    return parser.parse_args()
+
+def os_detect():
+    global OS_info
+    if os.name == "nt":
+        OS_info["ID"] = platform.system()
+    else:
+        inf_file = "/etc/os-release"
+        if os.path.exists(inf_file):
+            with open(inf_file) as f:
+                for line in f:
+                    if "=" in line:
+                        k,v = line.strip().split("=")
+                        OS_info[k] = v.replace('"','')
+    OS_info["NUM_PROC"] = os.cpu_count()
+    print(OS_info)
+
+def create_dir(dir_path):
+    full_path = ""
+    if os.path.isabs(dir_path):
+        full_path = dir_path
+    else:
+        full_path = os.path.join( os.getcwd(), dir_path )
+    pathlib.Path(full_path).mkdir(parents=True, exist_ok=True)
+    return
+
+def delete_dir(dir_path) :
+    if (not os.path.exists(dir_path)):
+        return
+    if os.name == "nt":
+        run_cmd( "RMDIR" , f"/S /Q {dir_path}")
+    else:
+        run_cmd( "rm" , f"-rf {dir_path}")
+
+def cmake_path(os_path):
+    if os.name == "nt":
+        return os_path.replace("\\", "/")
+    else:
+        return os_path
+
+def config_cmd():
+    global args
+    global OS_info
+    cwd_path = os.getcwd()
+    cmake_executable = ""
+    cmake_options = []
+    src_path = cmake_path(cwd_path)
+    cmake_platform_opts = []
+    if os.name == "nt":
+        # not really rocm path as none exist, HIP_DIR set in toolchain is more important
+        rocm_path = os.getenv( 'ROCM_CMAKE_PATH', "C:/github/rocm-cmake-master/share/rocm")
+        cmake_executable = "cmake"
+        #set CPACK_PACKAGING_INSTALL_PREFIX= defined as blank as it is appended to end of path for archive creation
+        cmake_platform_opts.append( "-DCPACK_PACKAGING_INSTALL_PREFIX=" )
+        cmake_platform_opts.append( "-DCMAKE_INSTALL_PREFIX=C:/hipSDK" )
+        lapack_dir = os.getenv("LAPACK_DIR")
+        cblas_dir = os.getenv("cblas_DIR")
+        if cblas_dir is None and lapack_dir is not None:
+            cmake_platform_opts.append( f"-Dcblas_DIR={lapack_dir}")
+        cmake_platform_opts.append('-DCMAKE_CXX_COMPILER=clang++.exe')
+        cmake_platform_opts.append('-DCMAKE_C_COMPILER=clang.exe')
+        if os.getenv("NO_VCPKG") is None:
+            vcpkg_path =  pathlib.Path(os.getenv("VCPKG_PATH", "C:/github/vcpkg"))
+            vcpkg_toolchain = vcpkg_path / 'scripts/buildsystems/vcpkg.cmake'
+            cmake_options.append(f"-DCMAKE_TOOLCHAIN_FILE={vcpkg_toolchain.as_posix()} -DVCPKG_TARGET_TRIPLET=x64-windows")
+        cmake_options.append("-DCMAKE_STATIC_LIBRARY_SUFFIX=.a")
+        cmake_options.append("-DCMAKE_STATIC_LIBRARY_PREFIX=static_")
+        cmake_options.append("-DCMAKE_SHARED_LIBRARY_SUFFIX=.dll")
+        cmake_options.append("-DCMAKE_SHARED_LIBRARY_PREFIX=")
+        cmake_options.append("-G Ninja")
+    else:
+        rocm_path = os.getenv( 'ROCM_PATH', "/opt/rocm")
+        cmake_executable = "cmake"
+        cmake_platform_opts.append( f"-DROCM_DIR:PATH={rocm_path} -DCPACK_PACKAGING_INSTALL_PREFIX={rocm_path}" )
+        cmake_platform_opts.append("-DCMAKE_INSTALL_PREFIX=hipsolver-install")
+
+    print( f"Build source path: {src_path}")
+
+    cmake_options.extend( cmake_platform_opts )
+
+    cmake_base_options = f"-DROCM_PATH={rocm_path} -DCMAKE_PREFIX_PATH:PATH={rocm_path}"
+    cmake_options.append( cmake_base_options )
+
+    # packaging options
+    cmake_pack_options = f"-DCPACK_SET_DESTDIR=OFF"
+    cmake_options.append( cmake_pack_options )
+
+    if os.getenv('CMAKE_CXX_COMPILER_LAUNCHER'):
+        cmake_options.append( f"-DCMAKE_CXX_COMPILER_LAUNCHER={os.getenv('CMAKE_CXX_COMPILER_LAUNCHER')}" )
+
+    print( cmake_options )
+
+    # build type
+    cmake_config = ""
+    build_dir = os.path.abspath(args.build_dir)
+    if not args.debug:
+        build_path = os.path.join(build_dir, "release")
+        cmake_config="Release"
+    else:
+        build_path = os.path.join(build_dir, "debug")
+        cmake_config="Debug"
+
+    cmake_options.append( f"-DCMAKE_BUILD_TYPE={cmake_config}" )
+
+    # clean
+    delete_dir( build_path )
+
+    create_dir( os.path.join(build_path, "clients") )
+    os.chdir( build_path )
+
+    if args.static_lib:
+        cmake_options.append("-DBUILD_SHARED_LIBS=OFF" )
+
+    if args.skip_ld_conf_entry:
+        cmake_options.append("-DROCM_DISABLE_LDCONFIG=ON" )
+
+    if args.build_clients:
+        cmake_build_dir = cmake_path(build_dir)
+        cmake_options.append("-DBUILD_CLIENTS_TESTS=ON -DBUILD_CLIENTS_BENCHMARKS=ON -DBUILD_CLIENTS_SAMPLES=ON" )
+
+    if args.rocsolver_path:
+        cmake_options.append("-DCUSTOM_ROCSOLVER=" + cmake_path(args.rocsolver_path))
+        os.environ['rocsolver_DIR'] = cmake_path(args.rocsolver_path)
+
+    if args.rocblas_path:
+        cmake_options.append("-DCUSTOM_ROCBLAS=" + cmake_path(args.rocblas_path))
+        os.environ['rocblas_DIR'] = cmake_path(args.rocblas_path)
+
+    if args.cmake_dargs:
+        for i in args.cmake_dargs:
+          cmake_options.append( f"-D{i}" )
+
+    cmake_options.append( f"{src_path}")
+    cmd_opts = " ".join(cmake_options)
+
+    try:
+        os.environ['HIP_DIR'] = cmake_path(os.environ['HIP_DIR'])
+    except:
+        pass
+
+    return cmake_executable, cmd_opts
+
+
+def make_cmd():
+    global args
+    global OS_info
+
+    make_options = []
+
+    nproc = OS_info["NUM_PROC"]
+    if os.name == "nt":
+        make_executable = f"cmake.exe --build . " # ninja
+        if args.verbose:
+          make_options.append( "--verbose" )
+        make_options.append( "--target all" )
+        if args.install:
+          make_options.append( "--target package --target install" )
+    else:
+        make_executable = f"make -j{nproc}"
+        if args.verbose:
+          make_options.append( "VERBOSE=1" )
+        if True: # args.install:
+         make_options.append( "install" )
+    cmd_opts = " ".join(make_options)
+
+    return make_executable, cmd_opts
+
+def run_cmd(exe, opts):
+    program = f"{exe} {opts}"
+    print(program)
+    proc = subprocess.run(program, check=True, stderr=subprocess.STDOUT, shell=True)
+    return proc.returncode
+
+def main():
+    global args
+    os_detect()
+    args = parse_args()
+
+    # configure
+    exe, opts = config_cmd()
+    run_cmd(exe, opts)
+
+    # make
+    exe, opts = make_cmd()
+    run_cmd(exe, opts)
+
+if __name__ == '__main__':
+    main()
+

--- a/rtest.py
+++ b/rtest.py
@@ -1,0 +1,311 @@
+#!/usr/bin/python3
+"""Copyright 2021 Advanced Micro Devices, Inc.
+Run tests on build"""
+
+import re
+import os
+import sys
+import subprocess
+import shlex
+import argparse
+import pathlib
+import platform
+from genericpath import exists
+from fnmatch import fnmatchcase
+from xml.dom import minidom
+import multiprocessing
+import time
+
+args = {}
+OS_info = {}
+
+timeout = False
+test_proc = None
+stop = 0
+
+test_script = [ 'cd %IDIR%', '%XML%' ]
+
+def parse_args():
+    """Parse command-line arguments"""
+    parser = argparse.ArgumentParser(description="""
+    Checks build arguments
+    """)
+    parser.add_argument('-t', '--test', required=True,
+                        help='Test set to run from rtest.win.xml (required, e.g. osdb)')
+    parser.add_argument('-g', '--debug', required=False, default=False,  action='store_true',
+                        help='Test Debug build (optional, default: false)')
+    parser.add_argument('-o', '--output', type=str, required=False, default="xml",
+                        help='Test output file (optional, default: test_detail.xml)')
+    parser.add_argument(      '--install_dir', type=str, required=False, default="build",
+                        help='Installation directory where build or release folders are (optional, default: build)')
+    parser.add_argument(      '--fail_test', default=False, required=False, action='store_true',
+                        help='Return as if test failed (optional, default: false)')
+    # parser.add_argument('-v', '--verbose', required=False, default = False, action='store_true',
+    #                     help='Verbose install (optional, default: False)')
+    return parser.parse_args()
+
+
+def vram_detect():
+    global OS_info
+    OS_info["VRAM"] = 0
+    if os.name == "nt":
+        cmd = "hipinfo.exe"
+        process = subprocess.run([cmd], stdout=subprocess.PIPE)
+        for line_in in process.stdout.decode().splitlines():
+            if 'totalGlobalMem' in line_in:
+                OS_info["VRAM"] = float(line_in.split()[1])
+                break
+    else:
+        cmd = "rocminfo"
+        process = subprocess.run([cmd], stdout=subprocess.PIPE)
+        for line_in in process.stdout.decode().splitlines():
+            match = re.search(r'.*Size:.*([0-9]+)\(.*\).*KB', line_in, re.IGNORECASE)
+            if match:
+                OS_info["VRAM"] = float(match.group(1))/(1024*1024)
+                break
+
+def os_detect():
+    global OS_info
+    if os.name == "nt":
+        OS_info["ID"] = platform.system()
+    else:
+        inf_file = "/etc/os-release"
+        if os.path.exists(inf_file):
+            with open(inf_file) as f:
+                for line in f:
+                    if "=" in line:
+                        k,v = line.strip().split("=")
+                        OS_info[k] = v.replace('"','')
+    OS_info["NUM_PROC"] = os.cpu_count()
+    vram_detect()
+    print(OS_info)
+
+
+def create_dir(dir_path):
+    if os.path.isabs(dir_path):
+        full_path = dir_path
+    else:
+        full_path = os.path.join( os.getcwd(), dir_path )
+    return pathlib.Path(full_path).mkdir(parents=True, exist_ok=True)
+
+def delete_dir(dir_path) :
+    if (not os.path.exists(dir_path)):
+        return
+    if os.name == "nt":
+        return run_cmd( "RMDIR" , f"/S /Q {dir_path}")
+    else:
+        linux_path = pathlib.Path(dir_path).absolute()
+        return run_cmd( "rm" , f"-rf {linux_path}")
+
+class TimerProcess(multiprocessing.Process):
+
+    def __init__(self, start, stop, kill_pid):
+        multiprocessing.Process.__init__(self)
+        self.quit = multiprocessing.Event()
+        self.timed_out = multiprocessing.Event()
+        self.start_time = start
+        self.max_time = stop
+        self.kill_pid = kill_pid
+
+    def run(self):
+        while not self.quit.is_set():
+            #print( f'time_stop {self.start_time} limit {self.max_time}')
+            if (self.max_time == 0):
+                return
+            t = time.monotonic()
+            if ( t - self.start_time > self.max_time ):
+                print( f'killing {self.kill_pid} t {t}')
+                if os.name == "nt":
+                    cmd = ['TASKKILL', '/F', '/T', '/PID', str(self.kill_pid)]
+                    proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+                else:
+                    os.kill(self.kill_pid, signal.SIGKILL)
+                self.timed_out.set()
+                self.stop()
+            pass
+
+    def stop(self):
+        self.quit.set()
+
+    def stopped(self):
+        return self.timed_out.is_set()
+
+
+def time_stop(start, pid):
+    global timeout, stop
+    while (True):
+        print( f'time_stop {start} limit {stop}')
+        t = time.monotonic()
+        if (stop == 0):
+            return
+        if ( (stop > 0) and (t - start > stop) ):
+            print( f'killing {pid} t {t}')
+            if os.name == "nt":
+                cmd = ['TASKKILL', '/F', '/T', '/PID', str(pid)]
+                proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+            else:
+                test_proc.kill()
+            timeout = True
+            stop = 0
+        time.sleep(0)
+
+def run_cmd(cmd, test = False, time_limit = 0):
+    global args
+    global test_proc, timer_thread
+    global stop
+    if (cmd.startswith('cd ')):
+        return os.chdir(cmd[3:])
+    if (cmd.startswith('mkdir ')):
+        return create_dir(cmd[6:])
+    cmdline = f"{cmd}"
+    print(cmdline)
+    try:
+        if not test:
+            proc = subprocess.run(cmdline, check=True, stderr=subprocess.STDOUT, shell=True)
+            status = proc.returncode
+        else:
+            error = False
+            timeout = False
+            test_proc = subprocess.Popen(shlex.split(cmdline), text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+            if time_limit > 0:
+                start = time.monotonic()
+                #p = multiprocessing.Process(target=time_stop, args=(start, test_proc.pid))
+                p = TimerProcess(start, time_limit, test_proc.pid)
+                p.start()
+            while True:
+                output = test_proc.stdout.readline()
+                if output == '' and test_proc.poll() is not None:
+                    break
+                elif output:
+                    outstring = output.strip()
+                    print (outstring)
+                    error = error or re.search(r'error|fail', outstring, re.IGNORECASE)
+            status = test_proc.poll()
+            if time_limit > 0:
+                p.stop()
+                p.join()
+                timeout = p.stopped()
+                print(f"timeout {timeout}")
+            if error:
+                status = 1
+            elif timeout:
+                status = 2
+            else:
+                status = test_proc.returncode
+    except:
+        import traceback
+        exc = traceback.format_exc()
+        print( "Python Exception: {0}".format(exc) )
+        status = 3
+    return status
+
+def batch(script, xml):
+    global OS_info
+    global args
+    #
+    cwd = pathlib.os.curdir
+    rtest_cwd_path = os.path.abspath( os.path.join( cwd, 'rtest.win.xml') )
+    if os.path.isfile(rtest_cwd_path) and os.path.dirname(rtest_cwd_path).endswith( "staging" ):
+        # if in a staging directory then test locally
+        test_dir = cwd
+    else:
+        if args.debug: build_type = "debug"
+        else: build_type = "release"
+        test_dir = f"{args.install_dir}//{build_type}//clients//staging"
+
+    fail = False
+    for i in range(len(script)):
+        cmdline = script[i]
+        xcmd = cmdline.replace('%IDIR%', test_dir)
+        cmd = xcmd.replace('%ODIR%', args.output)
+        if cmd.startswith('tdir '):
+            if pathlib.Path(cmd[5:]).exists():
+                return 0 # all further cmds skipped
+            else:
+                continue
+        error = False
+        if cmd.startswith('%XML%'):
+            # run the matching tests listed in the xml test file
+            var_subs = {}
+            for var in xml.getElementsByTagName('var'):
+                name = var.getAttribute('name')
+                val = var.getAttribute('value')
+                var_subs[name] = val
+            for test in xml.getElementsByTagName('test'):
+                sets = test.getAttribute('sets')
+                runset = sets.split(',')
+                if args.test in runset:
+                    for run in test.getElementsByTagName('run'):
+                        name = run.getAttribute('name')
+                        vram_limit = run.getAttribute('vram_min')
+                        if vram_limit:
+                            if OS_info["VRAM"] < float(vram_limit):
+                                print( f'***\n*** Skipped: {name} due to VRAM req.\n***')
+                                continue
+                        if name:
+                            print( f'***\n*** Running: {name}\n***')
+                        time_limit = run.getAttribute('time_max')
+                        if time_limit:
+                            timeout = float(time_limit)
+                        else:
+                            timeout = 0
+
+                        raw_cmd = run.firstChild.data
+                        var_cmd = raw_cmd.format_map(var_subs)
+                        error = run_cmd(var_cmd, True, timeout)
+                        if (error == 2):
+                            print( f'***\n*** Timed out when running: {name}\n***')
+        else:
+            error = run_cmd(cmd)
+        fail = fail or error
+
+    if (fail):
+        if (cmd == "%XML%"):
+            print(f"FAILED xml test suite!")
+        else:
+            print(f"ERROR running: {cmd}")
+        if (os.curdir != cwd):
+            os.chdir( cwd )
+        return 1
+    if (os.curdir != cwd):
+        os.chdir( cwd )
+    return 0
+
+def run_tests():
+    global test_script
+    global xmlDoc
+
+    # install
+    cwd = os.curdir
+
+    xmlPath = os.path.join( cwd, 'rtest.win.xml')
+    xmlDoc = minidom.parse( xmlPath )
+
+    scripts = []
+    scripts.append( test_script )
+    for i in scripts:
+        if (batch(i, xmlDoc)):
+            #print("Failure in script. ABORTING")
+            if (os.curdir != cwd):
+                os.chdir( cwd )
+            return 1
+    if (os.curdir != cwd):
+        os.chdir( cwd )
+    return 0
+
+def main():
+    global args
+    global timer_thread
+
+    os_detect()
+    args = parse_args()
+
+    status = run_tests()
+
+    if args.fail_test: status = 1
+
+    if (status):
+        sys.exit(status)
+
+if __name__ == '__main__':
+    main()

--- a/rtest.win.xml
+++ b/rtest.win.xml
@@ -1,0 +1,10 @@
+
+<testset>
+<var name="GTEST_FILTER" value="hipsolver-test --gtest_output=xml --gtest_color=yes --gtest_filter"></var>
+<test sets="psdb">
+  <run name="precheckin">{GTEST_FILTER}=*checkin_lapack*-*known_bug*</run>
+</test>
+<test sets="osdb">
+  <run name="daily">{GTEST_FILTER}=*checkin_lapack*-*known_bug*</run>
+</test>
+</testset>


### PR DESCRIPTION
This PR includes all changes required to start building and testing hipSOLVER on Windows. All tests pass, though Fortran support is not included. (The Fortran API tests still run, though it's misleading, as they don't actually exercise the Fortran API.)

Note that while various compilers are supported on Linux, the ROCm Clang and Clang++ are the only working compilers on Windows for the moment. Another limitation is that I have not tested CUDA on Windows. So, lots of caveats here, but the AMD version on Windows now works.

### How to Build
```
call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
set HIP_DIR=C:/hip
set HIP_PATH=C:/hip
set HIP_ROCCLR_HOME=C:/hip
set rocblas_DIR=C:/hipSDK
set rocsolver_DIR=C:/hipSDK
set cblas_DIR=C:/3rdparty/build
vcpkg install gtest:x64-windows
set VCPKG_PATH=C:/3rdparty/vcpkg
python rmake.py -ic
```

### How to Run Tests
```
cd build\release\clients\staging
python rtest.py -t psdb
python rtest.py -t osdb :: though, the osdb suite is identical to the psdb suite
```