### PR TITLE
Minor tweak to include guards for consistency

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2020-2022 Advanced Micro Devices, Inc.
+Copyright (C) 2020-2023 Advanced Micro Devices, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/library/include/internal/hipsolver-version.h.in
+++ b/library/include/internal/hipsolver-version.h.in
@@ -1,9 +1,9 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#ifndef HIPSOLVER_VERSION_H_
-#define HIPSOLVER_VERSION_H_
+#ifndef HIPSOLVER_VERSION_H
+#define HIPSOLVER_VERSION_H
 
 /* the configured version and settings
  */
@@ -14,4 +14,4 @@
 #define hipsolverVersionTweak @hipsolver_VERSION_TWEAK@
 // clang-format on
 
-#endif
+#endif /* HIPSOLVER_VERSION_H */


### PR DESCRIPTION
We were more or less already doing this right in hipSOLVER, but I figured I might as well clean up that last detail.