### PR TITLE
Workspace fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 ### Removed
 ### Fixed
 - bufferSize functions will now return HIPSOLVER_STATUS_NOT_INITIALIZED instead of HIPSOLVER_STATUS_INVALID_VALUE when both handle and lwork are null.
-- Fixed rare memory allocation failure in syevd/heevd and sygvd/hegvd caused by allocating workspace arrays outside of rocSOLVER.
+- Fixed rare memory allocation failure in syevd/heevd and sygvd/hegvd caused by improper workspace array allocation outside of rocSOLVER.
 
 ### Known Issues
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 ### Removed
 ### Fixed
 - bufferSize functions will now return HIPSOLVER_STATUS_NOT_INITIALIZED instead of HIPSOLVER_STATUS_INVALID_VALUE when both handle and lwork are null.
-- Fixed rare memory allocation failure in syevd/heevd and sygvd/hegvd when using rocblas_device_malloc to allocate multiple workspace arrays.
+- Fixed rare memory allocation failure in syevd/heevd and sygvd/hegvd caused by allocating workspace arrays outside of rocSOLVER.
 
 ### Known Issues
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed potential workspace allocation failure in some functions.
+
 ### Known Issues
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 ### Deprecated
 ### Removed
 ### Fixed
-- Fixed potential workspace allocation failure in some functions.
+- bufferSize functions will now return HIPSOLVER_STATUS_NOT_INITIALIZED instead of HIPSOLVER_STATUS_INVALID_VALUE when both handle and lwork are null.
+- Fixed rare memory allocation failure in syevd/heevd and sygvd/hegvd when using rocblas_device_malloc to allocate multiple workspace arrays.
 
 ### Known Issues
 ### Security

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -17,7 +17,6 @@
 #include <functional>
 #include <iostream>
 #include <math.h>
-#include <memory>
 
 using namespace std;
 

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -3249,13 +3249,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array (aka rwork)
     if(min(m, n) > 0)
-        sz += sizeof(float) * min(m, n);
+        size_E = sizeof(float) * min(m, n);
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -3301,13 +3303,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array (aka rwork)
     if(min(m, n) > 0)
-        sz += sizeof(double) * min(m, n);
+        size_E = sizeof(double) * min(m, n);
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -3353,13 +3357,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array (aka rwork)
     if(min(m, n) > 0)
-        sz += sizeof(float) * min(m, n);
+        size_E = sizeof(float) * min(m, n);
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -3405,13 +3411,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array (aka rwork)
     if(min(m, n) > 0)
-        sz += sizeof(double) * min(m, n);
+        size_E = sizeof(double) * min(m, n);
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -5651,13 +5659,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array
     if(n > 0)
-        sz += sizeof(float) * n;
+        size_E = sizeof(float) * n;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -5703,13 +5713,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array
     if(n > 0)
-        sz += sizeof(double) * n;
+        size_E = sizeof(double) * n;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -5755,13 +5767,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array
     if(n > 0)
-        sz += sizeof(float) * n;
+        size_E = sizeof(float) * n;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -5807,13 +5821,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array
     if(n > 0)
-        sz += sizeof(double) * n;
+        size_E = sizeof(double) * n;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -6066,13 +6082,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array
     if(n > 0)
-        sz += sizeof(float) * n;
+        size_E = sizeof(float) * n;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -6124,13 +6142,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array
     if(n > 0)
-        sz += sizeof(double) * n;
+        size_E = sizeof(double) * n;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -6182,13 +6202,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array
     if(n > 0)
-        sz += sizeof(float) * n;
+        size_E = sizeof(float) * n;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -6240,13 +6262,15 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
+    size_t size_E = 0;
+
     // space for E array
     if(n > 0)
-        sz += sizeof(double) * n;
+        size_E = sizeof(double) * n;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz, size_E);
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -3412,11 +3412,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array (aka rwork)
-    if(min(m, n) > 0)
-        size_E = sizeof(float) * min(m, n);
+    size_t size_E = min(m, n) > 0 ? sizeof(float) * min(m, n) : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -3466,11 +3463,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array (aka rwork)
-    if(min(m, n) > 0)
-        size_E = sizeof(double) * min(m, n);
+    size_t size_E = min(m, n) > 0 ? sizeof(double) * min(m, n) : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -3520,11 +3514,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array (aka rwork)
-    if(min(m, n) > 0)
-        size_E = sizeof(float) * min(m, n);
+    size_t size_E = min(m, n) > 0 ? sizeof(float) * min(m, n) : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -3574,11 +3565,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array (aka rwork)
-    if(min(m, n) > 0)
-        size_E = sizeof(double) * min(m, n);
+    size_t size_E = min(m, n) > 0 ? sizeof(double) * min(m, n) : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -7318,11 +7306,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array
-    if(n > 0)
-        size_E = sizeof(float) * n;
+    size_t size_E = n > 0 ? sizeof(float) * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -7372,11 +7357,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array
-    if(n > 0)
-        size_E = sizeof(double) * n;
+    size_t size_E = n > 0 ? sizeof(double) * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -7426,11 +7408,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array
-    if(n > 0)
-        size_E = sizeof(float) * n;
+    size_t size_E = n > 0 ? sizeof(float) * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -7480,11 +7459,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array
-    if(n > 0)
-        size_E = sizeof(double) * n;
+    size_t size_E = n > 0 ? sizeof(double) * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -8611,11 +8587,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array
-    if(n > 0)
-        size_E = sizeof(float) * n;
+    size_t size_E = n > 0 ? sizeof(float) * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -8671,11 +8644,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array
-    if(n > 0)
-        size_E = sizeof(double) * n;
+    size_t size_E = n > 0 ? sizeof(double) * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -8731,11 +8701,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array
-    if(n > 0)
-        size_E = sizeof(float) * n;
+    size_t size_E = n > 0 ? sizeof(float) * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -8791,11 +8758,8 @@ try
                                                                    nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
-    size_t size_E = 0;
-
     // space for E array
-    if(n > 0)
-        size_E = sizeof(double) * n;
+    size_t size_E = n > 0 ? sizeof(double) * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -2375,31 +2375,28 @@ try
     size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    hipsolverStatus_t status;
