### PR TITLE
Various fixes for rectangular gesvdj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,12 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 
 ### Changed
 - The rocSOLVER backend will now set `info` to zero if rocSOLVER does not reference `info`. (Applies to orgbr/ungbr, orgqr/ungqr, orgtr/ungtr, ormqr/unmqr, ormtr/unmtr, gebrd, geqrf, getrs, potrs, and sytrd/hetrd).
+- gesvdj will no longer require extra workspace to transpose `V` when `jobz` is `HIPSOLVER_EIG_MODE_VECTOR` and `econ` is 1.
 
 ### Fixed
 - Fixed Fortran return value declarations within hipsolver_module.f90
+- Fixed gesvdj_bufferSize returning `HIPSOLVER_STATUS_INVALID_VALUE` when `jobz` is `HIPSOLVER_EIG_MODE_NOVECTOR` and 1 <= `ldv` < `n`
+- Fixed gesvdj returning `HIPSOLVER_STATUS_INVALID_VALUE` when `jobz` is `HIPSOLVER_EIG_MODE_VECTOR`, `econ` is 1, and `m` < `n`
 
 
 ## hipSOLVER 1.4.0 for ROCm 5.2.0

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -329,6 +329,12 @@ try
             "                           ")
 
         // iterative Jacobi options
+        ("econ",
+         value<rocblas_int>()->default_value(0),
+            "Enable economy size for singular vector matrices? 0 = No, 1 = Yes.\n"
+            "                           Only applicable to gesvdj.\n"
+            "                           ")
+
         ("max_sweeps",
          value<rocblas_int>()->default_value(100),
             "Maximum number of sweeps/iterations.\n"

--- a/clients/gtest/gesvdj_gtest.cpp
+++ b/clients/gtest/gesvdj_gtest.cpp
@@ -33,7 +33,8 @@ const vector<vector<int>> size_range = {
     {1, 1, 0},
     {20, 20, 0},
     {30, 30, 0},
-    {32, 30, 0}};
+    {32, 30, 0},
+};
 
 const vector<vector<int>> opt_range = {
     // normal (valid) samples
@@ -76,10 +77,7 @@ Arguments gesvdj_setup_arguments(gesvdj_tuple tup, bool STRIDED)
     // leading dimensions
     arg.set<rocblas_int>("lda", m + opt[0] * 10);
     arg.set<rocblas_int>("ldu", m + opt[1] * 10);
-    if(opt[4] == 2 || STRIDED)
-        arg.set<rocblas_int>("ldv", n + opt[2] * 10);
-    else
-        arg.set<rocblas_int>("ldv", min(m, n) + opt[2] * 10);
+    arg.set<rocblas_int>("ldv", n + opt[2] * 10);
 
     // vector options
     if(opt[3] == 0)

--- a/clients/gtest/gesvdj_gtest.cpp
+++ b/clients/gtest/gesvdj_gtest.cpp
@@ -34,8 +34,8 @@ const vector<vector<int>> size_range = {
     {20, 20, 0},
     {30, 30, 0},
     {32, 30, 0},
-    {4, 60, 0},
-    {60, 4, 0},
+    {4, 32, 0},
+    {32, 4, 0},
 };
 
 const vector<vector<int>> opt_range = {

--- a/clients/gtest/gesvdj_gtest.cpp
+++ b/clients/gtest/gesvdj_gtest.cpp
@@ -34,6 +34,8 @@ const vector<vector<int>> size_range = {
     {20, 20, 0},
     {30, 30, 0},
     {32, 30, 0},
+    {4, 60, 0},
+    {60, 4, 0},
 };
 
 const vector<vector<int>> opt_range = {

--- a/clients/include/testing_gesvdj.hpp
+++ b/clients/include/testing_gesvdj.hpp
@@ -1021,12 +1021,12 @@ void testing_gesvdj(Arguments& argus)
     }
 
     // validate results for rocsolver-test
-    // using 3 * min(m, n) * machine_precision as tolerance
+    // using 3 * max(m, n) * machine_precision as tolerance
     if(argus.unit_check)
     {
-        ROCSOLVER_TEST_CHECK(T, max_error, 3 * min(m, n));
+        ROCSOLVER_TEST_CHECK(T, max_error, 3 * max(m, n));
         if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
-            ROCSOLVER_TEST_CHECK(T, max_errorv, 3 * min(m, n));
+            ROCSOLVER_TEST_CHECK(T, max_errorv, 3 * max(m, n));
     }
 
     // output results for rocsolver-bench

--- a/clients/include/testing_gesvdj.hpp
+++ b/clients/include/testing_gesvdj.hpp
@@ -431,9 +431,7 @@ void gesvdj_getError(const hipsolverHandle_t handle,
                      Wh&                     hA,
                      Th&                     hS,
                      Th&                     hSres,
-                     Uh&                     hU,
                      Uh&                     Ures,
-                     Uh&                     hV,
                      Uh&                     Vres,
                      Ih&                     hinfo,
                      Ih&                     hinfoRes,
@@ -446,8 +444,6 @@ void gesvdj_getError(const hipsolverHandle_t handle,
     std::vector<S> hE(size_W);
     std::vector<T> hWork(size_W);
     std::vector<T> A(lda * n * bc);
-
-    char svect = (jobz == HIPSOLVER_EIG_MODE_NOVECTOR ? 'N' : (econ == 0 ? 'A' : 'S'));
 
     // input data initialization
     gesvdj_initData<true, true, T>(handle, jobz, m, n, dA, lda, bc, hA, A);
@@ -487,17 +483,18 @@ void gesvdj_getError(const hipsolverHandle_t handle,
     }
 
     // CPU lapack
+    // Only singular values needed
     for(int b = 0; b < bc; ++b)
-        cblas_gesvd<T>(svect,
-                       svect,
+        cblas_gesvd<T>('N',
+                       'N',
                        m,
                        n,
                        hA[b],
                        lda,
                        hS[b],
-                       hU[b],
+                       nullptr,
                        ldu,
-                       hV[b],
+                       nullptr,
                        ldv,
                        hWork.data(),
                        size_W,
@@ -594,7 +591,8 @@ void gesvdj_getPerfData(const hipsolverHandle_t handle,
     std::vector<T> hWork(size_W);
     std::vector<T> A;
 
-    char svect = (jobz == HIPSOLVER_EIG_MODE_NOVECTOR ? 'N' : (econ == 0 ? 'A' : 'S'));
+    char svect     = (jobz == HIPSOLVER_EIG_MODE_NOVECTOR ? 'N' : (econ == 0 ? 'A' : 'S'));
+    int  ldv_trans = (jobz == HIPSOLVER_EIG_MODE_NOVECTOR ? 1 : (econ == 0 ? n : min(m, n)));
 
     if(!perf)
     {
@@ -613,7 +611,7 @@ void gesvdj_getPerfData(const hipsolverHandle_t handle,
                            hU[b],
                            ldu,
                            hV[b],
-                           ldv,
+                           ldv_trans,
                            hWork.data(),
                            size_W,
                            hE.data(),
@@ -708,8 +706,8 @@ void testing_gesvdj(Arguments& argus)
     int                         ldv   = argus.get<int>("ldv", n);
     int                         stA   = lda * n;
     int                         stS   = min(m, n);
-    int                         stU   = ldu * m;
-    int                         stV   = ldv * n;
+    int                         stU   = ldu * (econ ? min(m, n) : m);
+    int                         stV   = ldv * (econ ? min(m, n) : n);
 
     hipsolverEigMode_t jobz      = char2hipsolver_evect(jobzC);
     int                bc        = argus.batch_count;
@@ -721,23 +719,26 @@ void testing_gesvdj(Arguments& argus)
     // determine sizes
     size_t size_A = size_t(lda) * n;
     size_t size_S = size_t(min(m, n));
-    size_t size_V = size_t(ldv) * n;
-    size_t size_U = size_t(ldu) * m;
+    size_t size_V = 0;
+    size_t size_U = 0;
 
     size_t size_Sres = 0;
     size_t size_Ures = 0;
     size_t size_Vres = 0;
 
+    if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
+    {
+        size_U = size_t(ldu) * (econ ? min(m, n) : m);
+        size_V = size_t(ldv) * (econ ? min(m, n) : n);
+    }
+
     if(argus.unit_check || argus.norm_check)
     {
         size_Sres = size_S;
-        if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
-        {
-            size_Ures = size_U;
-            size_Vres = size_V;
-            stUres    = stU;
-            stVres    = stV;
-        }
+        size_Ures = size_U;
+        size_Vres = size_V;
+        stUres    = stU;
+        stVres    = stV;
     }
 
     double max_error = 0, gpu_time_used = 0, cpu_time_used = 0, max_errorv = 0;
@@ -896,9 +897,7 @@ void testing_gesvdj(Arguments& argus)
         //                                      hA,
         //                                      hS,
         //                                      hSres,
-        //                                      hU,
         //                                      Ures,
-        //                                      hV,
         //                                      Vres,
         //                                      hinfo,
         //                                      hinfoRes,
@@ -977,9 +976,7 @@ void testing_gesvdj(Arguments& argus)
                                              hA,
                                              hS,
                                              hSres,
-                                             hU,
                                              Ures,
-                                             hV,
                                              Vres,
                                              hinfo,
                                              hinfoRes,

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -4246,6 +4246,9 @@ try
     *lwork = 0;
     size_t sz;
 
+    bool use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR;
+    int  ldv_copy   = use_V_copy ? (econ ? min(m, n) : n) : 1;
+
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     hipsolverStatus_t status
         = rocblas2hip_status(rocsolver_sgesvd((rocblas_handle)handle,
@@ -4259,7 +4262,7 @@ try
                                               nullptr,
                                               ldu,
                                               nullptr,
-                                              ldv,
+                                              ldv_copy,
                                               nullptr,
                                               rocblas_outofplace,
                                               nullptr));
@@ -4269,8 +4272,7 @@ try
     size_t size_E = min(m, n) > 0 ? sizeof(float) * min(m, n) : 0;
 
     // space for V_copy array
-    bool   use_V_copy  = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR;
-    size_t size_V_copy = use_V_copy ? sizeof(float) * (econ ? min(m, n) : n) * n : 0;
+    size_t size_V_copy = use_V_copy ? sizeof(float) * ldv_copy * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -4316,6 +4318,9 @@ try
     *lwork = 0;
     size_t sz;
 
+    bool use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR;
+    int  ldv_copy   = use_V_copy ? (econ ? min(m, n) : n) : 1;
+
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     hipsolverStatus_t status
         = rocblas2hip_status(rocsolver_dgesvd((rocblas_handle)handle,
@@ -4329,7 +4334,7 @@ try
                                               nullptr,
                                               ldu,
                                               nullptr,
-                                              ldv,
+                                              ldv_copy,
                                               nullptr,
                                               rocblas_outofplace,
                                               nullptr));
@@ -4339,8 +4344,7 @@ try
     size_t size_E = min(m, n) > 0 ? sizeof(double) * min(m, n) : 0;
 
     // space for V_copy array
-    bool   use_V_copy  = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR;
-    size_t size_V_copy = use_V_copy ? sizeof(double) * (econ ? min(m, n) : n) * n : 0;
+    size_t size_V_copy = use_V_copy ? sizeof(double) * ldv_copy * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -4386,6 +4390,9 @@ try
     *lwork = 0;
     size_t sz;
 
+    bool use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR;
+    int  ldv_copy   = use_V_copy ? (econ ? min(m, n) : n) : 1;
+
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     hipsolverStatus_t status
         = rocblas2hip_status(rocsolver_cgesvd((rocblas_handle)handle,
@@ -4399,7 +4406,7 @@ try
                                               nullptr,
                                               ldu,
                                               nullptr,
-                                              ldv,
+                                              ldv_copy,
                                               nullptr,
                                               rocblas_outofplace,
                                               nullptr));
@@ -4409,9 +4416,7 @@ try
     size_t size_E = min(m, n) > 0 ? sizeof(float) * min(m, n) : 0;
 
     // space for V_copy array
-    bool   use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR;
-    size_t size_V_copy
-        = use_V_copy ? sizeof(rocblas_float_complex) * (econ ? min(m, n) : n) * n : 0;
+    size_t size_V_copy = use_V_copy ? sizeof(rocblas_float_complex) * ldv_copy * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -4457,6 +4462,9 @@ try
     *lwork = 0;
     size_t sz;
 
+    bool use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR;
+    int  ldv_copy   = use_V_copy ? (econ ? min(m, n) : n) : 1;
+
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
     hipsolverStatus_t status
         = rocblas2hip_status(rocsolver_zgesvd((rocblas_handle)handle,
@@ -4470,7 +4478,7 @@ try
                                               nullptr,
                                               ldu,
                                               nullptr,
-                                              ldv,
+                                              ldv_copy,
                                               nullptr,
                                               rocblas_outofplace,
                                               nullptr));
@@ -4480,9 +4488,7 @@ try
     size_t size_E = min(m, n) > 0 ? sizeof(double) * min(m, n) : 0;
 
     // space for V_copy array
-    bool   use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR;
-    size_t size_V_copy
-        = use_V_copy ? sizeof(rocblas_double_complex) * (econ ? min(m, n) : n) * n : 0;
+    size_t size_V_copy = use_V_copy ? sizeof(rocblas_double_complex) * ldv_copy * n : 0;
 
     // update size
     rocblas_start_device_memory_size_query((rocblas_handle)handle);
@@ -4586,7 +4592,7 @@ try
     if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
         return rocblas2hip_status(rocblas_sgeam((rocblas_handle)handle,
                                                 rocblas_operation_transpose,
-                                                rocblas_operation_none,
+                                                rocblas_operation_transpose,
                                                 n,
                                                 ldv_copy,
                                                 &one,
@@ -4690,7 +4696,7 @@ try
     if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
         return rocblas2hip_status(rocblas_dgeam((rocblas_handle)handle,
                                                 rocblas_operation_transpose,
-                                                rocblas_operation_none,
+                                                rocblas_operation_transpose,
                                                 n,
                                                 ldv_copy,
                                                 &one,
@@ -4793,7 +4799,7 @@ try
     if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
         return rocblas2hip_status(rocblas_cgeam((rocblas_handle)handle,
                                                 rocblas_operation_conjugate_transpose,
-                                                rocblas_operation_none,
+                                                rocblas_operation_conjugate_transpose,
                                                 n,
                                                 ldv_copy,
                                                 &one,
@@ -4897,7 +4903,7 @@ try
     if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
         return rocblas2hip_status(rocblas_zgeam((rocblas_handle)handle,
                                                 rocblas_operation_conjugate_transpose,
-                                                rocblas_operation_none,
+                                                rocblas_operation_conjugate_transpose,
                                                 n,
                                                 ldv_copy,
                                                 &one,

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -5327,6 +5327,8 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocblas_device_malloc mem((rocblas_handle)handle);
     float*                E;
@@ -5334,12 +5336,14 @@ try
 
     const float one         = 1.0f;
     const float zero        = 0.0f;
+    bool        use_V_copy  = false;
     int         ldv_copy    = 1;
     size_t      size_V_copy = 0;
     if(min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
     {
         if(ldv < n || !V)
             return HIPSOLVER_STATUS_INVALID_VALUE;
+        use_V_copy  = true;
         ldv_copy    = n;
         size_V_copy = sizeof(float) * ldv_copy * n * batch_count;
     }
@@ -5352,7 +5356,7 @@ try
             work = E + min(m, n) * batch_count;
 
         V_copy = work;
-        if(min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
+        if(use_V_copy)
             work = V_copy + ldv_copy * n * batch_count;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
@@ -5410,9 +5414,9 @@ try
     if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
         return rocblas2hip_status(rocblas_sgeam_strided_batched((rocblas_handle)handle,
                                                                 rocblas_operation_transpose,
-                                                                rocblas_operation_none,
+                                                                rocblas_operation_transpose,
                                                                 n,
-                                                                ldv_copy,
+                                                                n,
                                                                 &one,
                                                                 V_copy,
                                                                 ldv_copy,
@@ -5453,6 +5457,8 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocblas_device_malloc mem((rocblas_handle)handle);
     double*               E;
@@ -5460,12 +5466,14 @@ try
 
     const double one         = 1.0;
     const double zero        = 0.0;
+    bool         use_V_copy  = false;
     int          ldv_copy    = 1;
     size_t       size_V_copy = 0;
     if(min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
     {
         if(ldv < n || !V)
             return HIPSOLVER_STATUS_INVALID_VALUE;
+        use_V_copy  = true;
         ldv_copy    = n;
         size_V_copy = sizeof(double) * ldv_copy * n * batch_count;
     }
@@ -5478,7 +5486,7 @@ try
             work = E + min(m, n) * batch_count;
 
         V_copy = work;
-        if(min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
+        if(use_V_copy)
             work = V_copy + ldv_copy * n * batch_count;
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
@@ -5536,9 +5544,9 @@ try
     if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
         return rocblas2hip_status(rocblas_dgeam_strided_batched((rocblas_handle)handle,
                                                                 rocblas_operation_transpose,
-                                                                rocblas_operation_none,
+                                                                rocblas_operation_transpose,
                                                                 n,
-                                                                ldv_copy,
+                                                                n,
                                                                 &one,
                                                                 V_copy,
                                                                 ldv_copy,
@@ -5579,6 +5587,8 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocblas_device_malloc  mem((rocblas_handle)handle);
     float*                 E;
@@ -5586,12 +5596,14 @@ try
 
     const rocblas_float_complex one         = {1.0f, 0.0f};
     const rocblas_float_complex zero        = {0.0f, 0.0f};
+    bool                        use_V_copy  = false;
     int                         ldv_copy    = 1;
     size_t                      size_V_copy = 0;
     if(min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
     {
         if(ldv < n || !V)
             return HIPSOLVER_STATUS_INVALID_VALUE;
+        use_V_copy  = true;
         ldv_copy    = n;
         size_V_copy = sizeof(rocblas_float_complex) * ldv_copy * n * batch_count;
     }
@@ -5604,7 +5616,7 @@ try
             work = (hipFloatComplex*)(E + min(m, n) * batch_count);
 
         V_copy = (rocblas_float_complex*)work;
-        if(min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
+        if(use_V_copy)
             work = (hipFloatComplex*)(V_copy + ldv_copy * n * batch_count);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
@@ -5663,9 +5675,9 @@ try
         return rocblas2hip_status(
             rocblas_cgeam_strided_batched((rocblas_handle)handle,
                                           rocblas_operation_conjugate_transpose,
-                                          rocblas_operation_none,
+                                          rocblas_operation_conjugate_transpose,
                                           n,
-                                          ldv_copy,
+                                          n,
                                           &one,
                                           V_copy,
                                           ldv_copy,
@@ -5706,6 +5718,8 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocblas_device_malloc   mem((rocblas_handle)handle);
     double*                 E;
@@ -5713,12 +5727,14 @@ try
 
     const rocblas_double_complex one         = {1.0, 0.0};
     const rocblas_double_complex zero        = {0.0, 0.0};
+    bool                         use_V_copy  = false;
     int                          ldv_copy    = 1;
     size_t                       size_V_copy = 0;
     if(min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
     {
         if(ldv < n || !V)
             return HIPSOLVER_STATUS_INVALID_VALUE;
+        use_V_copy  = true;
         ldv_copy    = n;
         size_V_copy = sizeof(rocblas_double_complex) * ldv_copy * n * batch_count;
     }
@@ -5731,7 +5747,7 @@ try
             work = (hipDoubleComplex*)(E + min(m, n) * batch_count);
 
         V_copy = (rocblas_double_complex*)work;
-        if(min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR)
+        if(use_V_copy)
             work = (hipDoubleComplex*)(V_copy + ldv_copy * n * batch_count);
 
         CHECK_ROCBLAS_ERROR(rocblas_set_workspace((rocblas_handle)handle, work, lwork));
@@ -5790,9 +5806,9 @@ try
         return rocblas2hip_status(
             rocblas_zgeam_strided_batched((rocblas_handle)handle,
                                           rocblas_operation_conjugate_transpose,
-                                          rocblas_operation_none,
+                                          rocblas_operation_conjugate_transpose,
                                           n,
-                                          ldv_copy,
+                                          n,
                                           &one,
                                           V_copy,
                                           ldv_copy,

--- a/library/src/hcc_detail/hipsolver.cpp
+++ b/library/src/hcc_detail/hipsolver.cpp
@@ -4256,11 +4256,14 @@ try
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
-    if(ldv < n)
-        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
     size_t sz;
+
+    if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR && ldv < n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(jobz == HIPSOLVER_EIG_MODE_NOVECTOR && ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     bool use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR && !econ;
     int  ldv_copy   = use_V_copy ? n : 1;
@@ -4328,11 +4331,14 @@ try
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
-    if(ldv < n)
-        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
     size_t sz;
+
+    if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR && ldv < n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(jobz == HIPSOLVER_EIG_MODE_NOVECTOR && ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     bool use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR && !econ;
     int  ldv_copy   = use_V_copy ? n : 1;
@@ -4400,11 +4406,14 @@ try
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
-    if(ldv < n)
-        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
     size_t sz;
+
+    if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR && ldv < n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(jobz == HIPSOLVER_EIG_MODE_NOVECTOR && ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     bool use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR && !econ;
     int  ldv_copy   = use_V_copy ? n : 1;
@@ -4472,11 +4481,14 @@ try
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(lwork == nullptr)
         return HIPSOLVER_STATUS_INVALID_VALUE;
-    if(ldv < n)
-        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
     size_t sz;
+
+    if(jobz != HIPSOLVER_EIG_MODE_NOVECTOR && ldv < n)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(jobz == HIPSOLVER_EIG_MODE_NOVECTOR && ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     bool use_V_copy = min(m, n) > 0 && jobz != HIPSOLVER_EIG_MODE_NOVECTOR && !econ;
     int  ldv_copy   = use_V_copy ? n : 1;
@@ -4544,6 +4556,8 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocblas_device_malloc mem((rocblas_handle)handle);
     float*                E;
@@ -4660,6 +4674,8 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocblas_device_malloc mem((rocblas_handle)handle);
     double*               E;
@@ -4777,6 +4793,8 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocblas_device_malloc  mem((rocblas_handle)handle);
     float*                 E;
@@ -4893,6 +4911,8 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(ldv < 1)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocblas_device_malloc   mem((rocblas_handle)handle);
     double*                 E;


### PR DESCRIPTION
This PR hotfixes various issues with gesvdj, mostly related to non-square matrices and the economy size option.

1. Testing code fixes: Under the current testing code when economy size is enabled, V will be allocated as a `min(m,n)*n` matrix with `ldv >= min(m,n)` and U is allocated as `m*m`. This is incorrect. Since gesvdj returns V and not V^H (unlike gesvd), it should actually be a `n*min(m,n)` matrix with `ldv >= n`. Also, we can allocate U as a `m*min(m,n)` matrix instead to save memory.

2. gesvdj_bufferSize fixes: Current code will cause bufferSize to return an error if `ldv < n`, even if V is not required. Also, it's allocating too much workspace by passing `ldv >= n` to rocsolver_gesvd instead of `ldv >= min(m,n)`. I'm cutting down on the amount of workspace needed when economy size is enabled by using rocsolver_gesvd's overwrite functionality, meaning V^H will overwrite A instead of a temporary workspace array, which we can then transpose using rocblas_geam.

3. gesvdj fixes: I mistakenly used `rocblas_operation_none` for the second matrix op in the rocblas_geam calls (figuring it would be ignored), which causes gesvdj to return an error when `m < n`. Other changes to gesvdj are designed to use the overwrite functionality when economy size is enabled.