### PR TITLE
Remove RPATH/RUNPATH from ROCm libraries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -586,8 +586,8 @@ fi
   if [[ "${build_relocatable}" == true ]]; then
     CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX="${rocm_path}" \
     -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hip;$(pwd)/../deps/deps-install;${cuda_path};${cmake_prefix_path}" \
-    -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" \
-    -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--enable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \
+    -DCMAKE_SHARED_LINKER_FLAGS="" \
+    -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--disable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \
     -DROCM_DISABLE_LDCONFIG=ON \
     -DROCM_PATH="${rocm_path}" ../..
   else

--- a/install.sh
+++ b/install.sh
@@ -583,6 +583,7 @@ fi
     -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hip;$(pwd)/../deps/deps-install;${cuda_path};${cmake_prefix_path}" \
     -DROCM_DISABLE_LDCONFIG=ON \
     -DCMAKE_SKIP_INSTALL_RPATH=TRUE \
+    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE \
     -DROCM_PATH="${rocm_path}" ../..
   else
     CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..

--- a/install.sh
+++ b/install.sh
@@ -584,6 +584,7 @@ fi
     -DCMAKE_SHARED_LINKER_FLAGS="" \
     -DCMAKE_EXE_LINKER_FLAGS="" \
     -DROCM_DISABLE_LDCONFIG=ON \
+    -DCMAKE_SKIP_RPATH=TRUE \
     -DROCM_PATH="${rocm_path}" ../..
   else
     CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..

--- a/install.sh
+++ b/install.sh
@@ -582,7 +582,7 @@ fi
     CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX="${rocm_path}" \
     -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hip;$(pwd)/../deps/deps-install;${cuda_path};${cmake_prefix_path}" \
     -DCMAKE_SHARED_LINKER_FLAGS="" \
-    -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--disable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \
+    -DCMAKE_EXE_LINKER_FLAGS="" \
     -DROCM_DISABLE_LDCONFIG=ON \
     -DROCM_PATH="${rocm_path}" ../..
   else

--- a/install.sh
+++ b/install.sh
@@ -581,10 +581,8 @@ fi
   if [[ "${build_relocatable}" == true ]]; then
     CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX="${rocm_path}" \
     -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hip;$(pwd)/../deps/deps-install;${cuda_path};${cmake_prefix_path}" \
-    -DCMAKE_SHARED_LINKER_FLAGS="" \
-    -DCMAKE_EXE_LINKER_FLAGS="" \
     -DROCM_DISABLE_LDCONFIG=ON \
-    -DCMAKE_SKIP_RPATH=TRUE \
+    -DCMAKE_SKIP_INSTALL_RPATH=TRUE \
     -DROCM_PATH="${rocm_path}" ../..
   else
     CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..

--- a/install.sh
+++ b/install.sh
@@ -448,11 +448,6 @@ if [[ "${build_relocatable}" == true ]]; then
     if ! [ -z ${ROCM_PATH+x} ]; then
         rocm_path=${ROCM_PATH}
     fi
-
-    rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
-    if ! [ -z ${ROCM_RPATH+x} ]; then
-        rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"
-    fi
 fi
 
 build_dir=./build


### PR DESCRIPTION
Proposed Changes:
- SWDEV-310152: 
- Single version package: add ldconfig, no RPATH/RUNPATH in either binaries or libraries
- Multi version package: use RPATH for binaries, no RPATH/RUNPATH for libraries
- amdclang/clang/hipcc compilers shall not add RPATH/RUNPATH to produced binaries or libraries unless explicitly requested by an option
- Versioning scripts will take care of adding rpath to binaries for multi version package