### PR TITLE
Fix undefined LAPACK symbols in ASan builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,17 @@ option( BUILD_VERBOSE "Output additional build information" OFF )
 option( BUILD_SHARED_LIBS "Build hipSOLVER as a shared library" ON )
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 
+add_library(hipsolver-common INTERFACE)
 if(BUILD_ADDRESS_SANITIZER)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -shared-libasan")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -shared-libasan")
+  target_compile_options(hipsolver-common INTERFACE
+    -fsanitize=address
+    -shared-libasan
+  )
+  target_link_options(hipsolver-common INTERFACE
+    -fsanitize=address
+    -shared-libasan
+    -fuse-ld=lld
+  )
 endif()
 
 if( CMAKE_BUILD_TYPE STREQUAL "Debug" )

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -38,6 +38,10 @@ if( UNIX )
   target_link_libraries( hipsolver-bench PRIVATE hipsolver_fortran_client )
 endif( )
 
+target_link_libraries(hipsolver-bench PRIVATE
+  $<BUILD_INTERFACE:hipsolver-common>
+)
+
 add_armor_flags( hipsolver-bench "${ARMOR_LEVEL}" )
 
 # need mf16c flag for float->half convertion

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -69,6 +69,10 @@ if( UNIX )
   target_link_libraries( hipsolver-test PRIVATE hipsolver_fortran_client )
 endif( )
 
+target_link_libraries(hipsolver-test PRIVATE
+  $<BUILD_INTERFACE:hipsolver-common>
+)
+
 # need mf16c flag for float->half convertion
 target_compile_options( hipsolver-test PRIVATE -mf16c )
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc.
+# Copyright 2016-2021 Advanced Micro Devices, Inc.
 # ########################################################################
 # Helper cmake script to automate building dependencies for hipsolver
 # This script can be invoked manually by the user with 'cmake -P'
@@ -19,6 +19,10 @@ endif( )
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
 if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
   set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
+endif()
+
+if( NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC} )
+  set( CMAKE_Fortran_COMPILER  "gfortran" )
 endif()
 
 # The superbuild does not build anything itself; all compiling is done in external projects

--- a/deps/external-lapack.cmake
+++ b/deps/external-lapack.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2016-2020 Advanced Micro Devices, Inc.
+# Copyright 2016-2021 Advanced Micro Devices, Inc.
 # ########################################################################
 
 message( STATUS "Configuring lapack external dependency" )
@@ -32,7 +32,7 @@ ExternalProject_Add(
   PREFIX ${CMAKE_BINARY_DIR}/lapack
   GIT_REPOSITORY ${lapack_git_repository}
   GIT_TAG ${lapack_git_tag}
-  CMAKE_ARGS ${lapack_cmake_args} -DCBLAS=ON -DLAPACKE=OFF -DBUILD_TESTING=OFF
+  CMAKE_ARGS ${lapack_cmake_args} -DCBLAS=ON -DLAPACKE=OFF -DBUILD_TESTING=OFF -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
   LOG_BUILD 1
   INSTALL_COMMAND ""
   LOG_INSTALL 1

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -36,15 +36,15 @@ if( UNIX )
   add_library(hipsolver_fortran ${hipsolver_f90_source})
 endif( )
 
-if(BUILD_ADDRESS_SANITIZER)
-  add_link_options(-fuse-ld=lld)
-endif()
-
 add_library( hipsolver
   ${hipsolver_source}
   ${relative_hipsolver_headers_public}
 )
 add_library( roc::hipsolver ALIAS hipsolver )
+
+target_link_libraries(hipsolver PRIVATE
+  $<BUILD_INTERFACE:hipsolver-common> # https://gitlab.kitware.com/cmake/cmake/-/issues/15415
+)
 
 add_armor_flags( hipsolver "${ARMOR_LEVEL}" )
 


### PR DESCRIPTION
When `$ROCM_PATH/llvm/bin` is prepended to the `PATH`, our `./install.sh` script is building LAPACK with flang (as the first Fortran compiler in the `PATH`). However, hipSOLVER overrides the CMake default to set its own default to gfortran in the main CMakeLists.txt. Thus, when no Fortran compiler is explicitly specified, each component ends up choosing a different compiler. 

This PR will:
* Ensure dependencies use the same compiler selection logic as hipsolver
* Switch to using an INTERFACE library for AddressSanitizer flags

SWDEV-313529