### PR TITLE
HOTFIX: Remove backwards compatibility headers on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ endif()
 include(CMakeDependentOption)
 cmake_dependent_option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY
   "Build with file/folder reorg backward compatibility enabled" ON "NOT WIN32" OFF)
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_dir(
     ${CMAKE_SOURCE_DIR}/library/include
     PATTERNS "*.h"

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -153,7 +153,7 @@ set_target_properties( hipsolver PROPERTIES CXX_VISIBILITY_PRESET "hidden" VISIB
 generate_export_header( hipsolver EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/hipsolver/internal/hipsolver-export.h )
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/library/include ${PROJECT_BINARY_DIR}/include/hipsolver)
-if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_wrap_header_file(
     internal/hipsolver-version.h internal/hipsolver-export.h
     GUARDS SYMLINK WRAPPER
@@ -197,7 +197,7 @@ if( UNIX )
           DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/hipsolver")
 endif( )
 
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY AND NOT WIN32)
   rocm_install(
     DIRECTORY
        "${PROJECT_BINARY_DIR}/hipsolver"


### PR DESCRIPTION
The backwards compatibility headers should not be generated or installed on Windows.