### PR TITLE
Fix hipsolver-test on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 if( USE_CUDA)
     find_package( HIP MODULE REQUIRED )
 else( )
-    find_package( hip REQUIRED PATHS ${HIP_PATH} ${ROCM_PATH} /opt/rocm )
+    find_package( hip REQUIRED CONFIG PATHS ${HIP_PATH} ${ROCM_PATH} /opt/rocm )
 endif( )
 
 if( USE_CUDA )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -48,6 +48,21 @@ add_library( roc::hipsolver ALIAS hipsolver )
 
 add_armor_flags( hipsolver "${ARMOR_LEVEL}" )
 
+if( WIN32 )
+  if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS )
+    add_custom_command( TARGET hipsolver
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/$<TARGET_FILE_NAME:hipsolver>" "${PROJECT_BINARY_DIR}/clients/staging/$<TARGET_FILE_NAME:hipsolver>"
+    )
+    if( ${CMAKE_BUILD_TYPE} MATCHES "Debug" )
+      add_custom_command( TARGET hipsolver
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/hipsolver-d.pdb" "${PROJECT_BINARY_DIR}/clients/staging/hipsolver-d.pdb"
+      )
+    endif( )
+  endif( )
+endif( )
+
 # External header includes included as system files
 target_include_directories( hipsolver
   SYSTEM PRIVATE


### PR DESCRIPTION
This change should fix the hipSOLVER tests on the Windows CI. Targeting master, as this will be a hotfix.

The brunt of the change is copying hipsolver.dll into the clients/staging directory. At some point, we will probably switch to just updating the PATH before running the tests, but copying DLLs is the way the libraries are doing things for now. The DLL copying strategy was chosen because it ensures that the code we're testing is at the top of [the Windows DLL search priority list](https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-desktop-applications).

Issue: SWDEV-301261 (HOTFIX)