### PR TITLE
Enable Origin header file dump option for wrapper

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -139,6 +139,7 @@ if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
     internal/hipsolver-version.h internal/hipsolver-export.h
     GUARDS SYMLINK WRAPPER
     WRAPPER_LOCATIONS include hipsolver/include
+    ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/hipsolver/internal/hipsolver-version.h
   )
 endif( )
 


### PR DESCRIPTION
Summary of proposed changes:

- Original Header File Dump enabled for version header wrapper to support backward Compatibility for PT/TF
- ROCM-CMAKE Version required https://github.com/RadeonOpenCompute/rocm-cmake/commit/d108dbf05e029996d5d7bcbe258abb1166547a30