### PR TITLE
Only add HIP include directories for CUDA

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright 2016-2021 Advanced Micro Devices, Inc.
+# Copyright 2016-2022 Advanced Micro Devices, Inc.
 # ########################################################################
 
 # ########################################################################
@@ -71,12 +71,6 @@ if( WIN32 )
   endif( )
 endif( )
 
-# External header includes included as system files
-target_include_directories( hipsolver
-  SYSTEM PRIVATE
-    $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
-)
-
 # Build hipsolver from source on AMD platform
 if( NOT USE_CUDA )
   if( NOT TARGET rocblas )
@@ -111,6 +105,7 @@ else( )
   # External header includes included as system files
   target_include_directories( hipsolver
     SYSTEM PRIVATE
+      $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
       $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
   )
 endif( )


### PR DESCRIPTION
This properly allows the dependencies to be in a different location. When using the ROCm backend, the appropriate include directories are added by the CMake targets (`roc::rocblas`, `roc::rocsolver`, and `hip::host`).