### PR TITLE
Added mem_query option to benchmark client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
   - syevdx/heevdx
     - hipsolverDnSsyevdx_bufferSize, hipsolverDnDsyevdx_bufferSize, hipsolverDnCheevdx_bufferSize, hipsolverDnZheevdx_bufferSize
     - hipsolverDnSsyevdx, hipsolverDnDsyevdx, hipsolverDnCheevdx, hipsolverDnZheevdx
+- Added --mem_query option to hipsolver-bench, which will print the amount of device memory workspace required by the function.
 
 ### Optimized
 ### Changed

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -77,6 +77,13 @@ try
             "                           Reported time will be the average.\n"
             "                           ")
 
+        ("mem_query",
+         value<rocblas_int>(&argus.mem_query)->default_value(0),
+            "Calculate the required amount of device workspace memory? 0 = No, 1 = Yes.\n"
+            "                           This forces the client to print only the amount of device memory required by\n"
+            "                           the function, in bytes.\n"
+            "                           ")
+
         ("perf",
          value<rocblas_int>(&argus.perf)->default_value(0),
             "Ignore CPU timing results? 0 = No, 1 = Yes.\n"

--- a/clients/include/testing_gebrd.hpp
+++ b/clients/include/testing_gebrd.hpp
@@ -852,6 +852,16 @@ void testing_gebrd(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_gebrd_bufferSize(FORTRAN, handle, m, n, (T*)nullptr, lda, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -869,6 +879,7 @@ void testing_gebrd(Arguments& argus)
         // device_strided_batch_vector<T>   dTauq(size_Q, 1, stQ, bc);
         // device_strided_batch_vector<T>   dTaup(size_P, 1, stP, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // if(size_D)
@@ -880,10 +891,6 @@ void testing_gebrd(Arguments& argus)
         // if(size_P)
         //     CHECK_HIP_ERROR(dTaup.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // int size_W;
-        // hipsolver_gebrd_bufferSize(FORTRAN, handle, m, n, dA.data(), lda, &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -966,6 +973,7 @@ void testing_gebrd(Arguments& argus)
         device_strided_batch_vector<T>   dTauq(size_Q, 1, stQ, bc);
         device_strided_batch_vector<T>   dTaup(size_P, 1, stP, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_D)
@@ -977,10 +985,6 @@ void testing_gebrd(Arguments& argus)
         if(size_P)
             CHECK_HIP_ERROR(dTaup.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_gebrd_bufferSize(FORTRAN, handle, m, n, dA.data(), lda, &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_gebrd.hpp
+++ b/clients/include/testing_gebrd.hpp
@@ -847,7 +847,7 @@ void testing_gebrd(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -633,6 +633,17 @@ void testing_gels(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    size_t size_W;
+    hipsolver_gels_bufferSize(
+        API, handle, m, n, nrhs, (T*)nullptr, lda, (T*)nullptr, ldb, (T*)nullptr, ldx, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -648,6 +659,7 @@ void testing_gels(Arguments& argus)
         // device_batch_vector<T>           dB(size_B, 1, bc);
         // device_batch_vector<T>           dX(size_X, 1, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // if(size_B)
@@ -656,11 +668,6 @@ void testing_gels(Arguments& argus)
         //     CHECK_HIP_ERROR(dX.memcheck());
         // if(bc)
         //     CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // size_t size_W;
-        // hipsolver_gels_bufferSize(
-        //     API, handle, m, n, nrhs, dA.data(), lda, dB.data(), ldb, dX.data(), ldx, &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -737,6 +744,7 @@ void testing_gels(Arguments& argus)
         device_strided_batch_vector<T>   dB(size_B, 1, stB, bc);
         device_strided_batch_vector<T>   dX(size_X, 1, stX, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
@@ -745,11 +753,6 @@ void testing_gels(Arguments& argus)
             CHECK_HIP_ERROR(dX.memcheck());
         if(bc)
             CHECK_HIP_ERROR(dInfo.memcheck());
-
-        size_t size_W;
-        hipsolver_gels_bufferSize(
-            API, handle, m, n, nrhs, dA.data(), lda, dB.data(), ldb, dX.data(), ldx, &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -628,7 +628,7 @@ void testing_gels(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_geqrf.hpp
+++ b/clients/include/testing_geqrf.hpp
@@ -390,7 +390,7 @@ void testing_geqrf(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_geqrf.hpp
+++ b/clients/include/testing_geqrf.hpp
@@ -395,6 +395,16 @@ void testing_geqrf(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_geqrf_bufferSize(FORTRAN, handle, m, n, (T*)nullptr, lda, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -406,15 +416,12 @@ void testing_geqrf(Arguments& argus)
         // device_batch_vector<T>           dA(size_A, 1, bc);
         // device_strided_batch_vector<T>   dIpiv(size_P, 1, stP, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // if(size_P)
         //     CHECK_HIP_ERROR(dIpiv.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // int size_W;
-        // hipsolver_geqrf_bufferSize(FORTRAN, handle, m, n, dA.data(), lda, &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -473,15 +480,12 @@ void testing_geqrf(Arguments& argus)
         device_strided_batch_vector<T>   dA(size_A, 1, stA, bc);
         device_strided_batch_vector<T>   dIpiv(size_P, 1, stP, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_P)
             CHECK_HIP_ERROR(dIpiv.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_geqrf_bufferSize(FORTRAN, handle, m, n, dA.data(), lda, &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_gesv.hpp
+++ b/clients/include/testing_gesv.hpp
@@ -642,7 +642,7 @@ void testing_gesv(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_gesv.hpp
+++ b/clients/include/testing_gesv.hpp
@@ -647,6 +647,27 @@ void testing_gesv(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    size_t size_W;
+    hipsolver_gesv_bufferSize(API,
+                              handle,
+                              n,
+                              nrhs,
+                              (T*)nullptr,
+                              lda,
+                              (int*)nullptr,
+                              (T*)nullptr,
+                              ldb,
+                              (T*)nullptr,
+                              ldx,
+                              &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -662,6 +683,7 @@ void testing_gesv(Arguments& argus)
         // device_batch_vector<T>           dX(size_X, 1, bc);
         // device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // if(size_B)
@@ -671,21 +693,6 @@ void testing_gesv(Arguments& argus)
         // if(size_P)
         //     CHECK_HIP_ERROR(dIpiv.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // size_t size_W;
-        // hipsolver_gesv_bufferSize(API,
-        //                           handle,
-        //                           n,
-        //                           nrhs,
-        //                           dA.data(),
-        //                           lda,
-        //                           dIpiv.data(),
-        //                           dB.data(),
-        //                           ldb,
-        //                           dX.data(),
-        //                           ldx,
-        //                           &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -764,6 +771,7 @@ void testing_gesv(Arguments& argus)
         device_strided_batch_vector<T>   dX(size_X, 1, stX, bc);
         device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
@@ -773,21 +781,6 @@ void testing_gesv(Arguments& argus)
         if(size_P)
             CHECK_HIP_ERROR(dIpiv.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        size_t size_W;
-        hipsolver_gesv_bufferSize(API,
-                                  handle,
-                                  n,
-                                  nrhs,
-                                  dA.data(),
-                                  lda,
-                                  dIpiv.data(),
-                                  dB.data(),
-                                  ldb,
-                                  dX.data(),
-                                  ldx,
-                                  &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_gesvd.hpp
+++ b/clients/include/testing_gesvd.hpp
@@ -1035,6 +1035,18 @@ void testing_gesvd(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W, w1, w2;
+    hipsolver_gesvd_bufferSize(API, handle, leftv, rightv, m, n, (T*)nullptr, lda, &w1);
+    hipsolver_gesvd_bufferSize(API, handle, leftvT, rightvT, mT, nT, (T*)nullptr, lda, &w2);
+    size_W = max(w1, w2);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     // memory allocations (all cases)
     // host
     host_strided_batch_vector<S>   hE(5 * max(m, n), 1, 5 * max(m, n), bc);
@@ -1055,6 +1067,7 @@ void testing_gesvd(Arguments& argus)
     device_strided_batch_vector<int> dinfo(1, 1, 1, bc);
     device_strided_batch_vector<T>   dVT(size_VT, 1, stVT, bc);
     device_strided_batch_vector<T>   dUT(size_UT, 1, stUT, bc);
+    device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
     if(size_VT)
         CHECK_HIP_ERROR(dVT.memcheck());
     if(size_UT)
@@ -1068,6 +1081,8 @@ void testing_gesvd(Arguments& argus)
     if(size_U)
         CHECK_HIP_ERROR(dU.memcheck());
     CHECK_HIP_ERROR(dinfo.memcheck());
+    if(size_W)
+        CHECK_HIP_ERROR(dWork.memcheck());
 
     if(BATCHED)
     {
@@ -1076,14 +1091,6 @@ void testing_gesvd(Arguments& argus)
         // device_batch_vector<T> dA(size_A, 1, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
-
-        // int w1, w2;
-        // hipsolver_gesvd_bufferSize(API, handle, leftv, rightv, m, n, dA.data(), lda, &w1);
-        // hipsolver_gesvd_bufferSize(API, handle, leftvT, rightvT, mT, nT, dA.data(), lda, &w2);
-        // int size_W = max(w1, w2);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        // if(size_W)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
@@ -1182,14 +1189,6 @@ void testing_gesvd(Arguments& argus)
         device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
-
-        int w1, w2;
-        hipsolver_gesvd_bufferSize(API, handle, leftv, rightv, m, n, dA.data(), lda, &w1);
-        hipsolver_gesvd_bufferSize(API, handle, leftvT, rightvT, mT, nT, dA.data(), lda, &w2);
-        int                            size_W = max(w1, w2);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        if(size_W)
-            CHECK_HIP_ERROR(dWork.memcheck());
 
         // check computations
         if(argus.unit_check || argus.norm_check)

--- a/clients/include/testing_gesvd.hpp
+++ b/clients/include/testing_gesvd.hpp
@@ -863,7 +863,7 @@ void testing_gesvd(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(2);
+            rocsolver_bench_inform(inform_invalid_args);
 
         return;
     }
@@ -1030,7 +1030,7 @@ void testing_gesvd(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_gesvdj.hpp
+++ b/clients/include/testing_gesvdj.hpp
@@ -809,6 +809,32 @@ void testing_gesvdj(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_gesvdj_bufferSize(API,
+                                STRIDED,
+                                handle,
+                                jobz,
+                                econ,
+                                m,
+                                n,
+                                (T*)nullptr,
+                                lda,
+                                (S*)nullptr,
+                                (T*)nullptr,
+                                ldu,
+                                (T*)nullptr,
+                                ldv,
+                                &size_W,
+                                params,
+                                bc);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     // memory allocations (all cases)
     // host
     host_strided_batch_vector<S>   hS(size_S, 1, stS, bc);
@@ -824,6 +850,7 @@ void testing_gesvdj(Arguments& argus)
     device_strided_batch_vector<T>   dV(size_V, 1, stV, bc);
     device_strided_batch_vector<T>   dU(size_U, 1, stU, bc);
     device_strided_batch_vector<int> dinfo(1, 1, 1, bc);
+    device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
     if(size_S)
         CHECK_HIP_ERROR(dS.memcheck());
     if(size_V)
@@ -831,36 +858,16 @@ void testing_gesvdj(Arguments& argus)
     if(size_U)
         CHECK_HIP_ERROR(dU.memcheck());
     CHECK_HIP_ERROR(dinfo.memcheck());
+    if(size_W)
+        CHECK_HIP_ERROR(dWork.memcheck());
 
     if(BATCHED)
     {
         // // memory allocations
-        // host_batch_vector<T>   hA(size_A, 1, bc);
-        // device_batch_vector<T> dA(size_A, 1, bc);
+        // host_batch_vector<T>           hA(size_A, 1, bc);
+        // device_batch_vector<T>         dA(size_A, 1, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
-
-        // int size_W;
-        // hipsolver_gesvdj_bufferSize(API,
-        //                             STRIDED,
-        //                             handle,
-        //                             jobz,
-        //                             econ,
-        //                             m,
-        //                             n,
-        //                             dA.data(),
-        //                             lda,
-        //                             dS.data(),
-        //                             dU.data(),
-        //                             ldu,
-        //                             dV.data(),
-        //                             ldv,
-        //                             &size_W,
-        //                             params,
-        //                             bc);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        // if(size_W)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
@@ -942,28 +949,6 @@ void testing_gesvdj(Arguments& argus)
         device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
-
-        int size_W;
-        hipsolver_gesvdj_bufferSize(API,
-                                    STRIDED,
-                                    handle,
-                                    jobz,
-                                    econ,
-                                    m,
-                                    n,
-                                    dA.data(),
-                                    lda,
-                                    dS.data(),
-                                    dU.data(),
-                                    ldu,
-                                    dV.data(),
-                                    ldv,
-                                    &size_W,
-                                    params,
-                                    bc);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        if(size_W)
-            CHECK_HIP_ERROR(dWork.memcheck());
 
         // check computations
         if(argus.unit_check || argus.norm_check)

--- a/clients/include/testing_gesvdj.hpp
+++ b/clients/include/testing_gesvdj.hpp
@@ -804,7 +804,7 @@ void testing_gesvdj(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -407,7 +407,7 @@ void testing_getrf(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -412,6 +412,16 @@ void testing_getrf(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_getrf_bufferSize(API, handle, m, n, (T*)nullptr, lda, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -424,15 +434,12 @@ void testing_getrf(Arguments& argus)
         // device_batch_vector<T>           dA(size_A, 1, bc);
         // device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
         // if(size_P)
         //     CHECK_HIP_ERROR(dIpiv.memcheck());
-
-        // int size_W;
-        // hipsolver_getrf_bufferSize(API, handle, m, n, dA.data(), lda, &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -493,15 +500,12 @@ void testing_getrf(Arguments& argus)
         device_strided_batch_vector<T>   dA(size_A, 1, stA, bc);
         device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
         if(size_P)
             CHECK_HIP_ERROR(dIpiv.memcheck());
-
-        int size_W;
-        hipsolver_getrf_bufferSize(API, handle, m, n, dA.data(), lda, &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -546,6 +546,17 @@ void testing_getrs(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_getrs_bufferSize(
+        API, handle, trans, m, nrhs, (T*)nullptr, lda, (int*)nullptr, (T*)nullptr, ldb, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -559,6 +570,7 @@ void testing_getrs(Arguments& argus)
         // device_batch_vector<T>           dB(size_B, 1, bc);
         // device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // if(size_B)
@@ -566,11 +578,6 @@ void testing_getrs(Arguments& argus)
         // if(size_P)
         //     CHECK_HIP_ERROR(dIpiv.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // int size_W;
-        // hipsolver_getrs_bufferSize(
-        //    API, handle, trans, m, nrhs, dA.data(), lda, dIpiv.data(), dB.data(), ldb, &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -641,6 +648,7 @@ void testing_getrs(Arguments& argus)
         device_strided_batch_vector<T>   dB(size_B, 1, stB, bc);
         device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
@@ -648,11 +656,6 @@ void testing_getrs(Arguments& argus)
         if(size_P)
             CHECK_HIP_ERROR(dIpiv.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_getrs_bufferSize(
-            API, handle, trans, m, nrhs, dA.data(), lda, dIpiv.data(), dB.data(), ldb, &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -541,7 +541,7 @@ void testing_getrs(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_orgbr_ungbr.hpp
+++ b/clients/include/testing_orgbr_ungbr.hpp
@@ -347,7 +347,7 @@ void testing_orgbr_ungbr(Arguments& argus)
                               HIPSOLVER_STATUS_INVALID_VALUE);
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_orgbr_ungbr.hpp
+++ b/clients/include/testing_orgbr_ungbr.hpp
@@ -352,6 +352,17 @@ void testing_orgbr_ungbr(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_orgbr_ungbr_bufferSize(
+        FORTRAN, handle, side, m, n, k, (T*)nullptr, lda, (T*)nullptr, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     // memory allocations
     host_strided_batch_vector<T>     hA(size_A, 1, size_A, 1);
     host_strided_batch_vector<T>     hARes(size_ARes, 1, size_ARes, 1);
@@ -361,16 +372,12 @@ void testing_orgbr_ungbr(Arguments& argus)
     device_strided_batch_vector<T>   dA(size_A, 1, size_A, 1);
     device_strided_batch_vector<T>   dIpiv(size_P, 1, size_P, 1);
     device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
+    device_strided_batch_vector<T>   dWork(size_W, 1, size_W, 1);
     if(size_A)
         CHECK_HIP_ERROR(dA.memcheck());
     if(size_P)
         CHECK_HIP_ERROR(dIpiv.memcheck());
     CHECK_HIP_ERROR(dInfo.memcheck());
-
-    int size_W;
-    hipsolver_orgbr_ungbr_bufferSize(
-        FORTRAN, handle, side, m, n, k, dA.data(), lda, dIpiv.data(), &size_W);
-    device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
     if(size_W)
         CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_orgqr_ungqr.hpp
+++ b/clients/include/testing_orgqr_ungqr.hpp
@@ -280,7 +280,7 @@ void testing_orgqr_ungqr(Arguments& argus)
                               HIPSOLVER_STATUS_INVALID_VALUE);
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_orgqr_ungqr.hpp
+++ b/clients/include/testing_orgqr_ungqr.hpp
@@ -285,6 +285,17 @@ void testing_orgqr_ungqr(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_orgqr_ungqr_bufferSize(
+        FORTRAN, handle, m, n, k, (T*)nullptr, lda, (T*)nullptr, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     // memory allocations
     host_strided_batch_vector<T>     hA(size_A, 1, size_A, 1);
     host_strided_batch_vector<T>     hARes(size_ARes, 1, size_ARes, 1);
@@ -294,16 +305,12 @@ void testing_orgqr_ungqr(Arguments& argus)
     device_strided_batch_vector<T>   dA(size_A, 1, size_A, 1);
     device_strided_batch_vector<T>   dIpiv(size_P, 1, size_P, 1);
     device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
+    device_strided_batch_vector<T>   dWork(size_W, 1, size_W, 1);
     if(size_A)
         CHECK_HIP_ERROR(dA.memcheck());
     if(size_P)
         CHECK_HIP_ERROR(dIpiv.memcheck());
     CHECK_HIP_ERROR(dInfo.memcheck());
-
-    int size_W;
-    hipsolver_orgqr_ungqr_bufferSize(
-        FORTRAN, handle, m, n, k, dA.data(), lda, dIpiv.data(), &size_W);
-    device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
     if(size_W)
         CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_orgtr_ungtr.hpp
+++ b/clients/include/testing_orgtr_ungtr.hpp
@@ -288,6 +288,17 @@ void testing_orgtr_ungtr(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_orgtr_ungtr_bufferSize(
+        FORTRAN, handle, uplo, n, (T*)nullptr, lda, (T*)nullptr, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     // memory allocations
     host_strided_batch_vector<T>     hA(size_A, 1, size_A, 1);
     host_strided_batch_vector<T>     hARes(size_ARes, 1, size_ARes, 1);
@@ -297,16 +308,12 @@ void testing_orgtr_ungtr(Arguments& argus)
     device_strided_batch_vector<T>   dA(size_A, 1, size_A, 1);
     device_strided_batch_vector<T>   dIpiv(size_P, 1, size_P, 1);
     device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
+    device_strided_batch_vector<T>   dWork(size_W, 1, size_W, 1);
     if(size_A)
         CHECK_HIP_ERROR(dA.memcheck());
     if(size_P)
         CHECK_HIP_ERROR(dIpiv.memcheck());
     CHECK_HIP_ERROR(dInfo.memcheck());
-
-    int size_W;
-    hipsolver_orgtr_ungtr_bufferSize(
-        FORTRAN, handle, uplo, n, dA.data(), lda, dIpiv.data(), &size_W);
-    device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
     if(size_W)
         CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_orgtr_ungtr.hpp
+++ b/clients/include/testing_orgtr_ungtr.hpp
@@ -283,7 +283,7 @@ void testing_orgtr_ungtr(Arguments& argus)
                               HIPSOLVER_STATUS_INVALID_VALUE);
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_ormqr_unmqr.hpp
+++ b/clients/include/testing_ormqr_unmqr.hpp
@@ -486,7 +486,7 @@ void testing_ormqr_unmqr(Arguments& argus)
                               HIPSOLVER_STATUS_INVALID_VALUE);
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(2);
+            rocsolver_bench_inform(inform_invalid_args);
 
         return;
     }
@@ -523,7 +523,7 @@ void testing_ormqr_unmqr(Arguments& argus)
                               HIPSOLVER_STATUS_INVALID_VALUE);
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -559,6 +559,28 @@ void testing_ormtr_unmtr(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_ormtr_unmtr_bufferSize(FORTRAN,
+                                     handle,
+                                     side,
+                                     uplo,
+                                     trans,
+                                     m,
+                                     n,
+                                     (T*)nullptr,
+                                     lda,
+                                     (T*)nullptr,
+                                     (T*)nullptr,
+                                     ldc,
+                                     &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     // memory allocations
     host_strided_batch_vector<T>     hC(size_C, 1, size_C, 1);
     host_strided_batch_vector<T>     hCRes(size_CRes, 1, size_CRes, 1);
@@ -570,6 +592,7 @@ void testing_ormtr_unmtr(Arguments& argus)
     device_strided_batch_vector<T>   dIpiv(size_P, 1, size_P, 1);
     device_strided_batch_vector<T>   dA(size_A, 1, size_A, 1);
     device_strided_batch_vector<int> dInfo(1, 1, 1, 1);
+    device_strided_batch_vector<T>   dWork(size_W, 1, size_W, 1);
     if(size_A)
         CHECK_HIP_ERROR(dA.memcheck());
     if(size_P)
@@ -577,22 +600,6 @@ void testing_ormtr_unmtr(Arguments& argus)
     if(size_C)
         CHECK_HIP_ERROR(dC.memcheck());
     CHECK_HIP_ERROR(dInfo.memcheck());
-
-    int size_W;
-    hipsolver_ormtr_unmtr_bufferSize(FORTRAN,
-                                     handle,
-                                     side,
-                                     uplo,
-                                     trans,
-                                     m,
-                                     n,
-                                     dA.data(),
-                                     lda,
-                                     dIpiv.data(),
-                                     dC.data(),
-                                     ldc,
-                                     &size_W);
-    device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
     if(size_W)
         CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -517,7 +517,7 @@ void testing_ormtr_unmtr(Arguments& argus)
                               HIPSOLVER_STATUS_INVALID_VALUE);
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(2);
+            rocsolver_bench_inform(inform_invalid_args);
 
         return;
     }
@@ -554,7 +554,7 @@ void testing_ormtr_unmtr(Arguments& argus)
                               HIPSOLVER_STATUS_INVALID_VALUE);
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_potrf.hpp
+++ b/clients/include/testing_potrf.hpp
@@ -335,6 +335,19 @@ void testing_potrf(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    if(BATCHED)
+        hipsolver_potrf_bufferSize(API, handle, uplo, n, (T**)nullptr, lda, &size_W, bc);
+    else
+        hipsolver_potrf_bufferSize(API, handle, uplo, n, (T*)nullptr, lda, &size_W, bc);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // memory allocations
@@ -344,13 +357,10 @@ void testing_potrf(Arguments& argus)
         host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
         device_batch_vector<T>           dA(size_A, 1, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_potrf_bufferSize(API, handle, uplo, n, dA.data(), lda, &size_W, bc);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -401,13 +411,10 @@ void testing_potrf(Arguments& argus)
         host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
         device_strided_batch_vector<T>   dA(size_A, 1, stA, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_potrf_bufferSize(API, handle, uplo, n, dA.data(), lda, &size_W, bc);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_potrf.hpp
+++ b/clients/include/testing_potrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -291,7 +291,7 @@ void testing_potrf(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(2);
+            rocsolver_bench_inform(inform_invalid_args);
 
         return;
     }
@@ -330,7 +330,7 @@ void testing_potrf(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_potri.hpp
+++ b/clients/include/testing_potri.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -289,7 +289,7 @@ void testing_potri(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(2);
+            rocsolver_bench_inform(inform_invalid_args);
 
         return;
     }
@@ -336,7 +336,7 @@ void testing_potri(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_potri.hpp
+++ b/clients/include/testing_potri.hpp
@@ -341,6 +341,16 @@ void testing_potri(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_potri_bufferSize(FORTRAN, handle, uplo, n, (T*)nullptr, lda, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -350,13 +360,10 @@ void testing_potri(Arguments& argus)
         // host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
         // device_batch_vector<T>           dA(size_A, 1, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // int size_W;
-        // hipsolver_potri_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -407,13 +414,10 @@ void testing_potri(Arguments& argus)
         host_strided_batch_vector<int>   hInfoRes(1, 1, 1, bc);
         device_strided_batch_vector<T>   dA(size_A, 1, stA, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_potri_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_potrs.hpp
+++ b/clients/include/testing_potrs.hpp
@@ -447,7 +447,7 @@ void testing_potrs(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(2);
+            rocsolver_bench_inform(inform_invalid_args);
 
         return;
     }
@@ -503,7 +503,7 @@ void testing_potrs(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_potrs.hpp
+++ b/clients/include/testing_potrs.hpp
@@ -508,6 +508,21 @@ void testing_potrs(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    if(BATCHED)
+        hipsolver_potrs_bufferSize(
+            API, handle, uplo, n, nrhs, (T**)nullptr, lda, (T**)nullptr, ldb, &size_W, bc);
+    else
+        hipsolver_potrs_bufferSize(
+            API, handle, uplo, n, nrhs, (T*)nullptr, lda, (T*)nullptr, ldb, &size_W, bc);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // memory allocations
@@ -519,16 +534,12 @@ void testing_potrs(Arguments& argus)
         device_batch_vector<T>           dA(size_A, 1, bc);
         device_batch_vector<T>           dB(size_B, 1, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
             CHECK_HIP_ERROR(dB.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_potrs_bufferSize(
-            API, handle, uplo, n, nrhs, dA.data(), lda, dB.data(), ldb, &size_W, bc);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -591,16 +602,12 @@ void testing_potrs(Arguments& argus)
         device_strided_batch_vector<T>   dA(size_A, 1, stA, bc);
         device_strided_batch_vector<T>   dB(size_B, 1, stB, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
             CHECK_HIP_ERROR(dB.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_potrs_bufferSize(
-            API, handle, uplo, n, nrhs, dA.data(), lda, dB.data(), ldb, &size_W, bc);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2021 Advanced Micro Devices, Inc.
+ * Copyright 2021-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -570,7 +570,7 @@ void testing_syevd_heevd(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -575,6 +575,17 @@ void testing_syevd_heevd(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_syevd_heevd_bufferSize(
+        FORTRAN, handle, evect, uplo, n, (T*)nullptr, lda, (S*)nullptr, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     // memory allocations (all cases)
     // host
     host_strided_batch_vector<S>   hD(size_D, 1, stD, bc);
@@ -584,25 +595,21 @@ void testing_syevd_heevd(Arguments& argus)
     // device
     device_strided_batch_vector<S>   dD(size_D, 1, stD, bc);
     device_strided_batch_vector<int> dinfo(1, 1, 1, bc);
+    device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
     if(size_D)
         CHECK_HIP_ERROR(dD.memcheck());
     CHECK_HIP_ERROR(dinfo.memcheck());
+    if(size_W)
+        CHECK_HIP_ERROR(dWork.memcheck());
 
     if(BATCHED)
     {
         // // memory allocations
-        // host_batch_vector<T>   hA(size_A, 1, bc);
-        // host_batch_vector<T>   hAres(size_Ares, 1, bc);
-        // device_batch_vector<T> dA(size_A, 1, bc);
+        // host_batch_vector<T>           hA(size_A, 1, bc);
+        // host_batch_vector<T>           hAres(size_Ares, 1, bc);
+        // device_batch_vector<T>         dA(size_A, 1, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
-
-        // int size_W;
-        // hipsolver_syevd_heevd_bufferSize(
-        //     FORTRAN, handle, evect, uplo, n, dA.data(), lda, dD.data(), &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        // if(size_W)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
@@ -663,13 +670,6 @@ void testing_syevd_heevd(Arguments& argus)
         device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
-
-        int size_W;
-        hipsolver_syevd_heevd_bufferSize(
-            FORTRAN, handle, evect, uplo, n, dA.data(), lda, dD.data(), &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        if(size_W)
-            CHECK_HIP_ERROR(dWork.memcheck());
 
         // check computations
         if(argus.unit_check || argus.norm_check)

--- a/clients/include/testing_syevdx_heevdx.hpp
+++ b/clients/include/testing_syevdx_heevdx.hpp
@@ -797,7 +797,7 @@ void testing_syevdx_heevdx(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_syevdx_heevdx.hpp
+++ b/clients/include/testing_syevdx_heevdx.hpp
@@ -802,6 +802,30 @@ void testing_syevdx_heevdx(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_Work;
+    hipsolver_syevdx_heevdx_bufferSize(API,
+                                       handle,
+                                       evect,
+                                       erange,
+                                       uplo,
+                                       n,
+                                       (T*)nullptr,
+                                       lda,
+                                       vl,
+                                       vu,
+                                       il,
+                                       iu,
+                                       (int*)nullptr,
+                                       (S*)nullptr,
+                                       &size_Work);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_Work);
+        return;
+    }
+
     // memory allocations (all cases)
     // host
     host_strided_batch_vector<int> hNev(1, 1, 1, bc);
@@ -813,9 +837,12 @@ void testing_syevdx_heevdx(Arguments& argus)
     // device
     device_strided_batch_vector<S>   dW(size_W, 1, stW, bc);
     device_strided_batch_vector<int> dinfo(1, 1, 1, bc);
+    device_strided_batch_vector<T>   dWork(size_Work, 1, size_Work, bc);
     if(size_W)
         CHECK_HIP_ERROR(dW.memcheck());
     CHECK_HIP_ERROR(dinfo.memcheck());
+    if(size_Work)
+        CHECK_HIP_ERROR(dWork.memcheck());
 
     if(BATCHED)
     {
@@ -825,26 +852,6 @@ void testing_syevdx_heevdx(Arguments& argus)
         // device_batch_vector<T> dA(size_A, 1, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
-
-        // int size_W;
-        // hipsolver_syevdx_heevdx_bufferSize(API,
-        //                                    handle,
-        //                                    evect,
-        //                                    erange,
-        //                                    uplo,
-        //                                    n,
-        //                                    dA.data(),
-        //                                    lda,
-        //                                    vl,
-        //                                    vu,
-        //                                    il,
-        //                                    iu,
-        //                                    hNevRes.data(),
-        //                                    dW.data(),
-        //                                    &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        // if(size_W)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
@@ -865,7 +872,7 @@ void testing_syevdx_heevdx(Arguments& argus)
         //                                        dW,
         //                                        stW,
         //                                        dWork,
-        //                                        size_W,
+        //                                        size_Work,
         //                                        dinfo,
         //                                        bc,
         //                                        hA,
@@ -897,7 +904,7 @@ void testing_syevdx_heevdx(Arguments& argus)
         //                                           dW,
         //                                           stW,
         //                                           dWork,
-        //                                           size_W,
+        //                                           size_Work,
         //                                           dinfo,
         //                                           bc,
         //                                           hA,
@@ -920,26 +927,6 @@ void testing_syevdx_heevdx(Arguments& argus)
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
 
-        int size_W;
-        hipsolver_syevdx_heevdx_bufferSize(API,
-                                           handle,
-                                           evect,
-                                           erange,
-                                           uplo,
-                                           n,
-                                           dA.data(),
-                                           lda,
-                                           vl,
-                                           vu,
-                                           il,
-                                           iu,
-                                           hNevRes.data(),
-                                           dW.data(),
-                                           &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        if(size_W)
-            CHECK_HIP_ERROR(dWork.memcheck());
-
         // check computations
         if(argus.unit_check || argus.norm_check)
         {
@@ -959,7 +946,7 @@ void testing_syevdx_heevdx(Arguments& argus)
                                            dW,
                                            stW,
                                            dWork,
-                                           size_W,
+                                           size_Work,
                                            dinfo,
                                            bc,
                                            hA,
@@ -991,7 +978,7 @@ void testing_syevdx_heevdx(Arguments& argus)
                                               dW,
                                               stW,
                                               dWork,
-                                              size_W,
+                                              size_Work,
                                               dinfo,
                                               bc,
                                               hA,

--- a/clients/include/testing_syevj_heevj.hpp
+++ b/clients/include/testing_syevj_heevj.hpp
@@ -628,6 +628,17 @@ void testing_syevj_heevj(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_syevj_heevj_bufferSize(
+        API, STRIDED, handle, evect, uplo, n, (T*)nullptr, lda, (S*)nullptr, &size_W, params, bc);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     // memory allocations (all cases)
     // host
     host_strided_batch_vector<S>   hD(size_D, 1, stD, bc);
@@ -637,25 +648,21 @@ void testing_syevj_heevj(Arguments& argus)
     // device
     device_strided_batch_vector<S>   dD(size_D, 1, stD, bc);
     device_strided_batch_vector<int> dinfo(1, 1, 1, bc);
+    device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
     if(size_D)
         CHECK_HIP_ERROR(dD.memcheck());
     CHECK_HIP_ERROR(dinfo.memcheck());
+    if(size_W)
+        CHECK_HIP_ERROR(dWork.memcheck());
 
     if(BATCHED)
     {
         // // memory allocations
-        // host_batch_vector<T>   hA(size_A, 1, bc);
-        // host_batch_vector<T>   hAres(size_Ares, 1, bc);
-        // device_batch_vector<T> dA(size_A, 1, bc);
+        // host_batch_vector<T>           hA(size_A, 1, bc);
+        // host_batch_vector<T>           hAres(size_Ares, 1, bc);
+        // device_batch_vector<T>         dA(size_A, 1, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
-
-        // int size_W;
-        // hipsolver_syevj_heevj_bufferSize(
-        //     API, STRIDED, handle, evect, uplo, n, dA.data(), lda, dD.data(), &size_W, params, bc);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        // if(size_W)
-        //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
@@ -718,13 +725,6 @@ void testing_syevj_heevj(Arguments& argus)
         device_strided_batch_vector<T> dA(size_A, 1, stA, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
-
-        int size_W;
-        hipsolver_syevj_heevj_bufferSize(
-            API, STRIDED, handle, evect, uplo, n, dA.data(), lda, dD.data(), &size_W, params, bc);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
-        if(size_W)
-            CHECK_HIP_ERROR(dWork.memcheck());
 
         // check computations
         if(argus.unit_check || argus.norm_check)

--- a/clients/include/testing_syevj_heevj.hpp
+++ b/clients/include/testing_syevj_heevj.hpp
@@ -623,7 +623,7 @@ void testing_syevj_heevj(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -832,6 +832,27 @@ void testing_sygvd_hegvd(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_sygvd_hegvd_bufferSize(FORTRAN,
+                                     handle,
+                                     itype,
+                                     evect,
+                                     uplo,
+                                     n,
+                                     (T*)nullptr,
+                                     lda,
+                                     (T*)nullptr,
+                                     ldb,
+                                     (S*)nullptr,
+                                     &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -846,6 +867,7 @@ void testing_sygvd_hegvd(Arguments& argus)
         // device_batch_vector<T>           dB(size_B, 1, bc);
         // device_strided_batch_vector<S>   dD(size_D, 1, stD, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // if(size_B)
@@ -853,21 +875,6 @@ void testing_sygvd_hegvd(Arguments& argus)
         // if(size_D)
         //     CHECK_HIP_ERROR(dD.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // int size_W;
-        // hipsolver_sygvd_hegvd_bufferSize(FORTRAN,
-        //                                  handle,
-        //                                  itype,
-        //                                  evect,
-        //                                  uplo,
-        //                                  n,
-        //                                  dA.data(),
-        //                                  lda,
-        //                                  dB.data(),
-        //                                  ldb,
-        //                                  dD.data(),
-        //                                  &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -944,6 +951,7 @@ void testing_sygvd_hegvd(Arguments& argus)
         device_strided_batch_vector<T>   dB(size_B, 1, stB, bc);
         device_strided_batch_vector<S>   dD(size_D, 1, stD, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
@@ -951,21 +959,6 @@ void testing_sygvd_hegvd(Arguments& argus)
         if(size_D)
             CHECK_HIP_ERROR(dD.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_sygvd_hegvd_bufferSize(FORTRAN,
-                                         handle,
-                                         itype,
-                                         evect,
-                                         uplo,
-                                         n,
-                                         dA.data(),
-                                         lda,
-                                         dB.data(),
-                                         ldb,
-                                         dD.data(),
-                                         &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -827,7 +827,7 @@ void testing_sygvd_hegvd(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_sygvj_hegvj.hpp
+++ b/clients/include/testing_sygvj_hegvj.hpp
@@ -849,7 +849,7 @@ void testing_sygvj_hegvj(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_sygvj_hegvj.hpp
+++ b/clients/include/testing_sygvj_hegvj.hpp
@@ -854,6 +854,28 @@ void testing_sygvj_hegvj(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_sygvj_hegvj_bufferSize(API,
+                                     handle,
+                                     itype,
+                                     evect,
+                                     uplo,
+                                     n,
+                                     (T*)nullptr,
+                                     lda,
+                                     (T*)nullptr,
+                                     ldb,
+                                     (S*)nullptr,
+                                     &size_W,
+                                     params);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -868,6 +890,7 @@ void testing_sygvj_hegvj(Arguments& argus)
         // device_batch_vector<T>           dB(size_B, 1, bc);
         // device_strided_batch_vector<S>   dD(size_D, 1, stD, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // if(size_B)
@@ -875,22 +898,6 @@ void testing_sygvj_hegvj(Arguments& argus)
         // if(size_D)
         //     CHECK_HIP_ERROR(dD.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
-
-        // int size_W;
-        // hipsolver_sygvj_hegvj_bufferSize(API,
-        //                                  handle,
-        //                                  itype,
-        //                                  evect,
-        //                                  uplo,
-        //                                  n,
-        //                                  dA.data(),
-        //                                  lda,
-        //                                  dB.data(),
-        //                                  ldb,
-        //                                  dD.data(),
-        //                                  &size_W,
-        //                                  params);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -969,6 +976,7 @@ void testing_sygvj_hegvj(Arguments& argus)
         device_strided_batch_vector<T>   dB(size_B, 1, stB, bc);
         device_strided_batch_vector<S>   dD(size_D, 1, stD, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         if(size_B)
@@ -976,22 +984,6 @@ void testing_sygvj_hegvj(Arguments& argus)
         if(size_D)
             CHECK_HIP_ERROR(dD.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
-
-        int size_W;
-        hipsolver_sygvj_hegvj_bufferSize(API,
-                                         handle,
-                                         itype,
-                                         evect,
-                                         uplo,
-                                         n,
-                                         dA.data(),
-                                         lda,
-                                         dB.data(),
-                                         ldb,
-                                         dD.data(),
-                                         &size_W,
-                                         params);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_sytrd_hetrd.hpp
+++ b/clients/include/testing_sytrd_hetrd.hpp
@@ -677,7 +677,7 @@ void testing_sytrd_hetrd(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(2);
+            rocsolver_bench_inform(inform_invalid_args);
 
         return;
     }
@@ -739,7 +739,7 @@ void testing_sytrd_hetrd(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/include/testing_sytrf.hpp
+++ b/clients/include/testing_sytrf.hpp
@@ -470,6 +470,16 @@ void testing_sytrf(Arguments& argus)
         return;
     }
 
+    // memory size query is necessary
+    int size_W;
+    hipsolver_sytrf_bufferSize(FORTRAN, handle, n, (T*)nullptr, lda, &size_W);
+
+    if(argus.mem_query)
+    {
+        rocsolver_bench_inform(inform_mem_query, size_W);
+        return;
+    }
+
     if(BATCHED)
     {
         // // memory allocations
@@ -482,15 +492,12 @@ void testing_sytrf(Arguments& argus)
         // device_batch_vector<T>           dA(size_A, 1, bc);
         // device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
         // device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        // device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         // if(size_A)
         //     CHECK_HIP_ERROR(dA.memcheck());
         // CHECK_HIP_ERROR(dInfo.memcheck());
         // if(size_P)
         //     CHECK_HIP_ERROR(dIpiv.memcheck());
-
-        // int size_W;
-        // hipsolver_sytrf_bufferSize(FORTRAN, handle, n, dA.data(), lda, &size_W);
-        // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
@@ -551,15 +558,12 @@ void testing_sytrf(Arguments& argus)
         device_strided_batch_vector<T>   dA(size_A, 1, stA, bc);
         device_strided_batch_vector<int> dIpiv(size_P, 1, stP, bc);
         device_strided_batch_vector<int> dInfo(1, 1, 1, bc);
+        device_strided_batch_vector<T>   dWork(size_W, 1, size_W, bc);
         if(size_A)
             CHECK_HIP_ERROR(dA.memcheck());
         CHECK_HIP_ERROR(dInfo.memcheck());
         if(size_P)
             CHECK_HIP_ERROR(dIpiv.memcheck());
-
-        int size_W;
-        hipsolver_sytrf_bufferSize(FORTRAN, handle, n, dA.data(), lda, &size_W);
-        device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 

--- a/clients/include/testing_sytrf.hpp
+++ b/clients/include/testing_sytrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright 2020-2021 Advanced Micro Devices, Inc.
+ * Copyright 2020-2022 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #pragma once
@@ -412,7 +412,7 @@ void testing_sytrf(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(2);
+            rocsolver_bench_inform(inform_invalid_args);
 
         return;
     }
@@ -465,7 +465,7 @@ void testing_sytrf(Arguments& argus)
         }
 
         if(argus.timing)
-            ROCSOLVER_BENCH_INFORM(1);
+            rocsolver_bench_inform(inform_invalid_size);
 
         return;
     }

--- a/clients/rocsolvercommon/rocsolver_arguments.hpp
+++ b/clients/rocsolvercommon/rocsolver_arguments.hpp
@@ -28,6 +28,7 @@ public:
     rocblas_int perf        = 0;
     rocblas_int singular    = 0;
     rocblas_int iters       = 5;
+    rocblas_int mem_query   = 0;
     rocblas_int batch_count = 1;
 
     // get and set function arguments

--- a/clients/rocsolvercommon/rocsolver_test.hpp
+++ b/clients/rocsolvercommon/rocsolver_test.hpp
@@ -9,19 +9,6 @@
 #include <limits>
 #include <sstream>
 
-#define ROCSOLVER_BENCH_INFORM(case)                                    \
-    do                                                                  \
-    {                                                                   \
-        if(case == 2)                                                   \
-            std::cerr << "Invalid value in arguments ..." << std::endl; \
-        else if(case == 1)                                              \
-            std::cerr << "Invalid size arguments..." << std::endl;      \
-        else                                                            \
-            std::cerr << "Quick return..." << std::endl;                \
-        std::cerr << "No performance data to collect." << std::endl;    \
-        std::cerr << "No computations to verify." << std::endl;         \
-    } while(0)
-
 template <typename T>
 constexpr double get_epsilon()
 {
@@ -46,6 +33,36 @@ constexpr double get_safemin()
 #else
 #define ROCSOLVER_TEST_CHECK(T, max_error, tol)
 #endif
+
+typedef enum rocsolver_inform_type_
+{
+    inform_quick_return,
+    inform_invalid_size,
+    inform_invalid_args,
+    inform_mem_query,
+} rocsolver_inform_type;
+
+inline void rocsolver_bench_inform(rocsolver_inform_type it, size_t arg = 0)
+{
+    switch(it)
+    {
+    case inform_quick_return:
+        printf("Quick return...\n");
+        break;
+    case inform_invalid_size:
+        printf("Invalid size arguments...\n");
+        break;
+    case inform_invalid_args:
+        printf("Invalid value in arguments...\n");
+        break;
+    case inform_mem_query:
+        printf("%li bytes of device memory are required...\n", arg);
+        break;
+    }
+    printf("No performance data to collect.\n");
+    printf("No computations to verify.\n");
+    std::fflush(stdout);
+}
 
 inline void rocsolver_bench_output()
 {


### PR DESCRIPTION
This PR ports some client changes from rocSOLVER to hipSOLVER, including the addition of the `mem_query` option to the benchmark client, and the use of enums with `rocsolver_bench_inform`.