### PR TITLE
Update Ubuntu version for static analysis job

### DIFF
--- a/.jenkins/staticanalysis.groovy
+++ b/.jenkins/staticanalysis.groovy
@@ -63,6 +63,6 @@ ci: {
 
     properties(auxiliary.addCommonProperties([pipelineTriggers([cron('0 1 * * 2')])]))
     stage(urlJobName) {
-        runCI([ubuntu18:['cpu']], urlJobName)
+        runCI([ubuntu20:['cpu']], urlJobName)
     }
 }


### PR DESCRIPTION
As of ROCm 5.3, Ubuntu 18 is no longer supported. Updating the Static Analysis job to Ubuntu 20 for CI compatibility.