### PR TITLE
Update for new Tensile path on Windows

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -127,6 +127,6 @@ if(WIN32)
   add_custom_command(TARGET hipsolver-test
     POST_BUILD
     COMMAND ${CMAKE_COMMAND}
-    ARGS -E copy_directory $ENV{rocblas_DIR}/bin/library ${PROJECT_BINARY_DIR}/staging/library
+    ARGS -E copy_directory $ENV{rocblas_DIR}/bin/rocblas/library ${PROJECT_BINARY_DIR}/staging/library
   )
 endif()


### PR DESCRIPTION
The rocBLAS reorg puts the tensile tree within a rocblas subfolder in bin.
This corresponds to the changes in:
- ROCmSoftwarePlatform/rocSOLVER@ebc34d619f3f77b8997e62deb8a99215ff656cce
- ROCmSoftwarePlatform/rocBLAS@23826b9015e9565affc5fc31f5d955d12ef139fc