### PR TITLE
Fix Fortran result values

### DIFF
--- a/library/src/hipsolver_module.f90
+++ b/library/src/hipsolver_module.f90
@@ -55,7 +55,6 @@ end module hipsolver_enums
 
 module hipsolver
     use iso_c_binding
-    use hipsolver_enums
 
     !---------!
     !   Aux   !

--- a/library/src/hipsolver_module.f90
+++ b/library/src/hipsolver_module.f90
@@ -55,6 +55,7 @@ end module hipsolver_enums
 
 module hipsolver
     use iso_c_binding
+    use hipsolver_enums
 
     !---------!
     !   Aux   !
@@ -64,8 +65,9 @@ module hipsolver
         function hipsolverCreate(handle) &
                 bind(c, name = 'hipsolverCreate')
             use iso_c_binding
+            use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCreate_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCreate
             type(c_ptr), value :: handle
         end function hipsolverCreate
     end interface
@@ -74,8 +76,9 @@ module hipsolver
         function hipsolverDestroy(handle) &
                 bind(c, name = 'hipsolverDestroy')
             use iso_c_binding
+            use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDestroy_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDestroy
             type(c_ptr), value :: handle
         end function hipsolverDestroy
     end interface
@@ -84,8 +87,9 @@ module hipsolver
         function hipsolverSetStream(handle, streamId) &
                 bind(c, name = 'hipsolverSetStream')
             use iso_c_binding
+            use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSetStream_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSetStream
             type(c_ptr), value :: handle
             type(c_ptr), value :: streamId
         end function hipsolverSetStream
@@ -95,8 +99,9 @@ module hipsolver
         function hipsolverGetStream(handle, streamId) &
                 bind(c, name = 'hipsolverGetStream')
             use iso_c_binding
+            use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverGetStream_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverGetStream
             type(c_ptr), value :: handle
             type(c_ptr), value :: streamId
         end function hipsolverGetStream
