### PR TITLE
Fix Sphinx 'language = None' warning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,7 +57,7 @@ release = u'1.5.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Sphinx 5.0 includes the warning

    WARNING: Invalid configuration value found: 'language = None'.
    Update your configuration to a valid langauge code.
    Falling back to 'en' (English).

The sphinx source code notes that sphinx-quickstart generated this
setting by default, however, an actual langauge is now expected.