-    if(B == X)
-        status = rocblas2hip_status(rocsolver_sgels((rocblas_handle)handle,
-                                                    rocblas_operation_none,
-                                                    m,
-                                                    n,
-                                                    nrhs,
-                                                    nullptr,
-                                                    lda,
-                                                    nullptr,
-                                                    ldb,
-                                                    nullptr));
-    else
-        status = rocblas2hip_status(rocsolver_sgels_outofplace((rocblas_handle)handle,
-                                                               rocblas_operation_none,
-                                                               m,
-                                                               n,
-                                                               nrhs,
-                                                               nullptr,
-                                                               lda,
-                                                               nullptr,
-                                                               ldb,
-                                                               nullptr,
-                                                               ldx,
-                                                               nullptr));
+    hipsolverStatus_t status = rocblas2hip_status(rocsolver_sgels_outofplace((rocblas_handle)handle,
+                                                                             rocblas_operation_none,
+                                                                             m,
+                                                                             n,
+                                                                             nrhs,
+                                                                             nullptr,
+                                                                             lda,
+                                                                             nullptr,
+                                                                             ldb,
+                                                                             nullptr,
+                                                                             ldx,
+                                                                             nullptr));
+    rocblas2hip_status(rocsolver_sgels((rocblas_handle)handle,
+                                       rocblas_operation_none,
+                                       m,
+                                       n,
+                                       nrhs,
+                                       nullptr,
+                                       lda,
+                                       nullptr,
+                                       ldb,
+                                       nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     *lwork = sz;
@@ -2432,31 +2429,28 @@ try
     size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    hipsolverStatus_t status;
-    if(B == X)
-        status = rocblas2hip_status(rocsolver_dgels((rocblas_handle)handle,
-                                                    rocblas_operation_none,
-                                                    m,
-                                                    n,
-                                                    nrhs,
-                                                    nullptr,
-                                                    lda,
-                                                    nullptr,
-                                                    ldb,
-                                                    nullptr));
-    else
-        status = rocblas2hip_status(rocsolver_dgels_outofplace((rocblas_handle)handle,
-                                                               rocblas_operation_none,
-                                                               m,
-                                                               n,
-                                                               nrhs,
-                                                               nullptr,
-                                                               lda,
-                                                               nullptr,
-                                                               ldb,
-                                                               nullptr,
-                                                               ldx,
-                                                               nullptr));
+    hipsolverStatus_t status = rocblas2hip_status(rocsolver_dgels_outofplace((rocblas_handle)handle,
+                                                                             rocblas_operation_none,
+                                                                             m,
+                                                                             n,
+                                                                             nrhs,
+                                                                             nullptr,
+                                                                             lda,
+                                                                             nullptr,
+                                                                             ldb,
+                                                                             nullptr,
+                                                                             ldx,
+                                                                             nullptr));
+    rocblas2hip_status(rocsolver_dgels((rocblas_handle)handle,
+                                       rocblas_operation_none,
+                                       m,
+                                       n,
+                                       nrhs,
+                                       nullptr,
+                                       lda,
+                                       nullptr,
+                                       ldb,
+                                       nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     *lwork = sz;
@@ -2489,31 +2483,28 @@ try
     size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    hipsolverStatus_t status;
-    if(B == X)
-        status = rocblas2hip_status(rocsolver_cgels((rocblas_handle)handle,
-                                                    rocblas_operation_none,
-                                                    m,
-                                                    n,
-                                                    nrhs,
-                                                    nullptr,
-                                                    lda,
-                                                    nullptr,
-                                                    ldb,
-                                                    nullptr));
-    else
-        status = rocblas2hip_status(rocsolver_cgels_outofplace((rocblas_handle)handle,
-                                                               rocblas_operation_none,
-                                                               m,
-                                                               n,
-                                                               nrhs,
-                                                               nullptr,
-                                                               lda,
-                                                               nullptr,
-                                                               ldb,
-                                                               nullptr,
-                                                               ldx,
-                                                               nullptr));
+    hipsolverStatus_t status = rocblas2hip_status(rocsolver_cgels_outofplace((rocblas_handle)handle,
+                                                                             rocblas_operation_none,
+                                                                             m,
+                                                                             n,
+                                                                             nrhs,
+                                                                             nullptr,
+                                                                             lda,
+                                                                             nullptr,
+                                                                             ldb,
+                                                                             nullptr,
+                                                                             ldx,
+                                                                             nullptr));
+    rocblas2hip_status(rocsolver_cgels((rocblas_handle)handle,
+                                       rocblas_operation_none,
+                                       m,
+                                       n,
+                                       nrhs,
+                                       nullptr,
+                                       lda,
+                                       nullptr,
+                                       ldb,
+                                       nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     *lwork = sz;
@@ -2546,31 +2537,28 @@ try
     size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    hipsolverStatus_t status;
-    if(B == X)
-        status = rocblas2hip_status(rocsolver_zgels((rocblas_handle)handle,
-                                                    rocblas_operation_none,
-                                                    m,
-                                                    n,
-                                                    nrhs,
-                                                    nullptr,
-                                                    lda,
-                                                    nullptr,
-                                                    ldb,
-                                                    nullptr));
-    else
-        status = rocblas2hip_status(rocsolver_zgels_outofplace((rocblas_handle)handle,
-                                                               rocblas_operation_none,
-                                                               m,
-                                                               n,
-                                                               nrhs,
-                                                               nullptr,
-                                                               lda,
-                                                               nullptr,
-                                                               ldb,
-                                                               nullptr,
-                                                               ldx,
-                                                               nullptr));
+    hipsolverStatus_t status = rocblas2hip_status(rocsolver_zgels_outofplace((rocblas_handle)handle,
+                                                                             rocblas_operation_none,
+                                                                             m,
+                                                                             n,
+                                                                             nrhs,
+                                                                             nullptr,
+                                                                             lda,
+                                                                             nullptr,
+                                                                             ldb,
+                                                                             nullptr,
+                                                                             ldx,
+                                                                             nullptr));
+    rocblas2hip_status(rocsolver_zgels((rocblas_handle)handle,
+                                       rocblas_operation_none,
+                                       m,
+                                       n,
+                                       nrhs,
+                                       nullptr,
+                                       lda,
+                                       nullptr,
+                                       ldb,
+                                       nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     *lwork = sz;
@@ -3043,22 +3031,19 @@ try
     size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    hipsolverStatus_t status;
-    if(B == X)
-        status = rocblas2hip_status(rocsolver_sgesv(
-            (rocblas_handle)handle, n, nrhs, nullptr, lda, nullptr, nullptr, ldb, nullptr));
-    else
-        status = rocblas2hip_status(rocsolver_sgesv_outofplace((rocblas_handle)handle,
-                                                               n,
-                                                               nrhs,
-                                                               nullptr,
-                                                               lda,
-                                                               nullptr,
-                                                               nullptr,
-                                                               ldb,
-                                                               nullptr,
-                                                               ldx,
-                                                               nullptr));
+    hipsolverStatus_t status = rocblas2hip_status(rocsolver_sgesv_outofplace((rocblas_handle)handle,
+                                                                             n,
+                                                                             nrhs,
+                                                                             nullptr,
+                                                                             lda,
+                                                                             nullptr,
+                                                                             nullptr,
+                                                                             ldb,
+                                                                             nullptr,
+                                                                             ldx,
+                                                                             nullptr));
+    rocblas2hip_status(rocsolver_sgesv(
+        (rocblas_handle)handle, n, nrhs, nullptr, lda, nullptr, nullptr, ldb, nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -3094,22 +3079,19 @@ try
     size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    hipsolverStatus_t status;
-    if(B == X)
-        status = rocblas2hip_status(rocsolver_dgesv(
-            (rocblas_handle)handle, n, nrhs, nullptr, lda, nullptr, nullptr, ldb, nullptr));
-    else
-        status = rocblas2hip_status(rocsolver_dgesv_outofplace((rocblas_handle)handle,
-                                                               n,
-                                                               nrhs,
-                                                               nullptr,
-                                                               lda,
-                                                               nullptr,
-                                                               nullptr,
-                                                               ldb,
-                                                               nullptr,
-                                                               ldx,
-                                                               nullptr));
+    hipsolverStatus_t status = rocblas2hip_status(rocsolver_dgesv_outofplace((rocblas_handle)handle,
+                                                                             n,
+                                                                             nrhs,
+                                                                             nullptr,
+                                                                             lda,
+                                                                             nullptr,
+                                                                             nullptr,
+                                                                             ldb,
+                                                                             nullptr,
+                                                                             ldx,
+                                                                             nullptr));
+    rocblas2hip_status(rocsolver_dgesv(
+        (rocblas_handle)handle, n, nrhs, nullptr, lda, nullptr, nullptr, ldb, nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -3145,22 +3127,19 @@ try
     size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    hipsolverStatus_t status;
-    if(B == X)
-        status = rocblas2hip_status(rocsolver_cgesv(
-            (rocblas_handle)handle, n, nrhs, nullptr, lda, nullptr, nullptr, ldb, nullptr));
-    else
-        status = rocblas2hip_status(rocsolver_cgesv_outofplace((rocblas_handle)handle,
-                                                               n,
-                                                               nrhs,
-                                                               nullptr,
-                                                               lda,
-                                                               nullptr,
-                                                               nullptr,
-                                                               ldb,
-                                                               nullptr,
-                                                               ldx,
-                                                               nullptr));
+    hipsolverStatus_t status = rocblas2hip_status(rocsolver_cgesv_outofplace((rocblas_handle)handle,
+                                                                             n,
+                                                                             nrhs,
+                                                                             nullptr,
+                                                                             lda,
+                                                                             nullptr,
+                                                                             nullptr,
+                                                                             ldb,
+                                                                             nullptr,
+                                                                             ldx,
+                                                                             nullptr));
+    rocblas2hip_status(rocsolver_cgesv(
+        (rocblas_handle)handle, n, nrhs, nullptr, lda, nullptr, nullptr, ldb, nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
@@ -3196,22 +3175,19 @@ try
     size_t sz;
 
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
-    hipsolverStatus_t status;
-    if(B == X)
-        status = rocblas2hip_status(rocsolver_zgesv(
-            (rocblas_handle)handle, n, nrhs, nullptr, lda, nullptr, nullptr, ldb, nullptr));
-    else
-        status = rocblas2hip_status(rocsolver_zgesv_outofplace((rocblas_handle)handle,
-                                                               n,
-                                                               nrhs,
-                                                               nullptr,
-                                                               lda,
-                                                               nullptr,
-                                                               nullptr,
-                                                               ldb,
-                                                               nullptr,
-                                                               ldx,
-                                                               nullptr));
+    hipsolverStatus_t status = rocblas2hip_status(rocsolver_zgesv_outofplace((rocblas_handle)handle,
+                                                                             n,
+                                                                             nrhs,
+                                                                             nullptr,
+                                                                             lda,
+                                                                             nullptr,
+                                                                             nullptr,
+                                                                             ldb,
+                                                                             nullptr,
+                                                                             ldx,
+                                                                             nullptr));
+    rocblas2hip_status(rocsolver_zgesv(
+        (rocblas_handle)handle, n, nrhs, nullptr, lda, nullptr, nullptr, ldb, nullptr));
     rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -3640,7 +3640,7 @@ hipsolverStatus_t hipsolverSgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
+    rocblas_device_malloc mem((rocblas_handle)handle);
 
     if(work && lwork)
     {
@@ -3660,11 +3660,10 @@ try
 
         if(!rwork && min(m, n) > 1)
         {
-            mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
-                                                          sizeof(float) * min(m, n));
-            if(!mem->operator bool())
+            mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * min(m, n));
+            if(!mem)
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
-            rwork = (float*)(*mem)[0];
+            rwork = (float*)mem[0];
         }
     }
 
@@ -3707,7 +3706,7 @@ hipsolverStatus_t hipsolverDgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
+    rocblas_device_malloc mem((rocblas_handle)handle);
 
     if(work && lwork)
     {
@@ -3727,11 +3726,10 @@ try
 
         if(!rwork && min(m, n) > 1)
         {
-            mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
-                                                          sizeof(double) * min(m, n));
-            if(!mem->operator bool())
+            mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * min(m, n));
+            if(!mem)
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
-            rwork = (double*)(*mem)[0];
+            rwork = (double*)mem[0];
         }
     }
 
@@ -3774,7 +3772,7 @@ hipsolverStatus_t hipsolverCgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
+    rocblas_device_malloc mem((rocblas_handle)handle);
 
     if(work && lwork)
     {
@@ -3794,11 +3792,10 @@ try
 
         if(!rwork && min(m, n) > 1)
         {
-            mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
-                                                          sizeof(float) * min(m, n));
-            if(!mem->operator bool())
+            mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * min(m, n));
+            if(!mem)
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
-            rwork = (float*)(*mem)[0];
+            rwork = (float*)mem[0];
         }
     }
 
@@ -3841,7 +3838,7 @@ hipsolverStatus_t hipsolverZgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
+    rocblas_device_malloc mem((rocblas_handle)handle);
 
     if(work && lwork)
     {
@@ -3861,11 +3858,10 @@ try
 
         if(!rwork && min(m, n) > 1)
         {
-            mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
-                                                          sizeof(double) * min(m, n));
-            if(!mem->operator bool())
+            mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * min(m, n));
+            if(!mem)
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
-            rwork = (double*)(*mem)[0];
+            rwork = (double*)mem[0];
         }
     }
 
@@ -4194,9 +4190,9 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
-    float*                                 V_copy;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
+    float*                V_copy;
 
     const float one         = 1.0f;
     const float zero        = 0.0f;
@@ -4229,12 +4225,11 @@ try
             (rocblas_handle)handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv, &lwork, params));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>(
-            (rocblas_handle)handle, sizeof(float) * min(m, n), size_V_copy);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * min(m, n), size_V_copy);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E      = (float*)(*mem)[0];
-        V_copy = (float*)(*mem)[1];
+        E      = (float*)mem[0];
+        V_copy = (float*)mem[1];
     }
 
     // perform computation
@@ -4298,9 +4293,9 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
-    double*                                V_copy;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
+    double*               V_copy;
 
     const double one         = 1.0;
     const double zero        = 0.0;
@@ -4333,12 +4328,12 @@ try
             (rocblas_handle)handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv, &lwork, params));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>(
+        mem = rocblas_device_malloc(
             (rocblas_handle)handle, sizeof(double) * min(m, n), size_V_copy);
-        if(!mem->operator bool())
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E      = (double*)(*mem)[0];
-        V_copy = (double*)(*mem)[1];
+        E      = (double*)mem[0];
+        V_copy = (double*)mem[1];
     }
 
     // perform computation
