### PR TITLE
Match rocSOLVER ReadTheDocs settings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+   configuration: docs/source/conf.py
+
+formats: all
+
+python:
+   version: "3.7"
+   install:
+   - requirements: docs/source/requirements.txt

--- a/docs/run_doc.sh
+++ b/docs/run_doc.sh
@@ -11,5 +11,5 @@ bash run_doxygen.sh
 # Build sphinx docs
 cd source
 make clean
-make html
-make latexpdf
+make SPHINXOPTS='-W --keep-going' html
+make SPHINXOPTS='-W --keep-going' latexpdf

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,6 @@
-
-breathe
-m2r2
+docutils==0.16
+sphinx==3.5.3
+sphinx_rtd_theme==0.4.3
+readthedocs_sphinx_ext==2.1.4
+breathe==4.28.0
+m2r2==0.3.1


### PR DESCRIPTION
- Specify exact dependency versions to ensure reproducible builds
- Add ReadTheDocs config file
- Turn Sphinx warnings into errors

See https://github.com/ROCmSoftwarePlatform/rocSOLVER/pull/318.