### PR TITLE
Improve error reporting for zero-tolerance test failures

### DIFF
--- a/clients/include/testing_gebrd.hpp
+++ b/clients/include/testing_gebrd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -584,8 +584,11 @@ void gebrd_getError(const hipsolverHandle_t handle,
     // check info
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfoRes[b][0], 0) << "where b = " << b;
         if(hInfoRes[b][0] != 0)
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -422,8 +422,11 @@ void gels_getError(const hipsolverHandle_t handle,
     // also check info for singularities
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_geqrf.hpp
+++ b/clients/include/testing_geqrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -247,8 +247,11 @@ void geqrf_getError(const hipsolverHandle_t handle,
     // check info
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_gesv.hpp
+++ b/clients/include/testing_gesv.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -450,8 +450,11 @@ void gesv_getError(const hipsolverHandle_t handle,
     // also check info for singularities
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_gesvd.hpp
+++ b/clients/include/testing_gesvd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -612,8 +612,11 @@ void gesvd_getError(const hipsolverHandle_t handle,
     // Check info for non-convergence
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // (We expect the used input matrices to always converge. Testing
     // implicitly the equivalent non-converged matrix is very complicated and it boils

--- a/clients/include/testing_gesvda.hpp
+++ b/clients/include/testing_gesvda.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -539,8 +539,11 @@ void gesvda_getError(const hipsolverHandle_t handle,
     // // Check info for non-convergence
     *max_err = 0;
     // for(int b = 0; b < bc; ++b)
+    // {
+    //     EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
     //     if(hinfo[b][0] != hinfoRes[b][0])
     //         *max_err += 1;
+    // }
 
     double err;
     *max_errv = 0;

--- a/clients/include/testing_gesvdj.hpp
+++ b/clients/include/testing_gesvdj.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -532,20 +532,30 @@ void gesvdj_getError(const hipsolverHandle_t handle,
     // Check info for non-convergence
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     if(!STRIDED)
     {
         // Also check validity of residual
         for(rocblas_int b = 0; b < bc; ++b)
+        {
+            EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
             if(hResidualRes[b][0] < 0)
                 *max_err += 1;
+        }
 
         // Also check validity of sweeps
         for(rocblas_int b = 0; b < bc; ++b)
+        {
+            EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
+            EXPECT_LE(hSweepsRes[b][0], max_sweeps) << "where b = " << b;
             if(hSweepsRes[b][0] < 0 || hSweepsRes[b][0] > max_sweeps)
                 *max_err += 1;
+        }
     }
 
     // (We expect the used input matrices to always converge. Testing

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -254,8 +254,11 @@ void getrf_getError(const hipsolverHandle_t handle,
         {
             err = 0;
             for(int i = 0; i < min(m, n); ++i)
+            {
+                EXPECT_EQ(hIpiv[b][i], hIpivRes[b][i]) << "where b = " << b << ", i = " << i;
                 if(hIpiv[b][i] != hIpivRes[b][i])
                     err++;
+            }
             *max_err = err > *max_err ? err : *max_err;
         }
     }
@@ -263,8 +266,11 @@ void getrf_getError(const hipsolverHandle_t handle,
     // also check info for singularities
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_getrs.hpp
+++ b/clients/include/testing_getrs.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -375,8 +375,11 @@ void getrs_getError(const hipsolverHandle_t    handle,
     // check info
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_orgbr_ungbr.hpp
+++ b/clients/include/testing_orgbr_ungbr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -219,6 +219,7 @@ void orgbr_ungbr_getError(const hipsolverHandle_t   handle,
     *max_err = norm_error('F', m, n, lda, hA[0], hARes[0]);
 
     // check info
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err++;
 }

--- a/clients/include/testing_orgqr_ungqr.hpp
+++ b/clients/include/testing_orgqr_ungqr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -174,6 +174,7 @@ void orgqr_ungqr_getError(const hipsolverHandle_t handle,
     *max_err = norm_error('F', m, n, lda, hA[0], hARes[0]);
 
     // check info
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err++;
 }

--- a/clients/include/testing_orgtr_ungtr.hpp
+++ b/clients/include/testing_orgtr_ungtr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -177,6 +177,7 @@ void orgtr_ungtr_getError(const hipsolverHandle_t   handle,
     *max_err = norm_error('F', n, n, lda, hA[0], hARes[0]);
 
     // check info
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err++;
 }

--- a/clients/include/testing_ormqr_unmqr.hpp
+++ b/clients/include/testing_ormqr_unmqr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -355,6 +355,7 @@ void ormqr_unmqr_getError(const hipsolverHandle_t    handle,
     *max_err = norm_error('F', m, n, ldc, hC[0], hCRes[0]);
 
     // check info
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err++;
 }

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -385,6 +385,7 @@ void ormtr_unmtr_getError(const hipsolverHandle_t    handle,
     *max_err = norm_error('F', m, n, ldc, hC[0], hCRes[0]);
 
     // check info
+    EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
         *max_err++;
 }

--- a/clients/include/testing_potrf.hpp
+++ b/clients/include/testing_potrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -199,8 +199,11 @@ void potrf_getError(const hipsolverHandle_t   handle,
     // also check info for non positive definite cases
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_potri.hpp
+++ b/clients/include/testing_potri.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -178,6 +178,7 @@ void potri_getError(const hipsolverHandle_t   handle,
     *max_err   = 0;
     for(rocblas_int b = 0; b < bc; ++b)
     {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
     }

--- a/clients/include/testing_potrs.hpp
+++ b/clients/include/testing_potrs.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -300,8 +300,11 @@ void potrs_getError(const hipsolverHandle_t   handle,
     // check info
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -340,8 +340,11 @@ void syevd_heevd_getError(const hipsolverHandle_t   handle,
     // Check info for non-convergence
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // (We expect the used input matrices to always converge. Testing
     // implicitly the equivalent non-converged matrix is very complicated and it boils

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -341,7 +341,7 @@ void syevd_heevd_getError(const hipsolverHandle_t   handle,
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
     {
-        EXPECT_EQ(hinfo[b][0], hInfoRes[b][0]) << "where b = " << b;
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
     }

--- a/clients/include/testing_syevdx_heevdx.hpp
+++ b/clients/include/testing_syevdx_heevdx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -518,14 +518,20 @@ void syevdx_heevdx_getError(const hipsolverHandle_t   handle,
     // Check info for non-convergence
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     // Check number of returned eigenvalues
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
             *max_err += 1;
+    }
 
     // (We expect the used input matrices to always converge. Testing
     // implicitly the equivalent non-converged matrix is very complicated and it boils

--- a/clients/include/testing_syevj_heevj.hpp
+++ b/clients/include/testing_syevj_heevj.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -392,21 +392,37 @@ void syevj_heevj_getError(const hipsolverHandle_t   handle,
     // Check info for non-convergence
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hinfo[b][0], hinfoRes[b][0]) << "where b = " << b;
         if(hinfo[b][0] != hinfoRes[b][0])
             *max_err += 1;
+    }
 
     if(!STRIDED)
     {
         // Also check validity of residual
         for(rocblas_int b = 0; b < bc; ++b)
-            if(hResidualRes[b][0] < 0
-               || hResidualRes[b][0] > snorm('F', n, n, A.data() + b * lda * n, lda) * atol)
+        {
+            EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
+            if(hResidualRes[b][0] < 0)
                 *max_err += 1;
+            else
+            {
+                S threshold = snorm('F', n, n, A.data() + b * lda * n, lda) * atol;
+                EXPECT_LE(hResidualRes[b][0], threshold) << "where b = " << b;
+                if(hResidualRes[b][0] > threshold)
+                    *max_err += 1;
+            }
+        }
 
         // Also check validity of sweeps
         for(rocblas_int b = 0; b < bc; ++b)
+        {
+            EXPECT_GE(hSweepsRes[b][0], 0) << "where b = " << b;
+            EXPECT_LE(hSweepsRes[b][0], max_sweeps) << "where b = " << b;
             if(hSweepsRes[b][0] < 0 || hSweepsRes[b][0] > max_sweeps)
                 *max_err += 1;
+        }
     }
 
     double err = 0;

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -510,8 +510,11 @@ void sygvd_hegvd_getError(const hipsolverHandle_t   handle,
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             *max_err += 1;
+    }
 
     double err;
 

--- a/clients/include/testing_sygvdx_hegvdx.hpp
+++ b/clients/include/testing_sygvdx_hegvdx.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -758,14 +758,20 @@ void sygvdx_hegvdx_getError(const hipsolverHandle_t   handle,
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             *max_err += 1;
+    }
 
     // Check number of returned eigenvalues
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hNev[b][0], hNevRes[b][0]) << "where b = " << b;
         if(hNev[b][0] != hNevRes[b][0])
             *max_err += 1;
+    }
 
     double err;
 

--- a/clients/include/testing_sygvj_hegvj.hpp
+++ b/clients/include/testing_sygvj_hegvj.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -530,18 +530,28 @@ void sygvj_hegvj_getError(const hipsolverHandle_t   handle,
     // check info for non-convergence and/or positive-definiteness
     *max_err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             *max_err += 1;
+    }
 
     // Also check validity of residual
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_GE(hResidualRes[b][0], 0) << "where b = " << b;
         if(hResidualRes[b][0] < 0)
             *max_err += 1;
+    }
 
     // Also check validity of sweeps
     for(rocblas_int b = 0; b < bc; ++b)
+    {
+        EXPECT_GE(hSweepsRes[b][0], 0) << "where b = " << b;
+        EXPECT_LE(hSweepsRes[b][0], max_sweeps) << "where b = " << b;
         if(hSweepsRes[b][0] < 0 || hSweepsRes[b][0] > max_sweeps)
             *max_err += 1;
+    }
 
     double err;
 

--- a/clients/include/testing_sytrd_hetrd.hpp
+++ b/clients/include/testing_sytrd_hetrd.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -514,8 +514,11 @@ void sytrd_hetrd_getError(const hipsolverHandle_t   handle,
     // check info
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfoRes[b][0], 0) << "where b = " << b;
         if(hInfoRes[b][0] != 0)
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/testing_sytrf.hpp
+++ b/clients/include/testing_sytrf.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -272,16 +272,22 @@ void sytrf_getError(const hipsolverHandle_t   handle,
         // also check pivoting (count the number of incorrect pivots)
         err = 0;
         for(int i = 0; i < n; ++i)
+        {
+            EXPECT_EQ(hIpiv[b][i], hIpivRes[b][i]) << "where b = " << b << ", i = " << i;
             if(hIpiv[b][i] != hIpivRes[b][i])
                 err++;
+        }
         *max_err = err > *max_err ? err : *max_err;
     }
 
     // also check info
     err = 0;
     for(int b = 0; b < bc; ++b)
+    {
+        EXPECT_EQ(hInfo[b][0], hInfoRes[b][0]) << "where b = " << b;
         if(hInfo[b][0] != hInfoRes[b][0])
             err++;
+    }
     *max_err += err;
 }
 

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -90,6 +90,24 @@ inline void hipsolver_expect_status(hipsolverStatus_t status, hipsolverStatus_t 
 #define EXPECT_ROCBLAS_STATUS(status, expected) hipsolver_expect_status(status, expected)
 #define CHECK_ROCBLAS_ERROR(status) hipsolver_expect_status(status, HIPSOLVER_STATUS_SUCCESS)
 
+// The info provided to EXPECT macros is used in hipsolver-test, but
+// in hipsolver-bench, the information is just discarded.
+struct hipsolver_info_discarder
+{
+    template <typename T>
+    hipsolver_info_discarder& operator<<(T&&)
+    {
+        return *this;
+    }
+};
+
+#define EXPECT_EQ(v1, v2) hipsolver_info_discarder()
+#define EXPECT_NE(v1, v2) hipsolver_info_discarder()
+#define EXPECT_LT(v1, v2) hipsolver_info_discarder()
+#define EXPECT_LE(v1, v2) hipsolver_info_discarder()
+#define EXPECT_GT(v1, v2) hipsolver_info_discarder()
+#define EXPECT_GE(v1, v2) hipsolver_info_discarder()
+
 #endif
 
 #ifdef __cplusplus
@@ -111,10 +129,10 @@ public:
         hipsolverDestroy(m_handle);
     }
 
-    hipsolver_local_handle(const hipsolver_local_handle&) = delete;
-    hipsolver_local_handle(hipsolver_local_handle&&)      = delete;
+    hipsolver_local_handle(const hipsolver_local_handle&)            = delete;
+    hipsolver_local_handle(hipsolver_local_handle&&)                 = delete;
     hipsolver_local_handle& operator=(const hipsolver_local_handle&) = delete;
-    hipsolver_local_handle& operator=(hipsolver_local_handle&&) = delete;
+    hipsolver_local_handle& operator=(hipsolver_local_handle&&)      = delete;
 
     // Allow hipsolver_local_handle to be used anywhere hipsolverHandle_t is expected
     operator hipsolverHandle_t&()
@@ -144,10 +162,10 @@ public:
         hipsolverDnDestroyGesvdjInfo(m_info);
     }
 
-    hipsolver_local_gesvdj_info(const hipsolver_local_gesvdj_info&) = delete;
-    hipsolver_local_gesvdj_info(hipsolver_local_gesvdj_info&&)      = delete;
+    hipsolver_local_gesvdj_info(const hipsolver_local_gesvdj_info&)            = delete;
+    hipsolver_local_gesvdj_info(hipsolver_local_gesvdj_info&&)                 = delete;
     hipsolver_local_gesvdj_info& operator=(const hipsolver_local_gesvdj_info&) = delete;
-    hipsolver_local_gesvdj_info& operator=(hipsolver_local_gesvdj_info&&) = delete;
+    hipsolver_local_gesvdj_info& operator=(hipsolver_local_gesvdj_info&&)      = delete;
 
     // Allow hipsolver_local_gesvdj_info to be used anywhere hipsolverGesvdjInfo_t is expected
     operator hipsolverGesvdjInfo_t&()
@@ -177,10 +195,10 @@ public:
         hipsolverDnDestroySyevjInfo(m_info);
     }
 
-    hipsolver_local_syevj_info(const hipsolver_local_syevj_info&) = delete;
-    hipsolver_local_syevj_info(hipsolver_local_syevj_info&&)      = delete;
+    hipsolver_local_syevj_info(const hipsolver_local_syevj_info&)            = delete;
+    hipsolver_local_syevj_info(hipsolver_local_syevj_info&&)                 = delete;
     hipsolver_local_syevj_info& operator=(const hipsolver_local_syevj_info&) = delete;
-    hipsolver_local_syevj_info& operator=(hipsolver_local_syevj_info&&) = delete;
+    hipsolver_local_syevj_info& operator=(hipsolver_local_syevj_info&&)      = delete;
 
     // Allow hipsolver_local_syevj_info to be used anywhere hipsolverSyevjInfo_t is expected
     operator hipsolverSyevjInfo_t&()

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -129,10 +129,10 @@ public:
         hipsolverDestroy(m_handle);
     }
 
-    hipsolver_local_handle(const hipsolver_local_handle&)            = delete;
-    hipsolver_local_handle(hipsolver_local_handle&&)                 = delete;
+    hipsolver_local_handle(const hipsolver_local_handle&) = delete;
+    hipsolver_local_handle(hipsolver_local_handle&&)      = delete;
     hipsolver_local_handle& operator=(const hipsolver_local_handle&) = delete;
-    hipsolver_local_handle& operator=(hipsolver_local_handle&&)      = delete;
+    hipsolver_local_handle& operator=(hipsolver_local_handle&&) = delete;
 
     // Allow hipsolver_local_handle to be used anywhere hipsolverHandle_t is expected
     operator hipsolverHandle_t&()
@@ -162,10 +162,10 @@ public:
         hipsolverDnDestroyGesvdjInfo(m_info);
     }
 
-    hipsolver_local_gesvdj_info(const hipsolver_local_gesvdj_info&)            = delete;
-    hipsolver_local_gesvdj_info(hipsolver_local_gesvdj_info&&)                 = delete;
+    hipsolver_local_gesvdj_info(const hipsolver_local_gesvdj_info&) = delete;
+    hipsolver_local_gesvdj_info(hipsolver_local_gesvdj_info&&)      = delete;
     hipsolver_local_gesvdj_info& operator=(const hipsolver_local_gesvdj_info&) = delete;
-    hipsolver_local_gesvdj_info& operator=(hipsolver_local_gesvdj_info&&)      = delete;
+    hipsolver_local_gesvdj_info& operator=(hipsolver_local_gesvdj_info&&) = delete;
 
     // Allow hipsolver_local_gesvdj_info to be used anywhere hipsolverGesvdjInfo_t is expected
     operator hipsolverGesvdjInfo_t&()
@@ -195,10 +195,10 @@ public:
         hipsolverDnDestroySyevjInfo(m_info);
     }
 
-    hipsolver_local_syevj_info(const hipsolver_local_syevj_info&)            = delete;
-    hipsolver_local_syevj_info(hipsolver_local_syevj_info&&)                 = delete;
+    hipsolver_local_syevj_info(const hipsolver_local_syevj_info&) = delete;
+    hipsolver_local_syevj_info(hipsolver_local_syevj_info&&)      = delete;
     hipsolver_local_syevj_info& operator=(const hipsolver_local_syevj_info&) = delete;
-    hipsolver_local_syevj_info& operator=(hipsolver_local_syevj_info&&)      = delete;
+    hipsolver_local_syevj_info& operator=(hipsolver_local_syevj_info&&) = delete;
 
     // Allow hipsolver_local_syevj_info to be used anywhere hipsolverSyevjInfo_t is expected
     operator hipsolverSyevjInfo_t&()


### PR DESCRIPTION
The hipsolver tests report certain error conditions (like unexpected info values) by adding a positive integer to the measured error. This can make it difficult to understand what is wrong when reviewing the logs for a failed set of tests (especially when there are multiple properties that could all increment the error).

The Google Test EXPECT functions will check a condition, but allow the test to continue. This means that an error can be recorded at the place where it occurs, without losing data.

This matches the changes made to rocsolver in cac76478d3a2fb860.