### PR TITLE
Revert "Remove RPATH/RUNPATH from ROCm libraries (#136)"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -448,6 +448,11 @@ if [[ "${build_relocatable}" == true ]]; then
     if ! [ -z ${ROCM_PATH+x} ]; then
         rocm_path=${ROCM_PATH}
     fi
+
+    rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,/opt/rocm/lib:/opt/rocm/lib64"
+    if ! [ -z ${ROCM_RPATH+x} ]; then
+        rocm_rpath=" -Wl,--enable-new-dtags -Wl,--rpath,${ROCM_RPATH}"
+    fi
 fi
 
 build_dir=./build
@@ -581,9 +586,9 @@ fi
   if [[ "${build_relocatable}" == true ]]; then
     CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_INSTALL_PREFIX="${rocm_path}" \
     -DCMAKE_PREFIX_PATH="${rocm_path};${rocm_path}/hip;$(pwd)/../deps/deps-install;${cuda_path};${cmake_prefix_path}" \
+    -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" \
+    -DCMAKE_EXE_LINKER_FLAGS=" -Wl,--enable-new-dtags -Wl,--rpath,${rocm_path}/lib:${rocm_path}/lib64" \
     -DROCM_DISABLE_LDCONFIG=ON \
-    -DCMAKE_SKIP_INSTALL_RPATH=TRUE \
-    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE \
     -DROCM_PATH="${rocm_path}" ../..
   else
     CXX=${compiler} ${cmake_executable} ${cmake_common_options[@]} ${cmake_client_options[@]} -DCPACK_SET_DESTDIR=OFF -DCMAKE_PREFIX_PATH="$(pwd)/../deps/deps-install;${cmake_prefix_path}" -DROCM_PATH=${rocm_path} ../..


### PR DESCRIPTION
SWDEV-310152 has been deferred to a later release. It would be worse to have only some of the libraries changed in ROCm 5.5 than to have them all configured one way or the other, so we will undo the changes made to hipSOLVER for this release.

This reverts commit 9003d0ebe432d9de12f74db92ee2ff896341729a.