@@ -4402,9 +4397,9 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
-    rocblas_float_complex*                 V_copy;
+    rocblas_device_malloc  mem((rocblas_handle)handle);
+    float*                 E;
+    rocblas_float_complex* V_copy;
 
     const rocblas_float_complex one         = {1.0f, 0.0f};
     const rocblas_float_complex zero        = {0.0f, 0.0f};
@@ -4437,12 +4432,11 @@ try
             (rocblas_handle)handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv, &lwork, params));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>(
-            (rocblas_handle)handle, sizeof(float) * min(m, n), size_V_copy);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * min(m, n), size_V_copy);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E      = (float*)(*mem)[0];
-        V_copy = (rocblas_float_complex*)(*mem)[1];
+        E      = (float*)mem[0];
+        V_copy = (rocblas_float_complex*)mem[1];
     }
 
     // perform computation
@@ -4506,9 +4500,9 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
-    rocblas_double_complex*                V_copy;
+    rocblas_device_malloc   mem((rocblas_handle)handle);
+    double*                 E;
+    rocblas_double_complex* V_copy;
 
     const rocblas_double_complex one         = {1.0, 0.0};
     const rocblas_double_complex zero        = {0.0, 0.0};
@@ -4541,12 +4535,12 @@ try
             (rocblas_handle)handle, jobz, econ, m, n, A, lda, S, U, ldu, V, ldv, &lwork, params));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>(
+        mem = rocblas_device_malloc(
             (rocblas_handle)handle, sizeof(double) * min(m, n), size_V_copy);
-        if(!mem->operator bool())
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E      = (double*)(*mem)[0];
-        V_copy = (rocblas_double_complex*)(*mem)[1];
+        E      = (double*)mem[0];
+        V_copy = (rocblas_double_complex*)mem[1];
     }
 
     // perform computation
@@ -4907,9 +4901,9 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
-    float*                                 V_copy;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
+    float*                V_copy;
 
     const float one         = 1.0f;
     const float zero        = 0.0f;
@@ -4954,12 +4948,12 @@ try
                                                                    batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>(
+        mem = rocblas_device_malloc(
             (rocblas_handle)handle, sizeof(float) * min(m, n) * batch_count, size_V_copy);
-        if(!mem->operator bool())
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E      = (float*)(*mem)[0];
-        V_copy = (float*)(*mem)[1];
+        E      = (float*)mem[0];
+        V_copy = (float*)mem[1];
     }
 
     // perform computation
@@ -5033,9 +5027,9 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
-    double*                                V_copy;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
+    double*               V_copy;
 
     const double one         = 1.0;
     const double zero        = 0.0;
@@ -5080,12 +5074,12 @@ try
                                                                    batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>(
+        mem = rocblas_device_malloc(
             (rocblas_handle)handle, sizeof(double) * min(m, n) * batch_count, size_V_copy);
-        if(!mem->operator bool())
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E      = (double*)(*mem)[0];
-        V_copy = (double*)(*mem)[1];
+        E      = (double*)mem[0];
+        V_copy = (double*)mem[1];
     }
 
     // perform computation
@@ -5159,9 +5153,9 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
-    rocblas_float_complex*                 V_copy;
+    rocblas_device_malloc  mem((rocblas_handle)handle);
+    float*                 E;
+    rocblas_float_complex* V_copy;
 
     const rocblas_float_complex one         = {1.0f, 0.0f};
     const rocblas_float_complex zero        = {0.0f, 0.0f};
@@ -5206,12 +5200,12 @@ try
                                                                    batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>(
+        mem = rocblas_device_malloc(
             (rocblas_handle)handle, sizeof(float) * min(m, n) * batch_count, size_V_copy);
-        if(!mem->operator bool())
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E      = (float*)(*mem)[0];
-        V_copy = (rocblas_float_complex*)(*mem)[1];
+        E      = (float*)mem[0];
+        V_copy = (rocblas_float_complex*)mem[1];
     }
 
     // perform computation
