### PR TITLE
Merge branch 'master' into develop

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -4,3 +4,4 @@ sphinx_rtd_theme==0.4.3
 readthedocs_sphinx_ext==2.1.4
 breathe==4.28.0
 m2r2==0.3.1
+mistune==0.8.4


### PR DESCRIPTION
This change fixes the error:

    Module 'mistune' has no attribute 'BlockGrammar'

The mistune module is used by m2r2, but the version was not specified
tightly, so the release of mistune 2.0 caused a breakage due to
interface changes.