@@ -113,7 +118,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgbr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgbr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -132,7 +137,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgbr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgbr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -151,7 +156,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungbr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungbr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -170,7 +175,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungbr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungbr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -189,7 +194,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgbr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgbr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -210,7 +215,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgbr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgbr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -231,7 +236,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungbr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungbr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -252,7 +257,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungbr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungbr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -274,7 +279,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgqr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgqr_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -292,7 +297,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgqr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgqr_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -310,7 +315,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungqr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungqr_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -328,7 +333,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungqr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungqr_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -346,7 +351,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgqr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgqr
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -366,7 +371,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgqr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgqr
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -386,7 +391,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungqr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungqr
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -406,7 +411,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungqr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungqr
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -427,7 +432,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgtr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgtr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -444,7 +449,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgtr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgtr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -461,7 +466,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungtr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungtr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -478,7 +483,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungtr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungtr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -495,7 +500,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgtr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgtr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -514,7 +519,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgtr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgtr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -533,7 +538,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungtr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungtr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -552,7 +557,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungtr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungtr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -572,7 +577,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormqr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormqr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -594,7 +599,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormqr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormqr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -616,7 +621,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmqr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmqr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -638,7 +643,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmqr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmqr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -660,7 +665,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormqr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormqr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -684,7 +689,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormqr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormqr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -708,7 +713,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmqr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmqr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -732,7 +737,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmqr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmqr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -757,7 +762,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormtr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormtr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -779,7 +784,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormtr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormtr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -801,7 +806,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmtr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmtr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -823,7 +828,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmtr_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmtr_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -845,7 +850,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormtr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormtr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -869,7 +874,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormtr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormtr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -893,7 +898,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmtr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmtr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -917,7 +922,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmtr_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmtr
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -942,7 +947,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgebrd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgebrd_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -956,7 +961,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgebrd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgebrd_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -970,7 +975,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgebrd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgebrd_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -984,7 +989,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgebrd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgebrd_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -998,7 +1003,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgebrd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgebrd
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1020,7 +1025,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgebrd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgebrd
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1042,7 +1047,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgebrd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgebrd
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1064,7 +1069,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgebrd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgebrd
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1087,7 +1092,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgels_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgels_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1108,7 +1113,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgels_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgels_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1129,7 +1134,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgels_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgels_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1150,7 +1155,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgels_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgels_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1171,7 +1176,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgels_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgels
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1195,7 +1200,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgels_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgels
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1219,7 +1224,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgels_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgels
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1243,7 +1248,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgels_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgels
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1268,7 +1273,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgeqrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgeqrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1284,7 +1289,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgeqrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgeqrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1300,7 +1305,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgeqrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgeqrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1316,7 +1321,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgeqrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgeqrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1332,7 +1337,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgeqrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgeqrf
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1351,7 +1356,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgeqrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgeqrf
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1370,7 +1375,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgeqrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgeqrf
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1389,7 +1394,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgeqrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgeqrf
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1409,7 +1414,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgesv_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgesv_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1430,7 +1435,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgesv_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgesv_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1451,7 +1456,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgesv_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgesv_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1472,7 +1477,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgesv_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgesv_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1493,7 +1498,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgesv_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgesv
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1517,7 +1522,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgesv_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgesv
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1541,7 +1546,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgesv_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgesv
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1565,7 +1570,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgesv_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgesv
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1590,7 +1595,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgesvd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgesvd_bufferSize
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1606,7 +1611,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgesvd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgesvd_bufferSize
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1622,7 +1627,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgesvd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgesvd_bufferSize
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1638,7 +1643,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgesvd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgesvd_bufferSize
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1654,7 +1659,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgesvd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgesvd
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1680,7 +1685,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgesvd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgesvd
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1706,7 +1711,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgesvd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgesvd
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1732,7 +1737,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgesvd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgesvd
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1759,7 +1764,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1775,7 +1780,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1791,7 +1796,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1807,7 +1812,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1823,7 +1828,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrf
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1842,7 +1847,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrf
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1861,7 +1866,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrf
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1880,7 +1885,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrf
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1900,7 +1905,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrs_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrs_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -1920,7 +1925,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrs_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrs_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -1940,7 +1945,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrs_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrs_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -1960,7 +1965,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrs_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrs_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -1980,7 +1985,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrs_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrs
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -2002,7 +2007,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrs_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrs
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -2024,7 +2029,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrs_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrs
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -2046,7 +2051,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrs_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrs
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -2069,7 +2074,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrf_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2085,7 +2090,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrf_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2101,7 +2106,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrf_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2117,7 +2122,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrf_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2133,7 +2138,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrf
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2151,7 +2156,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrf
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2169,7 +2174,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrf
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2187,7 +2192,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrf
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2206,7 +2211,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrfBatched_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrfBatched_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2223,7 +2228,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrfBatched_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrfBatched_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2240,7 +2245,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrfBatched_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrfBatched_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2257,7 +2262,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrfBatched_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrfBatched_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2274,7 +2279,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrfBatched_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrfBatched
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2293,7 +2298,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrfBatched_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrfBatched
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2312,7 +2317,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrfBatched_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrfBatched
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2331,7 +2336,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrfBatched_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrfBatched
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2351,7 +2356,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotri_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotri_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2367,7 +2372,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotri_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotri_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2383,7 +2388,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotri_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotri_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2399,7 +2404,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotri_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotri_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2415,7 +2420,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotri_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotri
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2433,7 +2438,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotri_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotri
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2451,7 +2456,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotri_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotri
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2469,7 +2474,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotri_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotri
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2488,7 +2493,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrs_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrs_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2507,7 +2512,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrs_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrs_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2526,7 +2531,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrs_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrs_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2545,7 +2550,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrs_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrs_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2564,7 +2569,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrs_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrs
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2585,7 +2590,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrs_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrs
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2606,7 +2611,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrs_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrs
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2627,7 +2632,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrs_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrs
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2649,7 +2654,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrsBatched_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrsBatched_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2669,7 +2674,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrsBatched_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrsBatched_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2689,7 +2694,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrsBatched_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrsBatched_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2709,7 +2714,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrsBatched_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrsBatched_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2729,7 +2734,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrsBatched_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrsBatched
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2751,7 +2756,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrsBatched_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrsBatched
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2773,7 +2778,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrsBatched_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrsBatched
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2795,7 +2800,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrsBatched_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrsBatched
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2818,7 +2823,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsyevd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsyevd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2836,7 +2841,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsyevd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsyevd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2854,7 +2859,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCheevd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCheevd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2872,7 +2877,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZheevd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZheevd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2890,7 +2895,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsyevd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsyevd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2910,7 +2915,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsyevd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsyevd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2930,7 +2935,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCheevd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCheevd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2950,7 +2955,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZheevd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZheevd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2971,7 +2976,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsygvd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsygvd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -2992,7 +2997,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsygvd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsygvd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3013,7 +3018,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChegvd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChegvd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3034,7 +3039,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhegvd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhegvd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3055,7 +3060,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsygvd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsygvd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3078,7 +3083,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsygvd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsygvd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3101,7 +3106,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChegvd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChegvd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3124,7 +3129,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhegvd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhegvd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3148,7 +3153,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3167,7 +3172,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3186,7 +3191,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChetrd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChetrd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3205,7 +3210,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhetrd_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhetrd_bufferSize
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3224,7 +3229,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3245,7 +3250,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3266,7 +3271,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChetrd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChetrd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3287,7 +3292,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhetrd_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhetrd
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3309,7 +3314,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             type(c_ptr), value :: A
@@ -3324,7 +3329,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             type(c_ptr), value :: A
@@ -3339,7 +3344,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCsytrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCsytrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             type(c_ptr), value :: A
@@ -3354,7 +3359,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZsytrf_bufferSize_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZsytrf_bufferSize
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             type(c_ptr), value :: A
@@ -3369,7 +3374,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrf
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3388,7 +3393,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrf
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3407,7 +3412,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCsytrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCsytrf
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3426,7 +3431,7 @@ module hipsolver
             use iso_c_binding
             use hipsolver_enums
             implicit none
