### PR TITLE
Fix for old version rocm folder not removed on upgrade of meta packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,8 @@ else()
   endif()
 endif()
 
+set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" )
+
 # Give hipsolver compiled for CUDA backend a different name
 if( NOT USE_CUDA )
     set( package_name hipsolver )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,8 +232,6 @@ else()
   endif()
 endif()
 
-set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" )
-
 # Give hipsolver compiled for CUDA backend a different name
 if( NOT USE_CUDA )
     set( package_name hipsolver )


### PR DESCRIPTION
Proposed Changes:
- Fix for SWDEV-344187
- Removed CPACK_PACKAGING_INSTALL_PREFIX}/CMAKE_INSTALL_INCLUDEDIR and CPACK_PACKAGING_INSTALL_PREFIX/CMAKE_INSTALL_LIBDIR
from CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION list of exclude path