@@ -5286,9 +5280,9 @@ try
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
 
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
-    rocblas_double_complex*                V_copy;
+    rocblas_device_malloc   mem((rocblas_handle)handle);
+    double*                 E;
+    rocblas_double_complex* V_copy;
 
     const rocblas_double_complex one         = {1.0, 0.0};
     const rocblas_double_complex zero        = {0.0, 0.0};
@@ -5333,12 +5327,12 @@ try
                                                                    batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>(
+        mem = rocblas_device_malloc(
             (rocblas_handle)handle, sizeof(double) * min(m, n) * batch_count, size_V_copy);
-        if(!mem->operator bool())
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E      = (double*)(*mem)[0];
-        V_copy = (rocblas_double_complex*)(*mem)[1];
+        E      = (double*)mem[0];
+        V_copy = (rocblas_double_complex*)mem[1];
     }
 
     // perform computation
@@ -7546,8 +7540,8 @@ hipsolverStatus_t hipsolverSsyevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
 
     if(work && lwork)
     {
@@ -7563,10 +7557,10 @@ try
             hipsolverSsyevd_bufferSize((rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (float*)(*mem)[0];
+        E = (float*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_ssyevd((rocblas_handle)handle,
@@ -7596,8 +7590,8 @@ hipsolverStatus_t hipsolverDsyevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
 
     if(work && lwork)
     {
@@ -7613,10 +7607,10 @@ try
             hipsolverDsyevd_bufferSize((rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (double*)(*mem)[0];
+        E = (double*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_dsyevd((rocblas_handle)handle,
@@ -7646,8 +7640,8 @@ hipsolverStatus_t hipsolverCheevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
 
     if(work && lwork)
     {
@@ -7663,10 +7657,10 @@ try
             hipsolverCheevd_bufferSize((rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (float*)(*mem)[0];
+        E = (float*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_cheevd((rocblas_handle)handle,
@@ -7696,8 +7690,8 @@ hipsolverStatus_t hipsolverZheevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
 
     if(work && lwork)
     {
@@ -7713,10 +7707,10 @@ try
             hipsolverZheevd_bufferSize((rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (double*)(*mem)[0];
+        E = (double*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_zheevd((rocblas_handle)handle,
@@ -7956,8 +7950,8 @@ hipsolverStatus_t hipsolverDnSsyevj(hipsolverDnHandle_t  handle,
                                     hipsolverSyevjInfo_t params)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
 
     if(work && lwork)
     {
@@ -7973,10 +7967,10 @@ try
             (rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork, params));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (float*)(*mem)[0];
+        E = (float*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_ssyevd((rocblas_handle)handle,
@@ -8007,8 +8001,8 @@ hipsolverStatus_t hipsolverDnDsyevj(hipsolverDnHandle_t  handle,
                                     hipsolverSyevjInfo_t params)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
 
     if(work && lwork)
     {
@@ -8024,10 +8018,10 @@ try
             (rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork, params));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (double*)(*mem)[0];
+        E = (double*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_dsyevd((rocblas_handle)handle,
@@ -8058,8 +8052,8 @@ hipsolverStatus_t hipsolverDnCheevj(hipsolverDnHandle_t  handle,
                                     hipsolverSyevjInfo_t params)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
 
     if(work && lwork)
     {
@@ -8075,10 +8069,10 @@ try
             (rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork, params));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (float*)(*mem)[0];
+        E = (float*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_cheevd((rocblas_handle)handle,
@@ -8109,8 +8103,8 @@ hipsolverStatus_t hipsolverDnZheevj(hipsolverDnHandle_t  handle,
                                     hipsolverSyevjInfo_t params)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
 
     if(work && lwork)
     {
@@ -8126,10 +8120,10 @@ try
             (rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork, params));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (double*)(*mem)[0];
+        E = (double*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_zheevd((rocblas_handle)handle,
@@ -8394,8 +8388,8 @@ hipsolverStatus_t hipsolverDnSsyevjBatched(hipsolverDnHandle_t  handle,
                                            int                  batch_count)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
 
     if(work && lwork)
     {
@@ -8411,11 +8405,10 @@ try
             (rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork, params, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
-                                                      sizeof(float) * n * batch_count);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * n * batch_count);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (float*)(*mem)[0];
+        E = (float*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_ssyevd_strided_batched((rocblas_handle)handle,
@@ -8451,8 +8444,8 @@ hipsolverStatus_t hipsolverDnDsyevjBatched(hipsolverDnHandle_t  handle,
                                            int                  batch_count)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
 
     if(work && lwork)
     {
@@ -8468,11 +8461,10 @@ try
             (rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork, params, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
-                                                      sizeof(double) * n * batch_count);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * n * batch_count);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (double*)(*mem)[0];
+        E = (double*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_dsyevd_strided_batched((rocblas_handle)handle,
@@ -8508,8 +8500,8 @@ hipsolverStatus_t hipsolverDnCheevjBatched(hipsolverDnHandle_t  handle,
                                            int                  batch_count)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
 
     if(work && lwork)
     {
@@ -8525,11 +8517,10 @@ try
             (rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork, params, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
-                                                      sizeof(float) * n * batch_count);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * n * batch_count);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (float*)(*mem)[0];
+        E = (float*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_cheevd_strided_batched((rocblas_handle)handle,
@@ -8565,8 +8556,8 @@ hipsolverStatus_t hipsolverDnZheevjBatched(hipsolverDnHandle_t  handle,
                                            int                  batch_count)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
 
     if(work && lwork)
     {
@@ -8582,11 +8573,10 @@ try
             (rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork, params, batch_count));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
-                                                      sizeof(double) * n * batch_count);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * n * batch_count);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (double*)(*mem)[0];
+        E = (double*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_zheevd_strided_batched((rocblas_handle)handle,
@@ -8864,8 +8854,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
 
     if(work && lwork)
     {
@@ -8881,10 +8871,10 @@ try
             (rocblas_handle)handle, itype, jobz, uplo, n, A, lda, B, ldb, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (float*)(*mem)[0];
+        E = (float*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_ssygvd((rocblas_handle)handle,
@@ -8920,8 +8910,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsygvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
 
     if(work && lwork)
     {
@@ -8937,10 +8927,10 @@ try
             (rocblas_handle)handle, itype, jobz, uplo, n, A, lda, B, ldb, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (double*)(*mem)[0];
+        E = (double*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_dsygvd((rocblas_handle)handle,
@@ -8976,8 +8966,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    float*                                 E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    float*                E;
 
     if(work && lwork)
     {
@@ -8993,10 +8983,10 @@ try
             (rocblas_handle)handle, itype, jobz, uplo, n, A, lda, B, ldb, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(float) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (float*)(*mem)[0];
+        E = (float*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_chegvd((rocblas_handle)handle,
@@ -9032,8 +9022,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
-    std::unique_ptr<rocblas_device_malloc> mem;
-    double*                                E;
+    rocblas_device_malloc mem((rocblas_handle)handle);
+    double*               E;
 
     if(work && lwork)
     {
@@ -9049,10 +9039,10 @@ try
             (rocblas_handle)handle, itype, jobz, uplo, n, A, lda, B, ldb, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem->operator bool())
+        mem = rocblas_device_malloc((rocblas_handle)handle, sizeof(double) * n);
+        if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        E = (double*)(*mem)[0];
+        E = (double*)mem[0];
     }
 
     return rocblas2hip_status(rocsolver_zhegvd((rocblas_handle)handle,

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -3252,6 +3252,11 @@ try
     if(min(m, n) > 0)
         sz += sizeof(float) * min(m, n);
 
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
     if(sz > INT_MAX)
@@ -3298,6 +3303,11 @@ try
     // space for E array (aka rwork)
     if(min(m, n) > 0)
         sz += sizeof(double) * min(m, n);
+
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
@@ -3346,6 +3356,11 @@ try
     if(min(m, n) > 0)
         sz += sizeof(float) * min(m, n);
 
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
     if(sz > INT_MAX)
@@ -3392,6 +3407,11 @@ try
     // space for E array (aka rwork)
     if(min(m, n) > 0)
         sz += sizeof(double) * min(m, n);
+
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
@@ -5686,6 +5706,11 @@ try
     if(n > 0)
         sz += sizeof(float) * n;
 
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
     if(sz > INT_MAX)
@@ -5732,6 +5757,11 @@ try
     // space for E array
     if(n > 0)
         sz += sizeof(double) * n;
+
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
@@ -5780,6 +5810,11 @@ try
     if(n > 0)
         sz += sizeof(float) * n;
 
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
     if(sz > INT_MAX)
@@ -5826,6 +5861,11 @@ try
     // space for E array
     if(n > 0)
         sz += sizeof(double) * n;
+
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
@@ -6109,6 +6149,11 @@ try
     if(n > 0)
         sz += sizeof(float) * n;
 
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
     if(sz > INT_MAX)
@@ -6161,6 +6206,11 @@ try
     // space for E array
     if(n > 0)
         sz += sizeof(double) * n;
+
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
@@ -6215,6 +6265,11 @@ try
     if(n > 0)
         sz += sizeof(float) * n;
 
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
+
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;
     if(sz > INT_MAX)
@@ -6267,6 +6322,11 @@ try
     // space for E array
     if(n > 0)
         sz += sizeof(double) * n;
+
+    // update size
+    rocblas_start_device_memory_size_query((rocblas_handle)handle);
+    rocblas_set_optimal_device_memory_size((rocblas_handle)handle, sz);
+    rocblas_stop_device_memory_size_query((rocblas_handle)handle, &sz);
 
     if(status != HIPSOLVER_STATUS_SUCCESS)
         return status;

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -396,6 +396,8 @@ hipsolverStatus_t hipsolverSorgbr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -431,6 +433,8 @@ hipsolverStatus_t hipsolverDorgbr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -466,6 +470,8 @@ hipsolverStatus_t hipsolverCungbr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -501,6 +507,8 @@ hipsolverStatus_t hipsolverZungbr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -662,6 +670,8 @@ hipsolverStatus_t hipsolverSorgqr_bufferSize(
     hipsolverHandle_t handle, int m, int n, int k, float* A, int lda, float* tau, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -690,6 +700,8 @@ hipsolverStatus_t hipsolverDorgqr_bufferSize(
     hipsolverHandle_t handle, int m, int n, int k, double* A, int lda, double* tau, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -724,6 +736,8 @@ hipsolverStatus_t hipsolverCungqr_bufferSize(hipsolverHandle_t handle,
                                              int*              lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -758,6 +772,8 @@ hipsolverStatus_t hipsolverZungqr_bufferSize(hipsolverHandle_t handle,
                                              int*              lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -916,6 +932,8 @@ hipsolverStatus_t hipsolverSorgtr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -949,6 +967,8 @@ hipsolverStatus_t hipsolverDorgtr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -982,6 +1002,8 @@ hipsolverStatus_t hipsolverCungtr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1015,6 +1037,8 @@ hipsolverStatus_t hipsolverZungtr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1174,6 +1198,8 @@ hipsolverStatus_t hipsolverSormqr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1221,6 +1247,8 @@ hipsolverStatus_t hipsolverDormqr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1268,6 +1296,8 @@ hipsolverStatus_t hipsolverCunmqr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1315,6 +1345,8 @@ hipsolverStatus_t hipsolverZunmqr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1531,6 +1563,8 @@ hipsolverStatus_t hipsolverSormtr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1578,6 +1612,8 @@ hipsolverStatus_t hipsolverDormtr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1625,6 +1661,8 @@ hipsolverStatus_t hipsolverCunmtr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1672,6 +1710,8 @@ hipsolverStatus_t hipsolverZunmtr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1877,6 +1917,8 @@ catch(...)
 hipsolverStatus_t hipsolverSgebrd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1904,6 +1946,8 @@ catch(...)
 hipsolverStatus_t hipsolverDgebrd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1931,6 +1975,8 @@ catch(...)
 hipsolverStatus_t hipsolverCgebrd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -1958,6 +2004,8 @@ catch(...)
 hipsolverStatus_t hipsolverZgebrd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2130,6 +2178,8 @@ hipsolverStatus_t hipsolverSSgels_bufferSize(hipsolverHandle_t handle,
                                              size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2185,6 +2235,8 @@ hipsolverStatus_t hipsolverDDgels_bufferSize(hipsolverHandle_t handle,
                                              size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2240,6 +2292,8 @@ hipsolverStatus_t hipsolverCCgels_bufferSize(hipsolverHandle_t handle,
                                              size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2295,6 +2349,8 @@ hipsolverStatus_t hipsolverZZgels_bufferSize(hipsolverHandle_t handle,
                                              size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2546,6 +2602,8 @@ hipsolverStatus_t hipsolverSgeqrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2574,6 +2632,8 @@ hipsolverStatus_t hipsolverDgeqrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2602,6 +2662,8 @@ hipsolverStatus_t hipsolverCgeqrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2630,6 +2692,8 @@ hipsolverStatus_t hipsolverZgeqrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2782,6 +2846,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSSgesv_bufferSize(hipsolverHandle_t 
                                                               size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2831,6 +2897,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDDgesv_bufferSize(hipsolverHandle_t 
                                                               size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2880,6 +2948,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCCgesv_bufferSize(hipsolverHandle_t 
                                                               size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -2929,6 +2999,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZZgesv_bufferSize(hipsolverHandle_t 
                                                               size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3150,6 +3222,8 @@ hipsolverStatus_t hipsolverSgesvd_bufferSize(
     hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3195,6 +3269,8 @@ hipsolverStatus_t hipsolverDgesvd_bufferSize(
     hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3240,6 +3316,8 @@ hipsolverStatus_t hipsolverCgesvd_bufferSize(
     hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3285,6 +3363,8 @@ hipsolverStatus_t hipsolverZgesvd_bufferSize(
     hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3651,6 +3731,8 @@ hipsolverStatus_t hipsolverSgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3680,6 +3762,8 @@ hipsolverStatus_t hipsolverDgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3709,6 +3793,8 @@ hipsolverStatus_t hipsolverCgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3738,6 +3824,8 @@ hipsolverStatus_t hipsolverZgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3904,6 +3992,8 @@ hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3947,6 +4037,8 @@ hipsolverStatus_t hipsolverDgetrs_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -3990,6 +4082,8 @@ hipsolverStatus_t hipsolverCgetrs_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4033,6 +4127,8 @@ hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4207,6 +4303,8 @@ hipsolverStatus_t hipsolverSpotrf_bufferSize(
     hipsolverHandle_t handle, hipsolverFillMode_t uplo, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4235,6 +4333,8 @@ hipsolverStatus_t hipsolverDpotrf_bufferSize(
     hipsolverHandle_t handle, hipsolverFillMode_t uplo, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4267,6 +4367,8 @@ hipsolverStatus_t hipsolverCpotrf_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4299,6 +4401,8 @@ hipsolverStatus_t hipsolverZpotrf_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4449,6 +4553,8 @@ hipsolverStatus_t hipsolverSpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4482,6 +4588,8 @@ hipsolverStatus_t hipsolverDpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4515,6 +4623,8 @@ hipsolverStatus_t hipsolverCpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4548,6 +4658,8 @@ hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4699,6 +4811,8 @@ hipsolverStatus_t hipsolverSpotri_bufferSize(
     hipsolverHandle_t handle, hipsolverFillMode_t uplo, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4727,6 +4841,8 @@ hipsolverStatus_t hipsolverDpotri_bufferSize(
     hipsolverHandle_t handle, hipsolverFillMode_t uplo, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4759,6 +4875,8 @@ hipsolverStatus_t hipsolverCpotri_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4791,6 +4909,8 @@ hipsolverStatus_t hipsolverZpotri_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4943,6 +5063,8 @@ hipsolverStatus_t hipsolverSpotrs_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -4978,6 +5100,8 @@ hipsolverStatus_t hipsolverDpotrs_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5013,6 +5137,8 @@ hipsolverStatus_t hipsolverCpotrs_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5048,6 +5174,8 @@ hipsolverStatus_t hipsolverZpotrs_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5217,6 +5345,8 @@ hipsolverStatus_t hipsolverSpotrsBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5260,6 +5390,8 @@ hipsolverStatus_t hipsolverDpotrsBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5303,6 +5435,8 @@ hipsolverStatus_t hipsolverCpotrsBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5346,6 +5480,8 @@ hipsolverStatus_t hipsolverZpotrsBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5526,6 +5662,8 @@ hipsolverStatus_t hipsolverSsyevd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5571,6 +5709,8 @@ hipsolverStatus_t hipsolverDsyevd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5616,6 +5756,8 @@ hipsolverStatus_t hipsolverCheevd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5661,6 +5803,8 @@ hipsolverStatus_t hipsolverZheevd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5938,6 +6082,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvd_bufferSize(hipsolverHandle_t 
                                                               int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -5989,6 +6135,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsygvd_bufferSize(hipsolverHandle_t 
                                                               int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6040,6 +6188,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd_bufferSize(hipsolverHandle_t 
                                                               int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6091,6 +6241,8 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSize(hipsolverHandle_t 
                                                               int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6405,6 +6557,8 @@ hipsolverStatus_t hipsolverSsytrd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6446,6 +6600,8 @@ hipsolverStatus_t hipsolverDsytrd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6487,6 +6643,8 @@ hipsolverStatus_t hipsolverChetrd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6528,6 +6686,8 @@ hipsolverStatus_t hipsolverZhetrd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6695,6 +6855,8 @@ hipsolverStatus_t
     hipsolverSsytrf_bufferSize(hipsolverHandle_t handle, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6723,6 +6885,8 @@ hipsolverStatus_t
     hipsolverDsytrf_bufferSize(hipsolverHandle_t handle, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6751,6 +6915,8 @@ hipsolverStatus_t hipsolverCsytrf_bufferSize(
     hipsolverHandle_t handle, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -6779,6 +6945,8 @@ hipsolverStatus_t hipsolverZsytrf_bufferSize(
     hipsolverHandle_t handle, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -3475,7 +3475,7 @@ try
         {
             mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
                                                           sizeof(float) * min(m, n));
-            if(!mem)
+            if(!mem->operator bool())
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
             rwork = (float*)(*mem)[0];
         }
@@ -3542,7 +3542,7 @@ try
         {
             mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
                                                           sizeof(double) * min(m, n));
-            if(!mem)
+            if(!mem->operator bool())
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
             rwork = (double*)(*mem)[0];
         }
@@ -3609,7 +3609,7 @@ try
         {
             mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
                                                           sizeof(float) * min(m, n));
-            if(!mem)
+            if(!mem->operator bool())
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
             rwork = (float*)(*mem)[0];
         }
@@ -3676,7 +3676,7 @@ try
         {
             mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
                                                           sizeof(double) * min(m, n));
-            if(!mem)
+            if(!mem->operator bool())
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
             rwork = (double*)(*mem)[0];
         }
@@ -5875,7 +5875,7 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
         mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem)
+        if(!mem->operator bool())
             return HIPSOLVER_STATUS_ALLOC_FAILED;
         E = (float*)(*mem)[0];
     }
@@ -5925,7 +5925,7 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
         mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem)
+        if(!mem->operator bool())
             return HIPSOLVER_STATUS_ALLOC_FAILED;
         E = (double*)(*mem)[0];
     }
@@ -5975,7 +5975,7 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
         mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem)
+        if(!mem->operator bool())
             return HIPSOLVER_STATUS_ALLOC_FAILED;
         E = (float*)(*mem)[0];
     }
@@ -6025,7 +6025,7 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
         mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem)
+        if(!mem->operator bool())
             return HIPSOLVER_STATUS_ALLOC_FAILED;
         E = (double*)(*mem)[0];
     }
@@ -6319,7 +6319,7 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
         mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem)
+        if(!mem->operator bool())
             return HIPSOLVER_STATUS_ALLOC_FAILED;
         E = (float*)(*mem)[0];
     }
@@ -6375,7 +6375,7 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
         mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem)
+        if(!mem->operator bool())
             return HIPSOLVER_STATUS_ALLOC_FAILED;
         E = (double*)(*mem)[0];
     }
@@ -6431,7 +6431,7 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
         mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
-        if(!mem)
+        if(!mem->operator bool())
             return HIPSOLVER_STATUS_ALLOC_FAILED;
         E = (float*)(*mem)[0];
     }
@@ -6487,7 +6487,7 @@ try
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
         mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
-        if(!mem)
+        if(!mem->operator bool())
             return HIPSOLVER_STATUS_ALLOC_FAILED;
         E = (double*)(*mem)[0];
     }

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -17,6 +17,7 @@
 #include <functional>
 #include <iostream>
 #include <math.h>
+#include <memory>
 
 using namespace std;
 
@@ -3444,6 +3445,8 @@ hipsolverStatus_t hipsolverSgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+
     if(work && lwork)
     {
         if(!rwork && min(m, n) > 1)
@@ -3453,22 +3456,6 @@ try
         }
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_sgesvd((rocblas_handle)handle,
-                                                   char2rocblas_svect(jobu),
-                                                   char2rocblas_svect(jobv),
-                                                   m,
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   S,
-                                                   U,
-                                                   ldu,
-                                                   V,
-                                                   ldv,
-                                                   rwork,
-                                                   rocblas_outofplace,
-                                                   devInfo));
     }
     else
     {
@@ -3476,30 +3463,31 @@ try
             hipsolverSgesvd_bufferSize((rocblas_handle)handle, jobu, jobv, m, n, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(float) * min(m, n));
         if(!rwork && min(m, n) > 1)
         {
+            mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
+                                                          sizeof(float) * min(m, n));
             if(!mem)
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
-            rwork = (float*)mem[0];
+            rwork = (float*)(*mem)[0];
         }
-
-        return rocblas2hip_status(rocsolver_sgesvd((rocblas_handle)handle,
-                                                   char2rocblas_svect(jobu),
-                                                   char2rocblas_svect(jobv),
-                                                   m,
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   S,
-                                                   U,
-                                                   ldu,
-                                                   V,
-                                                   ldv,
-                                                   rwork,
-                                                   rocblas_outofplace,
-                                                   devInfo));
     }
+
+    return rocblas2hip_status(rocsolver_sgesvd((rocblas_handle)handle,
+                                               char2rocblas_svect(jobu),
+                                               char2rocblas_svect(jobv),
+                                               m,
+                                               n,
+                                               A,
+                                               lda,
+                                               S,
+                                               U,
+                                               ldu,
+                                               V,
+                                               ldv,
+                                               rwork,
+                                               rocblas_outofplace,
+                                               devInfo));
 }
 catch(...)
 {
@@ -3524,6 +3512,8 @@ hipsolverStatus_t hipsolverDgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+
     if(work && lwork)
     {
         if(!rwork && min(m, n) > 1)
@@ -3533,22 +3523,6 @@ try
         }
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_dgesvd((rocblas_handle)handle,
-                                                   char2rocblas_svect(jobu),
-                                                   char2rocblas_svect(jobv),
-                                                   m,
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   S,
-                                                   U,
-                                                   ldu,
-                                                   V,
-                                                   ldv,
-                                                   rwork,
-                                                   rocblas_outofplace,
-                                                   devInfo));
     }
     else
     {
@@ -3556,30 +3530,31 @@ try
             hipsolverDgesvd_bufferSize((rocblas_handle)handle, jobu, jobv, m, n, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(double) * min(m, n));
         if(!rwork && min(m, n) > 1)
         {
+            mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
+                                                          sizeof(double) * min(m, n));
             if(!mem)
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
-            rwork = (double*)mem[0];
+            rwork = (double*)(*mem)[0];
         }
-
-        return rocblas2hip_status(rocsolver_dgesvd((rocblas_handle)handle,
-                                                   char2rocblas_svect(jobu),
-                                                   char2rocblas_svect(jobv),
-                                                   m,
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   S,
-                                                   U,
-                                                   ldu,
-                                                   V,
-                                                   ldv,
-                                                   rwork,
-                                                   rocblas_outofplace,
-                                                   devInfo));
     }
+
+    return rocblas2hip_status(rocsolver_dgesvd((rocblas_handle)handle,
+                                               char2rocblas_svect(jobu),
+                                               char2rocblas_svect(jobv),
+                                               m,
+                                               n,
+                                               A,
+                                               lda,
+                                               S,
+                                               U,
+                                               ldu,
+                                               V,
+                                               ldv,
+                                               rwork,
+                                               rocblas_outofplace,
+                                               devInfo));
 }
 catch(...)
 {
@@ -3604,6 +3579,8 @@ hipsolverStatus_t hipsolverCgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+
     if(work && lwork)
     {
         if(!rwork && min(m, n) > 1)
@@ -3613,22 +3590,6 @@ try
         }
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_cgesvd((rocblas_handle)handle,
-                                                   char2rocblas_svect(jobu),
-                                                   char2rocblas_svect(jobv),
-                                                   m,
-                                                   n,
-                                                   (rocblas_float_complex*)A,
-                                                   lda,
-                                                   S,
-                                                   (rocblas_float_complex*)U,
-                                                   ldu,
-                                                   (rocblas_float_complex*)V,
-                                                   ldv,
-                                                   rwork,
-                                                   rocblas_outofplace,
-                                                   devInfo));
     }
     else
     {
@@ -3636,30 +3597,31 @@ try
             hipsolverCgesvd_bufferSize((rocblas_handle)handle, jobu, jobv, m, n, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(float) * min(m, n));
         if(!rwork && min(m, n) > 1)
         {
+            mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
+                                                          sizeof(float) * min(m, n));
             if(!mem)
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
-            rwork = (float*)mem[0];
+            rwork = (float*)(*mem)[0];
         }
-
-        return rocblas2hip_status(rocsolver_cgesvd((rocblas_handle)handle,
-                                                   char2rocblas_svect(jobu),
-                                                   char2rocblas_svect(jobv),
-                                                   m,
-                                                   n,
-                                                   (rocblas_float_complex*)A,
-                                                   lda,
-                                                   S,
-                                                   (rocblas_float_complex*)U,
-                                                   ldu,
-                                                   (rocblas_float_complex*)V,
-                                                   ldv,
-                                                   rwork,
-                                                   rocblas_outofplace,
-                                                   devInfo));
     }
+
+    return rocblas2hip_status(rocsolver_cgesvd((rocblas_handle)handle,
+                                               char2rocblas_svect(jobu),
+                                               char2rocblas_svect(jobv),
+                                               m,
+                                               n,
+                                               (rocblas_float_complex*)A,
+                                               lda,
+                                               S,
+                                               (rocblas_float_complex*)U,
+                                               ldu,
+                                               (rocblas_float_complex*)V,
+                                               ldv,
+                                               rwork,
+                                               rocblas_outofplace,
+                                               devInfo));
 }
 catch(...)
 {
@@ -3684,6 +3646,8 @@ hipsolverStatus_t hipsolverZgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+
     if(work && lwork)
     {
         if(!rwork && min(m, n) > 1)
@@ -3693,22 +3657,6 @@ try
         }
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_zgesvd((rocblas_handle)handle,
-                                                   char2rocblas_svect(jobu),
-                                                   char2rocblas_svect(jobv),
-                                                   m,
-                                                   n,
-                                                   (rocblas_double_complex*)A,
-                                                   lda,
-                                                   S,
-                                                   (rocblas_double_complex*)U,
-                                                   ldu,
-                                                   (rocblas_double_complex*)V,
-                                                   ldv,
-                                                   rwork,
-                                                   rocblas_outofplace,
-                                                   devInfo));
     }
     else
     {
@@ -3716,30 +3664,31 @@ try
             hipsolverZgesvd_bufferSize((rocblas_handle)handle, jobu, jobv, m, n, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(double) * min(m, n));
         if(!rwork && min(m, n) > 1)
         {
+            mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle,
+                                                          sizeof(double) * min(m, n));
             if(!mem)
                 return HIPSOLVER_STATUS_ALLOC_FAILED;
-            rwork = (double*)mem[0];
+            rwork = (double*)(*mem)[0];
         }
-
-        return rocblas2hip_status(rocsolver_zgesvd((rocblas_handle)handle,
-                                                   char2rocblas_svect(jobu),
-                                                   char2rocblas_svect(jobv),
-                                                   m,
-                                                   n,
-                                                   (rocblas_double_complex*)A,
-                                                   lda,
-                                                   S,
-                                                   (rocblas_double_complex*)U,
-                                                   ldu,
-                                                   (rocblas_double_complex*)V,
-                                                   ldv,
-                                                   rwork,
-                                                   rocblas_outofplace,
-                                                   devInfo));
     }
+
+    return rocblas2hip_status(rocsolver_zgesvd((rocblas_handle)handle,
+                                               char2rocblas_svect(jobu),
+                                               char2rocblas_svect(jobv),
+                                               m,
+                                               n,
+                                               (rocblas_double_complex*)A,
+                                               lda,
+                                               S,
+                                               (rocblas_double_complex*)U,
+                                               ldu,
+                                               (rocblas_double_complex*)V,
+                                               ldv,
+                                               rwork,
+                                               rocblas_outofplace,
+                                               devInfo));
 }
 catch(...)
 {
@@ -5892,23 +5841,16 @@ hipsolverStatus_t hipsolverSsyevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+    float*                                 E;
+
     if(work && lwork)
     {
-        float* E = work;
+        E = work;
         if(n > 0)
             work = E + n;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_ssyevd((rocblas_handle)handle,
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   D,
-                                                   E,
-                                                   devInfo));
     }
     else
     {
@@ -5916,21 +5858,21 @@ try
             hipsolverSsyevd_bufferSize((rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(float) * n);
+        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
         if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        float* E = (float*)mem[0];
-
-        return rocblas2hip_status(rocsolver_ssyevd((rocblas_handle)handle,
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   D,
-                                                   E,
-                                                   devInfo));
+        E = (float*)(*mem)[0];
     }
+
+    return rocblas2hip_status(rocsolver_ssyevd((rocblas_handle)handle,
+                                               hip2rocblas_evect(jobz),
+                                               hip2rocblas_fill(uplo),
+                                               n,
+                                               A,
+                                               lda,
+                                               D,
+                                               E,
+                                               devInfo));
 }
 catch(...)
 {
@@ -5949,23 +5891,16 @@ hipsolverStatus_t hipsolverDsyevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+    double*                                E;
+
     if(work && lwork)
     {
-        double* E = work;
+        E = work;
         if(n > 0)
             work = E + n;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_dsyevd((rocblas_handle)handle,
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   D,
-                                                   E,
-                                                   devInfo));
     }
     else
     {
@@ -5973,21 +5908,21 @@ try
             hipsolverDsyevd_bufferSize((rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(double) * n);
+        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
         if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        double* E = (double*)mem[0];
-
-        return rocblas2hip_status(rocsolver_dsyevd((rocblas_handle)handle,
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   D,
-                                                   E,
-                                                   devInfo));
+        E = (double*)(*mem)[0];
     }
+
+    return rocblas2hip_status(rocsolver_dsyevd((rocblas_handle)handle,
+                                               hip2rocblas_evect(jobz),
+                                               hip2rocblas_fill(uplo),
+                                               n,
+                                               A,
+                                               lda,
+                                               D,
+                                               E,
+                                               devInfo));
 }
 catch(...)
 {
@@ -6006,23 +5941,16 @@ hipsolverStatus_t hipsolverCheevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+    float*                                 E;
+
     if(work && lwork)
     {
-        float* E = (float*)work;
+        E = (float*)work;
         if(n > 0)
             work = (hipFloatComplex*)(E + n);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_cheevd((rocblas_handle)handle,
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   (rocblas_float_complex*)A,
-                                                   lda,
-                                                   D,
-                                                   E,
-                                                   devInfo));
     }
     else
     {
@@ -6030,21 +5958,21 @@ try
             hipsolverCheevd_bufferSize((rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(float) * n);
+        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
         if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        float* E = (float*)mem[0];
-
-        return rocblas2hip_status(rocsolver_cheevd((rocblas_handle)handle,
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   (rocblas_float_complex*)A,
-                                                   lda,
-                                                   D,
-                                                   E,
-                                                   devInfo));
+        E = (float*)(*mem)[0];
     }
+
+    return rocblas2hip_status(rocsolver_cheevd((rocblas_handle)handle,
+                                               hip2rocblas_evect(jobz),
+                                               hip2rocblas_fill(uplo),
+                                               n,
+                                               (rocblas_float_complex*)A,
+                                               lda,
+                                               D,
+                                               E,
+                                               devInfo));
 }
 catch(...)
 {
@@ -6063,23 +5991,16 @@ hipsolverStatus_t hipsolverZheevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+    double*                                E;
+
     if(work && lwork)
     {
-        double* E = (double*)work;
+        E = (double*)work;
         if(n > 0)
             work = (hipDoubleComplex*)(E + n);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_zheevd((rocblas_handle)handle,
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   (rocblas_double_complex*)A,
-                                                   lda,
-                                                   D,
-                                                   E,
-                                                   devInfo));
     }
     else
     {
@@ -6087,21 +6008,21 @@ try
             hipsolverZheevd_bufferSize((rocblas_handle)handle, jobz, uplo, n, A, lda, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(double) * n);
+        mem = std::make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
         if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        double* E = (double*)mem[0];
-
-        return rocblas2hip_status(rocsolver_zheevd((rocblas_handle)handle,
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   (rocblas_double_complex*)A,
-                                                   lda,
-                                                   D,
-                                                   E,
-                                                   devInfo));
+        E = (double*)(*mem)[0];
     }
+
+    return rocblas2hip_status(rocsolver_zheevd((rocblas_handle)handle,
+                                               hip2rocblas_evect(jobz),
+                                               hip2rocblas_fill(uplo),
+                                               n,
+                                               (rocblas_double_complex*)A,
+                                               lda,
+                                               D,
+                                               E,
+                                               devInfo));
 }
 catch(...)
 {
@@ -6356,26 +6277,16 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+    float*                                 E;
+
     if(work && lwork)
     {
-        float* E = work;
+        E = work;
         if(n > 0)
             work = E + n;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_ssygvd((rocblas_handle)handle,
-                                                   hip2rocblas_eform(itype),
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   B,
-                                                   ldb,
-                                                   D,
-                                                   E,
-                                                   devInfo));
     }
     else
     {
@@ -6383,24 +6294,24 @@ try
             (rocblas_handle)handle, itype, jobz, uplo, n, A, lda, B, ldb, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(float) * n);
+        mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
         if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        float* E = (float*)mem[0];
-
-        return rocblas2hip_status(rocsolver_ssygvd((rocblas_handle)handle,
-                                                   hip2rocblas_eform(itype),
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   B,
-                                                   ldb,
-                                                   D,
-                                                   E,
-                                                   devInfo));
+        E = (float*)(*mem)[0];
     }
+
+    return rocblas2hip_status(rocsolver_ssygvd((rocblas_handle)handle,
+                                               hip2rocblas_eform(itype),
+                                               hip2rocblas_evect(jobz),
+                                               hip2rocblas_fill(uplo),
+                                               n,
+                                               A,
+                                               lda,
+                                               B,
+                                               ldb,
+                                               D,
+                                               E,
+                                               devInfo));
 }
 catch(...)
 {
@@ -6422,26 +6333,16 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsygvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+    double*                                E;
+
     if(work && lwork)
     {
-        double* E = work;
+        E = work;
         if(n > 0)
             work = E + n;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_dsygvd((rocblas_handle)handle,
-                                                   hip2rocblas_eform(itype),
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   B,
-                                                   ldb,
-                                                   D,
-                                                   E,
-                                                   devInfo));
     }
     else
     {
@@ -6449,24 +6350,24 @@ try
             (rocblas_handle)handle, itype, jobz, uplo, n, A, lda, B, ldb, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(double) * n);
+        mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
         if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        double* E = (double*)mem[0];
-
-        return rocblas2hip_status(rocsolver_dsygvd((rocblas_handle)handle,
-                                                   hip2rocblas_eform(itype),
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   A,
-                                                   lda,
-                                                   B,
-                                                   ldb,
-                                                   D,
-                                                   E,
-                                                   devInfo));
+        E = (double*)(*mem)[0];
     }
+
+    return rocblas2hip_status(rocsolver_dsygvd((rocblas_handle)handle,
+                                               hip2rocblas_eform(itype),
+                                               hip2rocblas_evect(jobz),
+                                               hip2rocblas_fill(uplo),
+                                               n,
+                                               A,
+                                               lda,
+                                               B,
+                                               ldb,
+                                               D,
+                                               E,
+                                               devInfo));
 }
 catch(...)
 {
@@ -6488,26 +6389,16 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+    float*                                 E;
+
     if(work && lwork)
     {
-        float* E = (float*)work;
+        E = (float*)work;
         if(n > 0)
             work = (hipFloatComplex*)(E + n);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_chegvd((rocblas_handle)handle,
-                                                   hip2rocblas_eform(itype),
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   (rocblas_float_complex*)A,
-                                                   lda,
-                                                   (rocblas_float_complex*)B,
-                                                   ldb,
-                                                   D,
-                                                   E,
-                                                   devInfo));
     }
     else
     {
@@ -6515,24 +6406,24 @@ try
             (rocblas_handle)handle, itype, jobz, uplo, n, A, lda, B, ldb, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(float) * n);
+        mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(float) * n);
         if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        float* E = (float*)mem[0];
-
-        return rocblas2hip_status(rocsolver_chegvd((rocblas_handle)handle,
-                                                   hip2rocblas_eform(itype),
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   (rocblas_float_complex*)A,
-                                                   lda,
-                                                   (rocblas_float_complex*)B,
-                                                   ldb,
-                                                   D,
-                                                   E,
-                                                   devInfo));
+        E = (float*)(*mem)[0];
     }
+
+    return rocblas2hip_status(rocsolver_chegvd((rocblas_handle)handle,
+                                               hip2rocblas_eform(itype),
+                                               hip2rocblas_evect(jobz),
+                                               hip2rocblas_fill(uplo),
+                                               n,
+                                               (rocblas_float_complex*)A,
+                                               lda,
+                                               (rocblas_float_complex*)B,
+                                               ldb,
+                                               D,
+                                               E,
+                                               devInfo));
 }
 catch(...)
 {
@@ -6554,26 +6445,16 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
+    std::unique_ptr<rocblas_device_malloc> mem;
+    double*                                E;
+
     if(work && lwork)
     {
-        double* E = (double*)work;
+        E = (double*)work;
         if(n > 0)
             work = (hipDoubleComplex*)(E + n);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
-
-        return rocblas2hip_status(rocsolver_zhegvd((rocblas_handle)handle,
-                                                   hip2rocblas_eform(itype),
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   (rocblas_double_complex*)A,
-                                                   lda,
-                                                   (rocblas_double_complex*)B,
-                                                   ldb,
-                                                   D,
-                                                   E,
-                                                   devInfo));
     }
     else
     {
@@ -6581,24 +6462,24 @@ try
             (rocblas_handle)handle, itype, jobz, uplo, n, A, lda, B, ldb, D, &lwork));
         CHECK_ROCBLAS_ERROR(hipsolverManageWorkspace((rocblas_handle)handle, lwork));
 
-        rocblas_device_malloc mem((rocblas_handle)handle, sizeof(double) * n);
+        mem = make_unique<rocblas_device_malloc>((rocblas_handle)handle, sizeof(double) * n);
         if(!mem)
             return HIPSOLVER_STATUS_ALLOC_FAILED;
-        double* E = (double*)mem[0];
-
-        return rocblas2hip_status(rocsolver_zhegvd((rocblas_handle)handle,
-                                                   hip2rocblas_eform(itype),
-                                                   hip2rocblas_evect(jobz),
-                                                   hip2rocblas_fill(uplo),
-                                                   n,
-                                                   (rocblas_double_complex*)A,
-                                                   lda,
-                                                   (rocblas_double_complex*)B,
-                                                   ldb,
-                                                   D,
-                                                   E,
-                                                   devInfo));
+        E = (double*)(*mem)[0];
     }
+
+    return rocblas2hip_status(rocsolver_zhegvd((rocblas_handle)handle,
+                                               hip2rocblas_eform(itype),
+                                               hip2rocblas_evect(jobz),
+                                               hip2rocblas_fill(uplo),
+                                               n,
+                                               (rocblas_double_complex*)A,
+                                               lda,
+                                               (rocblas_double_complex*)B,
+                                               ldb,
+                                               D,
+                                               E,
+                                               devInfo));
 }
 catch(...)
 {


### PR DESCRIPTION
While working on one of the compatibility functions, I discovered an error in the bufferSize methods for those functions that need extra workspace for missing arguments (e.g. gesvd, syevd, sygvd), which can result in some rare allocation errors with automatic workspace management. We need to call `rocblas_set_optimal_device_memory_size` after computing the expanded size since rocBLAS does some rounding up behind the scenes.

I've also added a null handle check to the bufferSize methods to ensure the same error status precedence that we have in rocSOLVER remains in hipSOLVER.

Finally, I did a bit of cleanup in the functions that need extra workspace so that the function call is not duplicated in the code.

This doesn't need to get into the next release, but I will be applying the changes to the functions I'm currently working on.