### PR TITLE
Merge release/21.40 to develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 if( USE_CUDA)
     find_package( HIP MODULE REQUIRED )
 else( )
-    find_package( hip REQUIRED PATHS ${HIP_PATH} ${ROCM_PATH} /opt/rocm )
+    find_package( hip REQUIRED CONFIG PATHS ${HIP_PATH} ${ROCM_PATH} /opt/rocm )
 endif( )
 
 if( USE_CUDA )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -48,6 +48,21 @@ add_library( roc::hipsolver ALIAS hipsolver )
 
 add_armor_flags( hipsolver "${ARMOR_LEVEL}" )
 
+if( WIN32 )
+  if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS )
+    add_custom_command( TARGET hipsolver
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/$<TARGET_FILE_NAME:hipsolver>" "${PROJECT_BINARY_DIR}/clients/staging/$<TARGET_FILE_NAME:hipsolver>"
+    )
+    if( ${CMAKE_BUILD_TYPE} MATCHES "Debug" )
+      add_custom_command( TARGET hipsolver
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/hipsolver-d.pdb" "${PROJECT_BINARY_DIR}/clients/staging/hipsolver-d.pdb"
+      )
+    endif( )
+  endif( )
+endif( )
+
 # External header includes included as system files
 target_include_directories( hipsolver
   SYSTEM PRIVATE


### PR DESCRIPTION
* Copy hipsolver.dll into clients/staging directory

* Undo removal of CONFIG from find_package(hip)

The existence of both hip-config.cmake and FindHIP.cmake makes
this code unusual, and it should match hipBLAS and other hip
marshaling libraries.

Despite my concerns that removing CONFIG may have been a mistake,
it does not have a material impact on the build process. The use of `PATH`
implicitly sets `CONFIG` anyway.