### PR TITLE
Fix include reorg warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To download the hipSOLVER source code, clone this repository with the command:
 
     git clone https://github.com/ROCmSoftwarePlatform/hipSOLVER.git
 
-hipSOLVER requires either cuSOLVER or rocSOLVER + rocBLAS to be installed on the system. Once these are installed, the following commands will build hipSOLVER and install to `/opt/rocm/hipsolver`:
+hipSOLVER requires either cuSOLVER or rocSOLVER + rocBLAS to be installed on the system. Once these are installed, the following commands will build hipSOLVER and install to `/opt/rocm`:
 
     cd hipSOLVER
     ./install.sh -i

--- a/clients/samples/example_basic.c
+++ b/clients/samples/example_basic.c
@@ -1,5 +1,5 @@
 #include <hip/hip_runtime_api.h> // for hip functions
-#include <hipsolver.h> // for all the hipsolver C interfaces and type declarations
+#include <hipsolver/hipsolver.h> // for all the hipsolver C interfaces and type declarations
 #include <stdio.h> // for printf
 #include <stdlib.h> // for malloc
 

--- a/clients/samples/example_basic.cpp
+++ b/clients/samples/example_basic.cpp
@@ -1,6 +1,6 @@
 #include <algorithm> // for std::min
 #include <hip/hip_runtime_api.h> // for hip functions
-#include <hipsolver.h> // for all the hipsolver C interfaces and type declarations
+#include <hipsolver/hipsolver.h> // for all the hipsolver C interfaces and type declarations
 #include <stdio.h> // for size_t, printf
 #include <vector>
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -114,9 +114,9 @@ endif( )
 target_include_directories( hipsolver
   PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/library/include>
           $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/library/include/internal>
-          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/hipsolver>
           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/hipsolver/internal>
+          $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
           $<INSTALL_INTERFACE:include>
   PRIVATE
           ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -9,9 +9,9 @@
 #include "hipsolver.h"
 #include "error_macros.hpp"
 #include "exceptions.hpp"
-#include "internal/rocblas_device_malloc.hpp"
-#include "rocblas.h"
-#include "rocsolver.h"
+#include "rocblas/internal/rocblas_device_malloc.hpp"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
 #include <algorithm>
 #include <climits>
 #include <functional>


### PR DESCRIPTION
- Updated latest reorg path for rocsolver inclusions
- Updated latest reorg path for rocblas inclusions
- Build interface updated for warning fix.
