### PR TITLE
Hotfixes from release/rocm-rel-5.1 at release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](https://hipsolver.readthedocs.io/en/latest/).
 
-## (Unreleased) hipSOLVER
+## hipSOLVER 1.3.0 for ROCm 5.1.0
 ### Added
 - Added functions
   - gels


### PR DESCRIPTION
This is an autogenerated PR.
 This is intended to pull any hotfixes for ROCm release 5.1.0 (including changelogs and documentation) back into develop.