-            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZsytrf_
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZsytrf
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n

--- a/library/src/hipsolver_module.f90
+++ b/library/src/hipsolver_module.f90
@@ -62,30 +62,30 @@ module hipsolver
     
     interface
         function hipsolverCreate(handle) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCreate')
             use iso_c_binding
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCreate_
             type(c_ptr), value :: handle
         end function hipsolverCreate
     end interface
 
     interface
         function hipsolverDestroy(handle) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDestroy')
             use iso_c_binding
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDestroy_
             type(c_ptr), value :: handle
         end function hipsolverDestroy
     end interface
 
     interface
         function hipsolverSetStream(handle, streamId) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSetStream')
             use iso_c_binding
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSetStream_
             type(c_ptr), value :: handle
             type(c_ptr), value :: streamId
         end function hipsolverSetStream
@@ -93,10 +93,10 @@ module hipsolver
 
     interface
         function hipsolverGetStream(handle, streamId) &
-                result(c_int) &
                 bind(c, name = 'hipsolverGetStream')
             use iso_c_binding
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverGetStream_
             type(c_ptr), value :: handle
             type(c_ptr), value :: streamId
         end function hipsolverGetStream
@@ -109,11 +109,11 @@ module hipsolver
     ! ******************** ORGBR/UNGBR ********************
     interface
         function hipsolverSorgbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSorgbr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgbr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -128,11 +128,11 @@ module hipsolver
     
     interface
         function hipsolverDorgbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDorgbr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgbr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -147,11 +147,11 @@ module hipsolver
     
     interface
         function hipsolverCungbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCungbr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungbr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -166,11 +166,11 @@ module hipsolver
     
     interface
         function hipsolverZungbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZungbr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungbr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -185,11 +185,11 @@ module hipsolver
     
     interface
         function hipsolverSorgbr(handle, side, m, n, k, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSorgbr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgbr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -206,11 +206,11 @@ module hipsolver
     
     interface
         function hipsolverDorgbr(handle, side, m, n, k, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDorgbr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgbr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -227,11 +227,11 @@ module hipsolver
     
     interface
         function hipsolverCungbr(handle, side, m, n, k, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCungbr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungbr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -248,11 +248,11 @@ module hipsolver
     
     interface
         function hipsolverZungbr(handle, side, m, n, k, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZungbr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungbr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(c_int), value :: m
@@ -270,11 +270,11 @@ module hipsolver
     ! ******************** ORGQR/UNGQR ********************
     interface
         function hipsolverSorgqr_bufferSize(handle, m, n, k, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSorgqr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgqr_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -288,11 +288,11 @@ module hipsolver
     
     interface
         function hipsolverDorgqr_bufferSize(handle, m, n, k, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDorgqr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgqr_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -306,11 +306,11 @@ module hipsolver
     
     interface
         function hipsolverCungqr_bufferSize(handle, m, n, k, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCungqr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungqr_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -324,11 +324,11 @@ module hipsolver
     
     interface
         function hipsolverZungqr_bufferSize(handle, m, n, k, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZungqr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungqr_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -342,11 +342,11 @@ module hipsolver
     
     interface
         function hipsolverSorgqr(handle, m, n, k, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSorgqr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgqr_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -362,11 +362,11 @@ module hipsolver
     
     interface
         function hipsolverDorgqr(handle, m, n, k, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDorgqr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgqr_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -382,11 +382,11 @@ module hipsolver
     
     interface
         function hipsolverCungqr(handle, m, n, k, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCungqr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungqr_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -402,11 +402,11 @@ module hipsolver
     
     interface
         function hipsolverZungqr(handle, m, n, k, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZungqr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungqr_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -423,11 +423,11 @@ module hipsolver
     ! ******************** ORGTR/UNGTR ********************
     interface
         function hipsolverSorgtr_bufferSize(handle, uplo, n, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSorgtr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgtr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -440,11 +440,11 @@ module hipsolver
     
     interface
         function hipsolverDorgtr_bufferSize(handle, uplo, n, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDorgtr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgtr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -457,11 +457,11 @@ module hipsolver
     
     interface
         function hipsolverCungtr_bufferSize(handle, uplo, n, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCungtr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungtr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -474,11 +474,11 @@ module hipsolver
     
     interface
         function hipsolverZungtr_bufferSize(handle, uplo, n, A, lda, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZungtr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungtr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -491,11 +491,11 @@ module hipsolver
     
     interface
         function hipsolverSorgtr(handle, uplo, n, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSorgtr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSorgtr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -510,11 +510,11 @@ module hipsolver
     
     interface
         function hipsolverDorgtr(handle, uplo, n, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDorgtr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDorgtr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -529,11 +529,11 @@ module hipsolver
     
     interface
         function hipsolverCungtr(handle, uplo, n, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCungtr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCungtr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -548,11 +548,11 @@ module hipsolver
     
     interface
         function hipsolverZungtr(handle, uplo, n, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZungtr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZungtr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -568,11 +568,11 @@ module hipsolver
     ! ******************** ORMQR/UNMQR ********************
     interface
         function hipsolverSormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSormqr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormqr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -590,11 +590,11 @@ module hipsolver
     
     interface
         function hipsolverDormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDormqr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormqr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -612,11 +612,11 @@ module hipsolver
     
     interface
         function hipsolverCunmqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCunmqr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmqr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -634,11 +634,11 @@ module hipsolver
     
     interface
         function hipsolverZunmqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZunmqr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmqr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -656,11 +656,11 @@ module hipsolver
     
     interface
         function hipsolverSormqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSormqr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormqr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -680,11 +680,11 @@ module hipsolver
     
     interface
         function hipsolverDormqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDormqr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormqr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -704,11 +704,11 @@ module hipsolver
     
     interface
         function hipsolverCunmqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCunmqr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmqr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -728,11 +728,11 @@ module hipsolver
     
     interface
         function hipsolverZunmqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZunmqr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmqr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_OP_N)), value :: trans
@@ -753,11 +753,11 @@ module hipsolver
     ! ******************** ORMTR/UNMTR ********************
     interface
         function hipsolverSormtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSormtr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormtr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -775,11 +775,11 @@ module hipsolver
     
     interface
         function hipsolverDormtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDormtr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormtr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -797,11 +797,11 @@ module hipsolver
     
     interface
         function hipsolverCunmtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCunmtr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmtr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -819,11 +819,11 @@ module hipsolver
     
     interface
         function hipsolverZunmtr_bufferSize(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZunmtr_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmtr_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -841,11 +841,11 @@ module hipsolver
     
     interface
         function hipsolverSormtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSormtr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSormtr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -865,11 +865,11 @@ module hipsolver
     
     interface
         function hipsolverDormtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDormtr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDormtr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -889,11 +889,11 @@ module hipsolver
     
     interface
         function hipsolverCunmtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCunmtr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCunmtr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -913,11 +913,11 @@ module hipsolver
     
     interface
         function hipsolverZunmtr(handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZunmtr')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZunmtr_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_SIDE_LEFT)), value :: side
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -938,11 +938,11 @@ module hipsolver
     ! ******************** GEBRD ********************
     interface
         function hipsolverSgebrd_bufferSize(handle, m, n, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgebrd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgebrd_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -952,11 +952,11 @@ module hipsolver
     
     interface
         function hipsolverDgebrd_bufferSize(handle, m, n, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgebrd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgebrd_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -966,11 +966,11 @@ module hipsolver
     
     interface
         function hipsolverCgebrd_bufferSize(handle, m, n, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgebrd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgebrd_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -980,11 +980,11 @@ module hipsolver
     
     interface
         function hipsolverZgebrd_bufferSize(handle, m, n, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgebrd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgebrd_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -994,11 +994,11 @@ module hipsolver
 
     interface
         function hipsolverSgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgebrd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgebrd_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1016,11 +1016,11 @@ module hipsolver
 
     interface
         function hipsolverDgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgebrd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgebrd_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1038,11 +1038,11 @@ module hipsolver
 
     interface
         function hipsolverCgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgebrd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgebrd_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1060,11 +1060,11 @@ module hipsolver
 
     interface
         function hipsolverZgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgebrd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgebrd_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1083,11 +1083,11 @@ module hipsolver
     ! ******************** GELS ********************
     interface
         function hipsolverSSgels_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSSgels_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgels_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1104,11 +1104,11 @@ module hipsolver
     
     interface
         function hipsolverDDgels_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDDgels_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgels_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1125,11 +1125,11 @@ module hipsolver
     
     interface
         function hipsolverCCgels_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCCgels_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgels_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1146,11 +1146,11 @@ module hipsolver
     
     interface
         function hipsolverZZgels_bufferSize(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZZgels_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgels_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1167,11 +1167,11 @@ module hipsolver
 
     interface
         function hipsolverSSgels(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSSgels')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgels_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1191,11 +1191,11 @@ module hipsolver
 
     interface
         function hipsolverDDgels(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDDgels')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgels_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1215,11 +1215,11 @@ module hipsolver
 
     interface
         function hipsolverCCgels(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCCgels')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgels_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1239,11 +1239,11 @@ module hipsolver
 
     interface
         function hipsolverZZgels(handle, m, n, nrhs, A, lda, B, ldb, X, ldx, work, lwork, niters, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZZgels')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgels_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1264,11 +1264,11 @@ module hipsolver
     ! ******************** GEQRF ********************
     interface
         function hipsolverSgeqrf_bufferSize(handle, m, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgeqrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgeqrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1280,11 +1280,11 @@ module hipsolver
 
     interface
         function hipsolverDgeqrf_bufferSize(handle, m, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgeqrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgeqrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1296,11 +1296,11 @@ module hipsolver
 
     interface
         function hipsolverCgeqrf_bufferSize(handle, m, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgeqrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgeqrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1312,11 +1312,11 @@ module hipsolver
 
     interface
         function hipsolverZgeqrf_bufferSize(handle, m, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgeqrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgeqrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1328,11 +1328,11 @@ module hipsolver
 
     interface
         function hipsolverSgeqrf(handle, m, n, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgeqrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgeqrf_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1347,11 +1347,11 @@ module hipsolver
 
     interface
         function hipsolverDgeqrf(handle, m, n, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgeqrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgeqrf_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1366,11 +1366,11 @@ module hipsolver
 
     interface
         function hipsolverCgeqrf(handle, m, n, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgeqrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgeqrf_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1385,11 +1385,11 @@ module hipsolver
 
     interface
         function hipsolverZgeqrf(handle, m, n, A, lda, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgeqrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgeqrf_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1405,11 +1405,11 @@ module hipsolver
     ! ******************** GESV ********************
     interface
         function hipsolverSSgesv_bufferSize(handle, n, nrhs, A, lda, ipiv, B, ldb, X, ldx, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSSgesv_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgesv_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1426,11 +1426,11 @@ module hipsolver
     
     interface
         function hipsolverDDgesv_bufferSize(handle, n, nrhs, A, lda, ipiv, B, ldb, X, ldx, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDDgesv_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgesv_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1447,11 +1447,11 @@ module hipsolver
     
     interface
         function hipsolverCCgesv_bufferSize(handle, n, nrhs, A, lda, ipiv, B, ldb, X, ldx, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCCgesv_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgesv_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1468,11 +1468,11 @@ module hipsolver
     
     interface
         function hipsolverZZgesv_bufferSize(handle, n, nrhs, A, lda, ipiv, B, ldb, X, ldx, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZZgesv_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgesv_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1489,11 +1489,11 @@ module hipsolver
 
     interface
         function hipsolverSSgesv(handle, n, nrhs, A, lda, ipiv, B, ldb, X, ldx, work, lwork, niters, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSSgesv')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSSgesv_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1513,11 +1513,11 @@ module hipsolver
 
     interface
         function hipsolverDDgesv(handle, n, nrhs, A, lda, ipiv, B, ldb, X, ldx, work, lwork, niters, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDDgesv')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDDgesv_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1537,11 +1537,11 @@ module hipsolver
 
     interface
         function hipsolverCCgesv(handle, n, nrhs, A, lda, ipiv, B, ldb, X, ldx, work, lwork, niters, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCCgesv')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCCgesv_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1561,11 +1561,11 @@ module hipsolver
 
     interface
         function hipsolverZZgesv(handle, n, nrhs, A, lda, ipiv, B, ldb, X, ldx, work, lwork, niters, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZZgesv')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZZgesv_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             integer(c_int), value :: nrhs
@@ -1586,11 +1586,11 @@ module hipsolver
     ! ******************** GESVD ********************
     interface
         function hipsolverSgesvd_bufferSize(handle, jobu, jobv, m, n, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgesvd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgesvd_bufferSize_
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1602,11 +1602,11 @@ module hipsolver
     
     interface
         function hipsolverDgesvd_bufferSize(handle, jobu, jobv, m, n, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgesvd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgesvd_bufferSize_
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1618,11 +1618,11 @@ module hipsolver
     
     interface
         function hipsolverCgesvd_bufferSize(handle, jobu, jobv, m, n, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgesvd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgesvd_bufferSize_
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1634,11 +1634,11 @@ module hipsolver
     
     interface
         function hipsolverZgesvd_bufferSize(handle, jobu, jobv, m, n, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgesvd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgesvd_bufferSize_
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1650,11 +1650,11 @@ module hipsolver
 
     interface
         function hipsolverSgesvd(handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgesvd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgesvd_
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1676,11 +1676,11 @@ module hipsolver
 
     interface
         function hipsolverDgesvd(handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgesvd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgesvd_
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1702,11 +1702,11 @@ module hipsolver
 
     interface
         function hipsolverCgesvd(handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgesvd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgesvd_
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1728,11 +1728,11 @@ module hipsolver
 
     interface
         function hipsolverZgesvd(handle, jobu, jobv, m, n, A, lda, S, U, ldu, V, ldv, work, lwork, rwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgesvd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgesvd_
             type(c_ptr), value :: handle
             integer(c_signed_char), value :: jobu
             integer(c_signed_char), value :: jobv
@@ -1755,11 +1755,11 @@ module hipsolver
     ! ******************** GETRF ********************
     interface
         function hipsolverSgetrf_bufferSize(handle, m, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgetrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1771,11 +1771,11 @@ module hipsolver
     
     interface
         function hipsolverDgetrf_bufferSize(handle, m, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgetrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1787,11 +1787,11 @@ module hipsolver
     
     interface
         function hipsolverCgetrf_bufferSize(handle, m, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgetrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1803,11 +1803,11 @@ module hipsolver
     
     interface
         function hipsolverZgetrf_bufferSize(handle, m, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgetrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1819,11 +1819,11 @@ module hipsolver
 
     interface
         function hipsolverSgetrf(handle, m, n, A, lda, work, lwork, ipiv, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgetrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrf_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1838,11 +1838,11 @@ module hipsolver
     
     interface
         function hipsolverDgetrf(handle, m, n, A, lda, work, lwork, ipiv, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgetrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrf_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1857,11 +1857,11 @@ module hipsolver
     
     interface
         function hipsolverCgetrf(handle, m, n, A, lda, work, lwork, ipiv, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgetrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrf_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1876,11 +1876,11 @@ module hipsolver
     
     interface
         function hipsolverZgetrf(handle, m, n, A, lda, work, lwork, ipiv, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgetrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrf_
             type(c_ptr), value :: handle
             integer(c_int), value :: m
             integer(c_int), value :: n
@@ -1896,11 +1896,11 @@ module hipsolver
     ! ******************** GETRS ********************
     interface
         function hipsolverSgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgetrs_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrs_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -1916,11 +1916,11 @@ module hipsolver
     
     interface
         function hipsolverDgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgetrs_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrs_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -1936,11 +1936,11 @@ module hipsolver
     
     interface
         function hipsolverCgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgetrs_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrs_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -1956,11 +1956,11 @@ module hipsolver
     
     interface
         function hipsolverZgetrs_bufferSize(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgetrs_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrs_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -1976,11 +1976,11 @@ module hipsolver
 
     interface
         function hipsolverSgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSgetrs')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSgetrs_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -1998,11 +1998,11 @@ module hipsolver
     
     interface
         function hipsolverDgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDgetrs')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDgetrs_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -2020,11 +2020,11 @@ module hipsolver
     
     interface
         function hipsolverCgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCgetrs')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCgetrs_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -2042,11 +2042,11 @@ module hipsolver
     
     interface
         function hipsolverZgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZgetrs')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZgetrs_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_OP_N)), value :: trans
             integer(c_int), value :: n
@@ -2065,11 +2065,11 @@ module hipsolver
     ! ******************** POTRF ********************
     interface
         function hipsolverSpotrf_bufferSize(handle, uplo, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrf_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2081,11 +2081,11 @@ module hipsolver
     
     interface
         function hipsolverDpotrf_bufferSize(handle, uplo, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrf_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2097,11 +2097,11 @@ module hipsolver
     
     interface
         function hipsolverCpotrf_bufferSize(handle, uplo, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrf_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2113,11 +2113,11 @@ module hipsolver
     
     interface
         function hipsolverZpotrf_bufferSize(handle, uplo, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrf_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2129,11 +2129,11 @@ module hipsolver
 
     interface
         function hipsolverSpotrf(handle, uplo, n, A, lda, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrf_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2147,11 +2147,11 @@ module hipsolver
 
     interface
         function hipsolverDpotrf(handle, uplo, n, A, lda, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrf_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2165,11 +2165,11 @@ module hipsolver
 
     interface
         function hipsolverCpotrf(handle, uplo, n, A, lda, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrf_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2183,11 +2183,11 @@ module hipsolver
 
     interface
         function hipsolverZpotrf(handle, uplo, n, A, lda, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrf_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2202,11 +2202,11 @@ module hipsolver
     ! ******************** POTRF_BATCHED ********************
     interface
         function hipsolverSpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotrfBatched_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrfBatched_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2219,11 +2219,11 @@ module hipsolver
     
     interface
         function hipsolverDpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotrfBatched_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrfBatched_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2236,11 +2236,11 @@ module hipsolver
     
     interface
         function hipsolverCpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotrfBatched_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrfBatched_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2253,11 +2253,11 @@ module hipsolver
     
     interface
         function hipsolverZpotrfBatched_bufferSize(handle, uplo, n, A, lda, lwork, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotrfBatched_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrfBatched_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2270,11 +2270,11 @@ module hipsolver
 
     interface
         function hipsolverSpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotrfBatched')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrfBatched_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2289,11 +2289,11 @@ module hipsolver
     
     interface
         function hipsolverDpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotrfBatched')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrfBatched_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2308,11 +2308,11 @@ module hipsolver
     
     interface
         function hipsolverCpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotrfBatched')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrfBatched_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2327,11 +2327,11 @@ module hipsolver
     
     interface
         function hipsolverZpotrfBatched(handle, uplo, n, A, lda, work, lwork, info, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotrfBatched')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrfBatched_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2347,11 +2347,11 @@ module hipsolver
     ! ******************** POTRI ********************
     interface
         function hipsolverSpotri_bufferSize(handle, uplo, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotri_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotri_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2363,11 +2363,11 @@ module hipsolver
     
     interface
         function hipsolverDpotri_bufferSize(handle, uplo, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotri_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotri_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2379,11 +2379,11 @@ module hipsolver
     
     interface
         function hipsolverCpotri_bufferSize(handle, uplo, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotri_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotri_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2395,11 +2395,11 @@ module hipsolver
     
     interface
         function hipsolverZpotri_bufferSize(handle, uplo, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotri_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotri_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2411,11 +2411,11 @@ module hipsolver
 
     interface
         function hipsolverSpotri(handle, uplo, n, A, lda, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotri')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotri_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2429,11 +2429,11 @@ module hipsolver
 
     interface
         function hipsolverDpotri(handle, uplo, n, A, lda, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotri')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotri_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2447,11 +2447,11 @@ module hipsolver
 
     interface
         function hipsolverCpotri(handle, uplo, n, A, lda, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotri')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotri_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2465,11 +2465,11 @@ module hipsolver
 
     interface
         function hipsolverZpotri(handle, uplo, n, A, lda, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotri')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotri_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2484,11 +2484,11 @@ module hipsolver
     ! ******************** POTRS ********************
     interface
         function hipsolverSpotrs_bufferSize(handle, uplo, n, nrhs, A, lda, B, ldb, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotrs_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrs_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2503,11 +2503,11 @@ module hipsolver
     
     interface
         function hipsolverDpotrs_bufferSize(handle, uplo, n, nrhs, A, lda, B, ldb, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotrs_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrs_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2522,11 +2522,11 @@ module hipsolver
     
     interface
         function hipsolverCpotrs_bufferSize(handle, uplo, n, nrhs, A, lda, B, ldb, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotrs_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrs_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2541,11 +2541,11 @@ module hipsolver
     
     interface
         function hipsolverZpotrs_bufferSize(handle, uplo, n, nrhs, A, lda, B, ldb, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotrs_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrs_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2560,11 +2560,11 @@ module hipsolver
 
     interface
         function hipsolverSpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotrs')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrs_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2581,11 +2581,11 @@ module hipsolver
 
     interface
         function hipsolverDpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotrs')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrs_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2602,11 +2602,11 @@ module hipsolver
 
     interface
         function hipsolverCpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotrs')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrs_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2623,11 +2623,11 @@ module hipsolver
 
     interface
         function hipsolverZpotrs(handle, uplo, n, nrhs, A, lda, B, ldb, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotrs')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrs_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2645,11 +2645,11 @@ module hipsolver
     ! ******************** POTRS_BATCHED ********************
     interface
         function hipsolverSpotrsBatched_bufferSize(handle, uplo, n, nrhs, A, lda, B, ldb, lwork, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotrsBatched_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrsBatched_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2665,11 +2665,11 @@ module hipsolver
     
     interface
         function hipsolverDpotrsBatched_bufferSize(handle, uplo, n, nrhs, A, lda, B, ldb, lwork, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotrsBatched_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrsBatched_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2685,11 +2685,11 @@ module hipsolver
     
     interface
         function hipsolverCpotrsBatched_bufferSize(handle, uplo, n, nrhs, A, lda, B, ldb, lwork, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotrsBatched_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrsBatched_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2705,11 +2705,11 @@ module hipsolver
     
     interface
         function hipsolverZpotrsBatched_bufferSize(handle, uplo, n, nrhs, A, lda, B, ldb, lwork, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotrsBatched_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrsBatched_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2725,11 +2725,11 @@ module hipsolver
 
     interface
         function hipsolverSpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, work, lwork, info, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSpotrsBatched')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSpotrsBatched_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2747,11 +2747,11 @@ module hipsolver
 
     interface
         function hipsolverDpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, work, lwork, info, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDpotrsBatched')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDpotrsBatched_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2769,11 +2769,11 @@ module hipsolver
 
     interface
         function hipsolverCpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, work, lwork, info, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCpotrsBatched')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCpotrsBatched_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2791,11 +2791,11 @@ module hipsolver
 
     interface
         function hipsolverZpotrsBatched(handle, uplo, n, nrhs, A, lda, B, ldb, work, lwork, info, batch_count) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZpotrsBatched')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZpotrsBatched_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -2814,11 +2814,11 @@ module hipsolver
     ! ******************** SYEVD/HEEVD ********************
     interface
         function hipsolverSsyevd_bufferSize(handle, jobz, uplo, n, A, lda, D, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSsyevd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsyevd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2832,11 +2832,11 @@ module hipsolver
     
     interface
         function hipsolverDsyevd_bufferSize(handle, jobz, uplo, n, A, lda, D, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDsyevd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsyevd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2850,11 +2850,11 @@ module hipsolver
     
     interface
         function hipsolverCheevd_bufferSize(handle, jobz, uplo, n, A, lda, D, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCheevd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCheevd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2868,11 +2868,11 @@ module hipsolver
     
     interface
         function hipsolverZheevd_bufferSize(handle, jobz, uplo, n, A, lda, D, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZheevd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZheevd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2886,11 +2886,11 @@ module hipsolver
 
     interface
         function hipsolverSsyevd(handle, jobz, uplo, n, A, lda, D, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSsyevd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsyevd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2906,11 +2906,11 @@ module hipsolver
 
     interface
         function hipsolverDsyevd(handle, jobz, uplo, n, A, lda, D, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDsyevd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsyevd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2926,11 +2926,11 @@ module hipsolver
 
     interface
         function hipsolverCheevd(handle, jobz, uplo, n, A, lda, D, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCheevd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCheevd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2946,11 +2946,11 @@ module hipsolver
 
     interface
         function hipsolverZheevd(handle, jobz, uplo, n, A, lda, D, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZheevd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZheevd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
@@ -2967,11 +2967,11 @@ module hipsolver
     ! ******************** SYGVD/HEGVD ********************
     interface
         function hipsolverSsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSsygvd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsygvd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -2988,11 +2988,11 @@ module hipsolver
     
     interface
         function hipsolverDsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDsygvd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsygvd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3009,11 +3009,11 @@ module hipsolver
     
     interface
         function hipsolverChegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverChegvd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChegvd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3030,11 +3030,11 @@ module hipsolver
     
     interface
         function hipsolverZhegvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZhegvd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhegvd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3051,11 +3051,11 @@ module hipsolver
 
     interface
         function hipsolverSsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSsygvd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsygvd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3074,11 +3074,11 @@ module hipsolver
 
     interface
         function hipsolverDsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDsygvd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsygvd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3097,11 +3097,11 @@ module hipsolver
 
     interface
         function hipsolverChegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverChegvd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChegvd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3120,11 +3120,11 @@ module hipsolver
 
     interface
         function hipsolverZhegvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, D, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZhegvd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhegvd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_EIG_TYPE_1)), value :: itype
             integer(kind(HIPSOLVER_EIG_MODE_NOVECTOR)), value :: jobz
@@ -3144,11 +3144,11 @@ module hipsolver
     ! ******************** SYTRD/HETRD ********************
     interface
         function hipsolverSsytrd_bufferSize(handle, uplo, n, A, lda, D, E, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSsytrd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3163,11 +3163,11 @@ module hipsolver
     
     interface
         function hipsolverDsytrd_bufferSize(handle, uplo, n, A, lda, D, E, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDsytrd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3182,11 +3182,11 @@ module hipsolver
     
     interface
         function hipsolverChetrd_bufferSize(handle, uplo, n, A, lda, D, E, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverChetrd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChetrd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3201,11 +3201,11 @@ module hipsolver
     
     interface
         function hipsolverZhetrd_bufferSize(handle, uplo, n, A, lda, D, E, tau, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZhetrd_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhetrd_bufferSize_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3220,11 +3220,11 @@ module hipsolver
 
     interface
         function hipsolverSsytrd(handle, uplo, n, A, lda, D, E, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSsytrd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3241,11 +3241,11 @@ module hipsolver
 
     interface
         function hipsolverDsytrd(handle, uplo, n, A, lda, D, E, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDsytrd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3262,11 +3262,11 @@ module hipsolver
 
     interface
         function hipsolverChetrd(handle, uplo, n, A, lda, D, E, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverChetrd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverChetrd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3283,11 +3283,11 @@ module hipsolver
 
     interface
         function hipsolverZhetrd(handle, uplo, n, A, lda, D, E, tau, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZhetrd')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZhetrd_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3305,11 +3305,11 @@ module hipsolver
     ! ******************** SYTRF ********************
     interface
         function hipsolverSsytrf_bufferSize(handle, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSsytrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             type(c_ptr), value :: A
@@ -3320,11 +3320,11 @@ module hipsolver
     
     interface
         function hipsolverDsytrf_bufferSize(handle, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDsytrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             type(c_ptr), value :: A
@@ -3335,11 +3335,11 @@ module hipsolver
     
     interface
         function hipsolverCsytrf_bufferSize(handle, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCsytrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCsytrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             type(c_ptr), value :: A
@@ -3350,11 +3350,11 @@ module hipsolver
     
     interface
         function hipsolverZsytrf_bufferSize(handle, n, A, lda, lwork) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZsytrf_bufferSize')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZsytrf_bufferSize_
             type(c_ptr), value :: handle
             integer(c_int), value :: n
             type(c_ptr), value :: A
@@ -3365,11 +3365,11 @@ module hipsolver
 
     interface
         function hipsolverSsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverSsytrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverSsytrf_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3384,11 +3384,11 @@ module hipsolver
 
     interface
         function hipsolverDsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverDsytrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverDsytrf_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3403,11 +3403,11 @@ module hipsolver
 
     interface
         function hipsolverCsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverCsytrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverCsytrf_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n
@@ -3422,11 +3422,11 @@ module hipsolver
 
     interface
         function hipsolverZsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info) &
-                result(c_int) &
                 bind(c, name = 'hipsolverZsytrf')
             use iso_c_binding
             use hipsolver_enums
             implicit none
+            integer(kind(HIPSOLVER_STATUS_SUCCESS)) :: hipsolverZsytrf_
             type(c_ptr), value :: handle
             integer(kind(HIPSOLVER_FILL_MODE_LOWER)), value :: uplo
             integer(c_int), value :: n


### PR DESCRIPTION
The `result` declaration in Fortran defines the name of the result variable, not the type. The result type is not necessarily `c_int`, either. The value returned is an enum.

The hipfort bindings for hipsolver handles this correctly, so this this change is to define the hipsolver API return types in the same way that hipfort does.