### PR TITLE
Convert void pointer typedefs into opaque types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 ### Added
 ### Optimized
 ### Changed
+- hipsolverHandle_t, hipsolverRfHandle_t, hipsolverGesvdjInfo_t, and hipsolverSyevjInfo_t are now opaque types instead of void pointers.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/clients/include/testing_csrrf_refactlu.hpp
+++ b/clients/include/testing_csrrf_refactlu.hpp
@@ -39,10 +39,8 @@ void csrrf_refactlu_checkBadArgs(hipsolverRfHandle_t handle,
                                  int*                pivP,
                                  int*                pivQ)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolverRfRefactor(nullptr), HIPSOLVER_STATUS_NOT_INITIALIZED);
-#endif
 }
 
 template <typename T>

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -45,7 +45,6 @@ void gels_checkBadArgs(const hipsolverHandle_t handle,
                        int*                    info,
                        const int               bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_gels(API,
                                          false,
@@ -72,6 +71,7 @@ void gels_checkBadArgs(const hipsolverHandle_t handle,
     // values
     // N/A
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_gels(API,
                                          false,

--- a/clients/include/testing_gesv.hpp
+++ b/clients/include/testing_gesv.hpp
@@ -46,7 +46,6 @@ void gesv_checkBadArgs(const hipsolverHandle_t handle,
                        U                       dInfo,
                        const int               bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_gesv(API,
                                          false,
@@ -74,6 +73,7 @@ void gesv_checkBadArgs(const hipsolverHandle_t handle,
     // values
     // N/A
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_gesv(API,
                                          false,

--- a/clients/include/testing_gesvda.hpp
+++ b/clients/include/testing_gesvda.hpp
@@ -48,7 +48,6 @@ void gesvda_checkBadArgs(const hipsolverHandle_t handle,
                          double*                 hRnrmF,
                          const int               bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_gesvda(API,
                                            STRIDED,
@@ -101,6 +100,7 @@ void gesvda_checkBadArgs(const hipsolverHandle_t handle,
                                            bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_gesvda(API,
                                            STRIDED,

--- a/clients/include/testing_gesvdj.hpp
+++ b/clients/include/testing_gesvdj.hpp
@@ -48,7 +48,6 @@ void gesvdj_checkBadArgs(const hipsolverHandle_t     handle,
                          const hipsolverGesvdjInfo_t params,
                          const int                   bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_gesvdj(API,
                                            STRIDED,
@@ -101,6 +100,7 @@ void gesvdj_checkBadArgs(const hipsolverHandle_t     handle,
                                            bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_gesvdj(API,
                                            STRIDED,

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -37,7 +37,6 @@ void getrf_checkBadArgs(const hipsolverHandle_t handle,
                         V                       dinfo,
                         const int               bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(
         hipsolver_getrf(
@@ -47,6 +46,7 @@ void getrf_checkBadArgs(const hipsolverHandle_t handle,
     // values
     // N/A
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(
         hipsolver_getrf(

--- a/clients/include/testing_syevdx_heevdx.hpp
+++ b/clients/include/testing_syevdx_heevdx.hpp
@@ -46,7 +46,6 @@ void syevdx_heevdx_checkBadArgs(const hipsolverHandle_t   handle,
                                 U                         dinfo,
                                 const int                 bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_syevdx_heevdx(API,
                                                   nullptr,
@@ -135,6 +134,7 @@ void syevdx_heevdx_checkBadArgs(const hipsolverHandle_t   handle,
                                                   bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_syevdx_heevdx(API,
                                                   handle,

--- a/clients/include/testing_syevj_heevj.hpp
+++ b/clients/include/testing_syevj_heevj.hpp
@@ -41,7 +41,6 @@ void syevj_heevj_checkBadArgs(const hipsolverHandle_t    handle,
                               const hipsolverSyevjInfo_t params,
                               const int                  bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_syevj_heevj(API,
                                                 STRIDED,
@@ -97,6 +96,7 @@ void syevj_heevj_checkBadArgs(const hipsolverHandle_t    handle,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_syevj_heevj(API,
                                                 STRIDED,

--- a/library/include/internal/hipsolver-refactor.h
+++ b/library/include/internal/hipsolver-refactor.h
@@ -7,7 +7,7 @@
 
 #include "hipsolver-types.h"
 
-typedef void* hipsolverRfHandle_t;
+typedef struct hipsolverRfHandle* hipsolverRfHandle_t;
 
 #ifdef __cplusplus
 extern "C" {

--- a/library/include/internal/hipsolver-types.h
+++ b/library/include/internal/hipsolver-types.h
@@ -13,8 +13,8 @@
 
 typedef void* hipsolverHandle_t;
 
-typedef void* hipsolverGesvdjInfo_t;
-typedef void* hipsolverSyevjInfo_t;
+typedef void*                      hipsolverGesvdjInfo_t;
+typedef struct hipsolverSyevjInfo* hipsolverSyevjInfo_t;
 
 typedef enum
 {

--- a/library/include/internal/hipsolver-types.h
+++ b/library/include/internal/hipsolver-types.h
@@ -13,8 +13,8 @@
 
 typedef void* hipsolverHandle_t;
 
-typedef void*                      hipsolverGesvdjInfo_t;
-typedef struct hipsolverSyevjInfo* hipsolverSyevjInfo_t;
+typedef struct hipsolverGesvdjInfo* hipsolverGesvdjInfo_t;
+typedef struct hipsolverSyevjInfo*  hipsolverSyevjInfo_t;
 
 typedef enum
 {

--- a/library/include/internal/hipsolver-types.h
+++ b/library/include/internal/hipsolver-types.h
@@ -11,7 +11,7 @@
 
 #include <hip/hip_complex.h>
 
-typedef void* hipsolverHandle_t;
+typedef struct hipsolverHandle* hipsolverHandle_t;
 
 typedef struct hipsolverGesvdjInfo* hipsolverGesvdjInfo_t;
 typedef struct hipsolverSyevjInfo*  hipsolverSyevjInfo_t;

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -43,6 +43,7 @@ prepend_path( ".." hipsolver_headers_public relative_hipsolver_headers_public )
 if( NOT USE_CUDA )
   set( hipsolver_source
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_conversions.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_types.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_compat.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_refactor.cpp"
@@ -51,6 +52,7 @@ if( NOT USE_CUDA )
 else( )
   set( hipsolver_source
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_conversions.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_types.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_compat.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_refactor.cpp"

--- a/library/src/amd_detail/hipsolver.cpp
+++ b/library/src/amd_detail/hipsolver.cpp
@@ -494,7 +494,10 @@ try
     hipsolverStatus_t result = (*handle)->setup();
 
     if(result != HIPSOLVER_STATUS_SUCCESS)
+    {
         delete *handle;
+        *handle = nullptr;
+    }
 
     return result;
 }

--- a/library/src/amd_detail/hipsolver.cpp
+++ b/library/src/amd_detail/hipsolver.cpp
@@ -848,7 +848,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -885,7 +885,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -922,7 +922,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -959,7 +959,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1142,7 +1142,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1172,7 +1172,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1208,7 +1208,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1244,7 +1244,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1410,7 +1410,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1445,7 +1445,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1480,7 +1480,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1515,7 +1515,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1692,7 +1692,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1741,7 +1741,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1790,7 +1790,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1839,7 +1839,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2077,7 +2077,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2126,7 +2126,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2175,7 +2175,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2224,7 +2224,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2451,7 +2451,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2480,7 +2480,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2509,7 +2509,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2538,7 +2538,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2730,7 +2730,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2776,7 +2776,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2822,7 +2822,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2868,7 +2868,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3102,7 +3102,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3132,7 +3132,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3162,7 +3162,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3192,7 +3192,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3358,7 +3358,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3397,7 +3397,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3436,7 +3436,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3475,7 +3475,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3698,7 +3698,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3749,7 +3749,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3800,7 +3800,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3851,7 +3851,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -5245,7 +5245,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -5338,7 +5338,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -5431,7 +5431,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -5524,7 +5524,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6219,7 +6219,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6250,7 +6250,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6281,7 +6281,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6312,7 +6312,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6484,7 +6484,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6529,7 +6529,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6574,7 +6574,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6619,7 +6619,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6815,7 +6815,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6845,7 +6845,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6879,7 +6879,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6913,7 +6913,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7065,7 +7065,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7100,7 +7100,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7135,7 +7135,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7170,7 +7170,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7335,7 +7335,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7365,7 +7365,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7399,7 +7399,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7433,7 +7433,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7587,7 +7587,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7624,7 +7624,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7661,7 +7661,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7698,7 +7698,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7889,7 +7889,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7927,7 +7927,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7965,7 +7965,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8003,7 +8003,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8198,7 +8198,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8249,7 +8249,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8300,7 +8300,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8351,7 +8351,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8603,7 +8603,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8659,7 +8659,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8715,7 +8715,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8771,7 +8771,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -9871,7 +9871,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -9928,7 +9928,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -9985,7 +9985,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10042,7 +10042,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10342,7 +10342,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10404,7 +10404,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10466,7 +10466,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10528,7 +10528,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11252,7 +11252,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11289,7 +11289,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11326,7 +11326,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11363,7 +11363,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11546,7 +11546,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11576,7 +11576,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11606,7 +11606,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11636,7 +11636,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;

--- a/library/src/amd_detail/hipsolver_refactor.cpp
+++ b/library/src/amd_detail/hipsolver_refactor.cpp
@@ -30,6 +30,7 @@
 #include "exceptions.hpp"
 #include "hipsolver.h"
 #include "hipsolver_conversions.hpp"
+#include "hipsolver_types.hpp"
 
 #include "rocblas/internal/rocblas_device_malloc.hpp"
 #include "rocblas/rocblas.h"

--- a/library/src/amd_detail/hipsolver_refactor.cpp
+++ b/library/src/amd_detail/hipsolver_refactor.cpp
@@ -54,7 +54,10 @@ try
     hipsolverStatus_t result = (*handle)->setup();
 
     if(result != HIPSOLVER_STATUS_SUCCESS)
+    {
         delete *handle;
+        *handle = nullptr;
+    }
 
     return result;
 }

--- a/library/src/amd_detail/hipsolver_types.cpp
+++ b/library/src/amd_detail/hipsolver_types.cpp
@@ -24,6 +24,21 @@
 #include "hipsolver_types.hpp"
 #include "hipsolver_conversions.hpp"
 
+/******************** DN HANDLE ********************/
+hipsolverHandle::hipsolverHandle()
+    : handle(nullptr)
+{
+}
+
+hipsolverStatus_t hipsolverHandle::setup()
+{
+    return rocblas2hip_status(rocblas_create_handle(&handle));
+}
+hipsolverStatus_t hipsolverHandle::teardown()
+{
+    return rocblas2hip_status(rocblas_destroy_handle(handle));
+}
+
 /******************** RF HANDLE ********************/
 hipsolverRfHandle::hipsolverRfHandle()
     : fast_mode(HIPSOLVERRF_RESET_VALUES_FAST_MODE_OFF)

--- a/library/src/amd_detail/hipsolver_types.cpp
+++ b/library/src/amd_detail/hipsolver_types.cpp
@@ -1,0 +1,77 @@
+/* ************************************************************************
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#include "hipsolver_types.hpp"
+#include "hipsolver_conversions.hpp"
+
+/******************** SYEVJ PARAMS ********************/
+hipsolverSyevjInfo::hipsolverSyevjInfo()
+    : capacity(0)
+    , batch_count(0)
+    , n_sweeps(nullptr)
+    , residual(nullptr)
+    , max_sweeps(100)
+    , tolerance(0)
+    , is_batched(false)
+    , is_float(false)
+    , sort_eig(true)
+    , d_buffer(nullptr)
+{
+}
+
+hipsolverStatus_t hipsolverSyevjInfo::setup(int bc)
+{
+    if(capacity < bc)
+    {
+        if(capacity > 0)
+        {
+            if(hipFree(d_buffer) != hipSuccess)
+                return HIPSOLVER_STATUS_INTERNAL_ERROR;
+        }
+
+        if(hipMalloc(&d_buffer, (sizeof(int) + sizeof(double)) * bc) != hipSuccess)
+        {
+            capacity = 0;
+            return HIPSOLVER_STATUS_ALLOC_FAILED;
+        }
+
+        n_sweeps    = (int*)d_buffer;
+        residual    = (double*)(n_sweeps + bc);
+        capacity    = bc;
+        batch_count = bc;
+    }
+
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+
+hipsolverStatus_t hipsolverSyevjInfo::teardown()
+{
+    if(capacity > 0)
+    {
+        capacity = 0;
+        if(hipFree(d_buffer) != hipSuccess)
+            return HIPSOLVER_STATUS_INTERNAL_ERROR;
+    }
+
+    return HIPSOLVER_STATUS_SUCCESS;
+}

--- a/library/src/amd_detail/hipsolver_types.cpp
+++ b/library/src/amd_detail/hipsolver_types.cpp
@@ -24,6 +24,224 @@
 #include "hipsolver_types.hpp"
 #include "hipsolver_conversions.hpp"
 
+/******************** RF HANDLE ********************/
+hipsolverRfHandle::hipsolverRfHandle()
+    : fast_mode(HIPSOLVERRF_RESET_VALUES_FAST_MODE_OFF)
+    , matrix_format(HIPSOLVERRF_MATRIX_FORMAT_CSR)
+    , diag_format(HIPSOLVERRF_UNIT_DIAGONAL_STORED_L)
+    , numeric_boost(HIPSOLVERRF_NUMERIC_BOOST_NOT_USED)
+    , fact_alg(HIPSOLVERRF_FACTORIZATION_ALG0)
+    , solve_alg(HIPSOLVERRF_TRIANGULAR_SOLVE_ALG1)
+    , n(0)
+    , nnzA(0)
+    , nnzL(0)
+    , nnzU(0)
+    , nnzLU(0)
+    , batch_count(0)
+    , effective_zero(0.0)
+    , boost_val(0.0)
+    , d_buffer(nullptr)
+    , h_buffer(nullptr)
+{
+}
+
+hipsolverStatus_t hipsolverRfHandle::setup()
+{
+    rocblas_status status;
+
+    if((status = rocblas_create_handle(&this->handle)) != rocblas_status_success)
+        return rocblas2hip_status(status);
+
+    if((status = rocsolver_create_rfinfo(&this->rfinfo, this->handle)) != rocblas_status_success)
+    {
+        rocblas_destroy_handle(this->handle);
+        return rocblas2hip_status(status);
+    }
+
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+
+hipsolverStatus_t hipsolverRfHandle::teardown()
+{
+    rocblas_status status;
+
+    if(free_mem() != HIPSOLVER_STATUS_SUCCESS)
+    {
+        rocsolver_destroy_rfinfo(this->rfinfo);
+        rocblas_destroy_handle(this->handle);
+        return HIPSOLVER_STATUS_INTERNAL_ERROR;
+    }
+
+    if((status = rocsolver_destroy_rfinfo(this->rfinfo)) != rocblas_status_success)
+    {
+        rocblas_destroy_handle(this->handle);
+        return rocblas2hip_status(status);
+    }
+
+    if((status = rocblas_destroy_handle(this->handle)) != rocblas_status_success)
+        return rocblas2hip_status(status);
+
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+
+hipsolverStatus_t hipsolverRfHandle::malloc_device(int n, int nnzA, int nnzL, int nnzU)
+{
+    if(n < 0 || nnzA < 0 || nnzL < 0 || nnzU < 0)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    if(this->n != n || this->nnzA != nnzA || this->nnzL != nnzL || this->nnzU != nnzU)
+    {
+        int nnzLU = nnzL - n + nnzU;
+
+        if(free_mem() != HIPSOLVER_STATUS_SUCCESS)
+            return HIPSOLVER_STATUS_INTERNAL_ERROR;
+
+        size_t size_dPtrA = sizeof(rocblas_int) * (n + 1);
+        size_t size_dIndA = sizeof(rocblas_int) * nnzA;
+        size_t size_dValA = sizeof(double) * nnzA;
+
+        size_t size_dPtrL = sizeof(rocblas_int) * (n + 1);
+        size_t size_dIndL = sizeof(rocblas_int) * nnzL;
+        size_t size_dValL = sizeof(double) * nnzL;
+
+        size_t size_dPtrU = sizeof(rocblas_int) * (n + 1);
+        size_t size_dIndU = sizeof(rocblas_int) * nnzU;
+        size_t size_dValU = sizeof(double) * nnzU;
+
+        size_t size_dPtrLU = sizeof(rocblas_int) * (n + 1);
+        size_t size_dIndLU = sizeof(rocblas_int) * nnzLU;
+        size_t size_dValLU = sizeof(double) * nnzLU;
+
+        size_t size_dP = sizeof(rocblas_int) * n;
+        size_t size_dQ = sizeof(rocblas_int) * n;
+
+        // 128 byte alignment
+        size_dPtrL  = ((size_dPtrL - 1) / 128 + 1) * 128;
+        size_dIndL  = ((size_dIndL - 1) / 128 + 1) * 128;
+        size_dValL  = ((size_dValL - 1) / 128 + 1) * 128;
+        size_dPtrU  = ((size_dPtrU - 1) / 128 + 1) * 128;
+        size_dIndU  = ((size_dIndU - 1) / 128 + 1) * 128;
+        size_dValU  = ((size_dValU - 1) / 128 + 1) * 128;
+        size_dPtrLU = ((size_dPtrLU - 1) / 128 + 1) * 128;
+        size_dIndLU = ((size_dIndLU - 1) / 128 + 1) * 128;
+        size_dValLU = ((size_dValLU - 1) / 128 + 1) * 128;
+        size_dP     = ((size_dP - 1) / 128 + 1) * 128;
+        size_dQ     = ((size_dQ - 1) / 128 + 1) * 128;
+
+        size_t size_buffer = size_dPtrA + size_dIndA + size_dValA + size_dPtrL + size_dIndL
+                             + size_dValL + size_dPtrU + size_dIndU + size_dValU + size_dPtrLU
+                             + size_dIndLU + size_dValLU + size_dP + size_dQ;
+
+        if(hipMalloc(&this->d_buffer, size_buffer) != hipSuccess)
+            return HIPSOLVER_STATUS_ALLOC_FAILED;
+
+        char* temp_buf;
+        this->dPtrA  = (rocblas_int*)(temp_buf = this->d_buffer);
+        this->dPtrL  = (rocblas_int*)(temp_buf += size_dPtrA);
+        this->dPtrU  = (rocblas_int*)(temp_buf += size_dPtrL);
+        this->dPtrLU = (rocblas_int*)(temp_buf += size_dPtrU);
+
+        this->dIndA  = (rocblas_int*)(temp_buf += size_dPtrLU);
+        this->dIndL  = (rocblas_int*)(temp_buf += size_dIndA);
+        this->dIndU  = (rocblas_int*)(temp_buf += size_dIndL);
+        this->dIndLU = (rocblas_int*)(temp_buf += size_dIndU);
+
+        this->dP = (rocblas_int*)(temp_buf += size_dIndLU);
+        this->dQ = (rocblas_int*)(temp_buf += size_dP);
+
+        this->dValA  = (double*)(temp_buf += size_dQ);
+        this->dValL  = (double*)(temp_buf += size_dValA);
+        this->dValU  = (double*)(temp_buf += size_dValL);
+        this->dValLU = (double*)(temp_buf += size_dValU);
+
+        this->n     = n;
+        this->nnzA  = nnzA;
+        this->nnzL  = nnzL;
+        this->nnzU  = nnzU;
+        this->nnzLU = nnzLU;
+    }
+
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+
+hipsolverStatus_t hipsolverRfHandle::malloc_host()
+{
+    if(!this->h_buffer)
+    {
+        size_t size_hPtrL = sizeof(rocblas_int) * (n + 1);
+        size_t size_hIndL = sizeof(rocblas_int) * nnzL;
+        size_t size_hValL = sizeof(double) * nnzL;
+
+        size_t size_hPtrU = sizeof(rocblas_int) * (n + 1);
+        size_t size_hIndU = sizeof(rocblas_int) * nnzU;
+        size_t size_hValU = sizeof(double) * nnzU;
+
+        size_t size_hPtrLU = sizeof(rocblas_int) * (n + 1);
+        size_t size_hIndLU = sizeof(rocblas_int) * nnzLU;
+        size_t size_hValLU = sizeof(double) * nnzLU;
+
+        // 128 byte alignment
+        size_hPtrL  = ((size_hPtrL - 1) / 128 + 1) * 128;
+        size_hIndL  = ((size_hIndL - 1) / 128 + 1) * 128;
+        size_hValL  = ((size_hValL - 1) / 128 + 1) * 128;
+        size_hPtrU  = ((size_hPtrU - 1) / 128 + 1) * 128;
+        size_hIndU  = ((size_hIndU - 1) / 128 + 1) * 128;
+        size_hValU  = ((size_hValU - 1) / 128 + 1) * 128;
+        size_hPtrLU = ((size_hPtrLU - 1) / 128 + 1) * 128;
+        size_hIndLU = ((size_hIndLU - 1) / 128 + 1) * 128;
+        size_hValLU = ((size_hValLU - 1) / 128 + 1) * 128;
+
+        size_t size_buffer = size_hPtrL + size_hIndL + size_hValL + size_hPtrU + size_hIndU
+                             + size_hValU + size_hPtrLU + size_hIndLU + size_hValLU;
+
+        this->h_buffer = (char*)malloc(size_buffer);
+        if(!this->h_buffer)
+            return HIPSOLVER_STATUS_ALLOC_FAILED;
+
+        char* temp_buf;
+        this->hPtrL  = (rocblas_int*)(temp_buf = this->h_buffer);
+        this->hPtrU  = (rocblas_int*)(temp_buf += size_hPtrL);
+        this->hPtrLU = (rocblas_int*)(temp_buf += size_hPtrU);
+
+        this->hIndL  = (rocblas_int*)(temp_buf += size_hPtrLU);
+        this->hIndU  = (rocblas_int*)(temp_buf += size_hIndL);
+        this->hIndLU = (rocblas_int*)(temp_buf += size_hIndU);
+
+        this->hValL  = (double*)(temp_buf += size_hIndLU);
+        this->hValU  = (double*)(temp_buf += size_hValL);
+        this->hValLU = (double*)(temp_buf += size_hValU);
+    }
+
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+
+hipsolverStatus_t hipsolverRfHandle::free_mem()
+{
+    if(this->h_buffer)
+    {
+        try
+        {
+            free(this->h_buffer);
+        }
+        catch(...)
+        {
+            if(this->d_buffer)
+                hipFree(this->d_buffer);
+            return HIPSOLVER_STATUS_INTERNAL_ERROR;
+        }
+        this->h_buffer = nullptr;
+    }
+
+    if(this->d_buffer)
+    {
+        if(hipFree(this->d_buffer) != hipSuccess)
+            return HIPSOLVER_STATUS_INTERNAL_ERROR;
+        this->d_buffer = nullptr;
+    }
+
+    return HIPSOLVER_STATUS_SUCCESS;
+}
+
 /******************** GESVDJ PARAMS ********************/
 hipsolverGesvdjInfo::hipsolverGesvdjInfo()
     : capacity(0)

--- a/library/src/amd_detail/hipsolver_types.hpp
+++ b/library/src/amd_detail/hipsolver_types.hpp
@@ -27,6 +27,35 @@
 #include "rocblas/rocblas.h"
 #include "rocsolver/rocsolver.h"
 
+struct hipsolverGesvdjInfo
+{
+    int     capacity;
+    int     batch_count;
+    int*    n_sweeps;
+    double* residual;
+
+    int    max_sweeps;
+    double tolerance;
+    bool   is_batched, is_float, sort_eig;
+
+    char* d_buffer;
+
+    // Constructor
+    hipsolverGesvdjInfo();
+
+    hipsolverGesvdjInfo(const hipsolverGesvdjInfo&) = delete;
+
+    hipsolverGesvdjInfo(hipsolverGesvdjInfo&&) = delete;
+
+    hipsolverGesvdjInfo& operator=(const hipsolverGesvdjInfo&) = delete;
+
+    hipsolverGesvdjInfo& operator=(hipsolverGesvdjInfo&&) = delete;
+
+    // Allocate resources
+    hipsolverStatus_t setup(int bc);
+    hipsolverStatus_t teardown();
+};
+
 struct hipsolverSyevjInfo
 {
     int     capacity;

--- a/library/src/amd_detail/hipsolver_types.hpp
+++ b/library/src/amd_detail/hipsolver_types.hpp
@@ -27,6 +27,26 @@
 #include "rocblas/rocblas.h"
 #include "rocsolver/rocsolver.h"
 
+struct hipsolverHandle
+{
+    rocblas_handle handle;
+
+    // Constructor
+    hipsolverHandle();
+
+    hipsolverHandle(const hipsolverHandle&) = delete;
+
+    hipsolverHandle(hipsolverHandle&&) = delete;
+
+    hipsolverHandle& operator=(const hipsolverHandle&) = delete;
+
+    hipsolverHandle& operator=(hipsolverHandle&&) = delete;
+
+    // Allocate resources
+    hipsolverStatus_t setup();
+    hipsolverStatus_t teardown();
+};
+
 struct hipsolverRfHandle
 {
     hipsolverRfResetValuesFastMode_t fast_mode;

--- a/library/src/amd_detail/hipsolver_types.hpp
+++ b/library/src/amd_detail/hipsolver_types.hpp
@@ -27,6 +27,64 @@
 #include "rocblas/rocblas.h"
 #include "rocsolver/rocsolver.h"
 
+struct hipsolverRfHandle
+{
+    hipsolverRfResetValuesFastMode_t fast_mode;
+    hipsolverRfMatrixFormat_t        matrix_format;
+    hipsolverRfUnitDiagonal_t        diag_format;
+    hipsolverRfNumericBoostReport_t  numeric_boost;
+
+    hipsolverRfFactorization_t   fact_alg;
+    hipsolverRfTriangularSolve_t solve_alg;
+
+    rocblas_handle   handle;
+    rocsolver_rfinfo rfinfo;
+
+    rocblas_int n, nnzA, nnzL, nnzU, nnzLU, batch_count;
+    double      effective_zero;
+    double      boost_val;
+
+    rocblas_int* dPtrA;
+    rocblas_int* dIndA;
+    double*      dValA;
+
+    rocblas_int *dPtrL, *hPtrL;
+    rocblas_int *dIndL, *hIndL;
+    double *     dValL, *hValL;
+
+    rocblas_int *dPtrU, *hPtrU;
+    rocblas_int *dIndU, *hIndU;
+    double *     dValU, *hValU;
+
+    rocblas_int *dPtrLU, *hPtrLU;
+    rocblas_int *dIndLU, *hIndLU;
+    double *     dValLU, *hValLU;
+
+    rocblas_int* dP;
+    rocblas_int* dQ;
+
+    char *d_buffer, *h_buffer;
+
+    // Constructor
+    explicit hipsolverRfHandle();
+
+    hipsolverRfHandle(const hipsolverRfHandle&) = delete;
+
+    hipsolverRfHandle(hipsolverRfHandle&&) = delete;
+
+    hipsolverRfHandle& operator=(const hipsolverRfHandle&) = delete;
+
+    hipsolverRfHandle& operator=(hipsolverRfHandle&&) = delete;
+
+    // Allocate resources
+    hipsolverStatus_t setup();
+    hipsolverStatus_t teardown();
+
+    hipsolverStatus_t malloc_device(int n, int nnzA, int nnzL, int nnzU);
+    hipsolverStatus_t malloc_host();
+    hipsolverStatus_t free_mem();
+};
+
 struct hipsolverGesvdjInfo
 {
     int     capacity;

--- a/library/src/amd_detail/hipsolver_types.hpp
+++ b/library/src/amd_detail/hipsolver_types.hpp
@@ -1,0 +1,57 @@
+/* ************************************************************************
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#pragma once
+
+#include "hipsolver.h"
+#include "rocblas/rocblas.h"
+#include "rocsolver/rocsolver.h"
+
+struct hipsolverSyevjInfo
+{
+    int     capacity;
+    int     batch_count;
+    int*    n_sweeps;
+    double* residual;
+
+    int    max_sweeps;
+    double tolerance;
+    bool   is_batched, is_float, sort_eig;
+
+    char* d_buffer;
+
+    // Constructor
+    hipsolverSyevjInfo();
+
+    hipsolverSyevjInfo(const hipsolverSyevjInfo&) = delete;
+
+    hipsolverSyevjInfo(hipsolverSyevjInfo&&) = delete;
+
+    hipsolverSyevjInfo& operator=(const hipsolverSyevjInfo&) = delete;
+
+    hipsolverSyevjInfo& operator=(hipsolverSyevjInfo&&) = delete;
+
+    // Allocate resources
+    hipsolverStatus_t setup(int bc);
+    hipsolverStatus_t teardown();
+};

--- a/library/src/nvidia_detail/hipsolver.cpp
+++ b/library/src/nvidia_detail/hipsolver.cpp
@@ -28,6 +28,7 @@
 #include "hipsolver.h"
 #include "exceptions.hpp"
 #include "hipsolver_conversions.hpp"
+#include "hipsolver_types.hpp"
 
 #include <cusolverDn.h>
 
@@ -155,7 +156,16 @@ catch(...)
 hipsolverStatus_t hipsolverCreateSyevjInfo(hipsolverSyevjInfo_t* info)
 try
 {
-    return cuda2hip_status(cusolverDnCreateSyevjInfo((syevjInfo_t*)info));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *info                    = new hipsolverSyevjInfo;
+    hipsolverStatus_t result = (*info)->setup();
+
+    if(result != HIPSOLVER_STATUS_SUCCESS)
+        delete *info;
+
+    return result;
 }
 catch(...)
 {
@@ -165,7 +175,13 @@ catch(...)
 hipsolverStatus_t hipsolverDestroySyevjInfo(hipsolverSyevjInfo_t info)
 try
 {
-    return cuda2hip_status(cusolverDnDestroySyevjInfo((syevjInfo_t)info));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    hipsolverStatus_t result = info->teardown();
+    delete info;
+
+    return result;
 }
 catch(...)
 {
@@ -175,7 +191,10 @@ catch(...)
 hipsolverStatus_t hipsolverXsyevjSetMaxSweeps(hipsolverSyevjInfo_t info, int max_sweeps)
 try
 {
-    return cuda2hip_status(cusolverDnXsyevjSetMaxSweeps((syevjInfo_t)info, max_sweeps));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return cuda2hip_status(cusolverDnXsyevjSetMaxSweeps(info->info, max_sweeps));
 }
 catch(...)
 {
@@ -185,7 +204,10 @@ catch(...)
 hipsolverStatus_t hipsolverXsyevjSetSortEig(hipsolverSyevjInfo_t info, int sort_eig)
 try
 {
-    return cuda2hip_status(cusolverDnXsyevjSetSortEig((syevjInfo_t)info, sort_eig));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return cuda2hip_status(cusolverDnXsyevjSetSortEig(info->info, sort_eig));
 }
 catch(...)
 {
@@ -195,7 +217,10 @@ catch(...)
 hipsolverStatus_t hipsolverXsyevjSetTolerance(hipsolverSyevjInfo_t info, double tolerance)
 try
 {
-    return cuda2hip_status(cusolverDnXsyevjSetTolerance((syevjInfo_t)info, tolerance));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return cuda2hip_status(cusolverDnXsyevjSetTolerance(info->info, tolerance));
 }
 catch(...)
 {
@@ -207,8 +232,11 @@ hipsolverStatus_t hipsolverXsyevjGetResidual(hipsolverDnHandle_t  handle,
                                              double*              residual)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(
-        cusolverDnXsyevjGetResidual((cusolverDnHandle_t)handle, (syevjInfo_t)info, residual));
+        cusolverDnXsyevjGetResidual((cusolverDnHandle_t)handle, info->info, residual));
 }
 catch(...)
 {
@@ -220,8 +248,11 @@ hipsolverStatus_t hipsolverXsyevjGetSweeps(hipsolverDnHandle_t  handle,
                                            int*                 executed_sweeps)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(
-        cusolverDnXsyevjGetSweeps((cusolverDnHandle_t)handle, (syevjInfo_t)info, executed_sweeps));
+        cusolverDnXsyevjGetSweeps((cusolverDnHandle_t)handle, info->info, executed_sweeps));
 }
 catch(...)
 {
@@ -4963,9 +4994,12 @@ hipsolverStatus_t hipsolverSsyevj_bufferSize(hipsolverDnHandle_t  handle,
                                              int                  lda,
                                              float*               W,
                                              int*                 lwork,
-                                             hipsolverSyevjInfo_t params)
+                                             hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsyevj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -4974,7 +5008,7 @@ try
                                                        lda,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       info->info));
 }
 catch(...)
 {
@@ -4989,9 +5023,12 @@ hipsolverStatus_t hipsolverDsyevj_bufferSize(hipsolverDnHandle_t  handle,
                                              int                  lda,
                                              double*              W,
                                              int*                 lwork,
-                                             hipsolverSyevjInfo_t params)
+                                             hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsyevj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -5000,7 +5037,7 @@ try
                                                        lda,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       info->info));
 }
 catch(...)
 {
@@ -5015,9 +5052,12 @@ hipsolverStatus_t hipsolverCheevj_bufferSize(hipsolverDnHandle_t  handle,
                                              int                  lda,
                                              float*               W,
                                              int*                 lwork,
-                                             hipsolverSyevjInfo_t params)
+                                             hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCheevj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -5026,7 +5066,7 @@ try
                                                        lda,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       info->info));
 }
 catch(...)
 {
@@ -5041,9 +5081,12 @@ hipsolverStatus_t hipsolverZheevj_bufferSize(hipsolverDnHandle_t  handle,
                                              int                  lda,
                                              double*              W,
                                              int*                 lwork,
-                                             hipsolverSyevjInfo_t params)
+                                             hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZheevj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -5052,7 +5095,7 @@ try
                                                        lda,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       info->info));
 }
 catch(...)
 {
@@ -5069,9 +5112,12 @@ hipsolverStatus_t hipsolverSsyevj(hipsolverDnHandle_t  handle,
                                   float*               work,
                                   int                  lwork,
                                   int*                 devInfo,
-                                  hipsolverSyevjInfo_t params)
+                                  hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsyevj((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -5082,7 +5128,7 @@ try
                                             work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            info->info));
 }
 catch(...)
 {
@@ -5099,9 +5145,12 @@ hipsolverStatus_t hipsolverDsyevj(hipsolverDnHandle_t  handle,
                                   double*              work,
                                   int                  lwork,
                                   int*                 devInfo,
-                                  hipsolverSyevjInfo_t params)
+                                  hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsyevj((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -5112,7 +5161,7 @@ try
                                             work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            info->info));
 }
 catch(...)
 {
@@ -5129,9 +5178,12 @@ hipsolverStatus_t hipsolverCheevj(hipsolverDnHandle_t  handle,
                                   hipFloatComplex*     work,
                                   int                  lwork,
                                   int*                 devInfo,
-                                  hipsolverSyevjInfo_t params)
+                                  hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCheevj((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -5142,7 +5194,7 @@ try
                                             (cuComplex*)work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            info->info));
 }
 catch(...)
 {
@@ -5159,9 +5211,12 @@ hipsolverStatus_t hipsolverZheevj(hipsolverDnHandle_t  handle,
                                   hipDoubleComplex*    work,
                                   int                  lwork,
                                   int*                 devInfo,
-                                  hipsolverSyevjInfo_t params)
+                                  hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZheevj((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -5172,7 +5227,7 @@ try
                                             (cuDoubleComplex*)work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            info->info));
 }
 catch(...)
 {
@@ -5188,10 +5243,13 @@ hipsolverStatus_t hipsolverSsyevjBatched_bufferSize(hipsolverDnHandle_t  handle,
                                                     int                  lda,
                                                     float*               W,
                                                     int*                 lwork,
-                                                    hipsolverSyevjInfo_t params,
+                                                    hipsolverSyevjInfo_t info,
                                                     int                  batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsyevjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                               hip2cuda_evect(jobz),
                                                               hip2cuda_fill(uplo),
@@ -5200,7 +5258,7 @@ try
                                                               lda,
                                                               W,
                                                               lwork,
-                                                              (syevjInfo_t)params,
+                                                              info->info,
                                                               batch_count));
 }
 catch(...)
@@ -5216,10 +5274,13 @@ hipsolverStatus_t hipsolverDsyevjBatched_bufferSize(hipsolverDnHandle_t  handle,
                                                     int                  lda,
                                                     double*              W,
                                                     int*                 lwork,
-                                                    hipsolverSyevjInfo_t params,
+                                                    hipsolverSyevjInfo_t info,
                                                     int                  batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsyevjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                               hip2cuda_evect(jobz),
                                                               hip2cuda_fill(uplo),
@@ -5228,7 +5289,7 @@ try
                                                               lda,
                                                               W,
                                                               lwork,
-                                                              (syevjInfo_t)params,
+                                                              info->info,
                                                               batch_count));
 }
 catch(...)
@@ -5244,10 +5305,13 @@ hipsolverStatus_t hipsolverCheevjBatched_bufferSize(hipsolverDnHandle_t  handle,
                                                     int                  lda,
                                                     float*               W,
                                                     int*                 lwork,
-                                                    hipsolverSyevjInfo_t params,
+                                                    hipsolverSyevjInfo_t info,
                                                     int                  batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCheevjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                               hip2cuda_evect(jobz),
                                                               hip2cuda_fill(uplo),
@@ -5256,7 +5320,7 @@ try
                                                               lda,
                                                               W,
                                                               lwork,
-                                                              (syevjInfo_t)params,
+                                                              info->info,
                                                               batch_count));
 }
 catch(...)
@@ -5272,10 +5336,13 @@ hipsolverStatus_t hipsolverZheevjBatched_bufferSize(hipsolverDnHandle_t  handle,
                                                     int                  lda,
                                                     double*              W,
                                                     int*                 lwork,
-                                                    hipsolverSyevjInfo_t params,
+                                                    hipsolverSyevjInfo_t info,
                                                     int                  batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZheevjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                               hip2cuda_evect(jobz),
                                                               hip2cuda_fill(uplo),
@@ -5284,7 +5351,7 @@ try
                                                               lda,
                                                               W,
                                                               lwork,
-                                                              (syevjInfo_t)params,
+                                                              info->info,
                                                               batch_count));
 }
 catch(...)
@@ -5302,10 +5369,13 @@ hipsolverStatus_t hipsolverSsyevjBatched(hipsolverDnHandle_t  handle,
                                          float*               work,
                                          int                  lwork,
                                          int*                 devInfo,
-                                         hipsolverSyevjInfo_t params,
+                                         hipsolverSyevjInfo_t info,
                                          int                  batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsyevjBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_evect(jobz),
                                                    hip2cuda_fill(uplo),
@@ -5316,7 +5386,7 @@ try
                                                    work,
                                                    lwork,
                                                    devInfo,
-                                                   (syevjInfo_t)params,
+                                                   info->info,
                                                    batch_count));
 }
 catch(...)
@@ -5334,10 +5404,13 @@ hipsolverStatus_t hipsolverDsyevjBatched(hipsolverDnHandle_t  handle,
                                          double*              work,
                                          int                  lwork,
                                          int*                 devInfo,
-                                         hipsolverSyevjInfo_t params,
+                                         hipsolverSyevjInfo_t info,
                                          int                  batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsyevjBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_evect(jobz),
                                                    hip2cuda_fill(uplo),
@@ -5348,7 +5421,7 @@ try
                                                    work,
                                                    lwork,
                                                    devInfo,
-                                                   (syevjInfo_t)params,
+                                                   info->info,
                                                    batch_count));
 }
 catch(...)
@@ -5366,10 +5439,13 @@ hipsolverStatus_t hipsolverCheevjBatched(hipsolverDnHandle_t  handle,
                                          hipFloatComplex*     work,
                                          int                  lwork,
                                          int*                 devInfo,
-                                         hipsolverSyevjInfo_t params,
+                                         hipsolverSyevjInfo_t info,
                                          int                  batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCheevjBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_evect(jobz),
                                                    hip2cuda_fill(uplo),
@@ -5380,7 +5456,7 @@ try
                                                    (cuComplex*)work,
                                                    lwork,
                                                    devInfo,
-                                                   (syevjInfo_t)params,
+                                                   info->info,
                                                    batch_count));
 }
 catch(...)
@@ -5398,10 +5474,13 @@ hipsolverStatus_t hipsolverZheevjBatched(hipsolverDnHandle_t  handle,
                                          hipDoubleComplex*    work,
                                          int                  lwork,
                                          int*                 devInfo,
-                                         hipsolverSyevjInfo_t params,
+                                         hipsolverSyevjInfo_t info,
                                          int                  batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZheevjBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_evect(jobz),
                                                    hip2cuda_fill(uplo),
@@ -5412,7 +5491,7 @@ try
                                                    (cuDoubleComplex*)work,
                                                    lwork,
                                                    devInfo,
-                                                   (syevjInfo_t)params,
+                                                   info->info,
                                                    batch_count));
 }
 catch(...)
@@ -6042,9 +6121,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvj_bufferSize(hipsolverHandle_t 
                                                               int                  ldb,
                                                               float*               W,
                                                               int*                 lwork,
-                                                              hipsolverSyevjInfo_t params)
+                                                              hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsygvj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -6056,7 +6138,7 @@ try
                                                        ldb,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       info->info));
 }
 catch(...)
 {
@@ -6074,9 +6156,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsygvj_bufferSize(hipsolverHandle_t 
                                                               int                  ldb,
                                                               double*              W,
                                                               int*                 lwork,
-                                                              hipsolverSyevjInfo_t params)
+                                                              hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsygvj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -6088,7 +6173,7 @@ try
                                                        ldb,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       info->info));
 }
 catch(...)
 {
@@ -6106,9 +6191,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvj_bufferSize(hipsolverHandle_t 
                                                               int                  ldb,
                                                               float*               W,
                                                               int*                 lwork,
-                                                              hipsolverSyevjInfo_t params)
+                                                              hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnChegvj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -6120,7 +6208,7 @@ try
                                                        ldb,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       info->info));
 }
 catch(...)
 {
@@ -6138,9 +6226,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvj_bufferSize(hipsolverHandle_t 
                                                               int                  ldb,
                                                               double*              W,
                                                               int*                 lwork,
-                                                              hipsolverSyevjInfo_t params)
+                                                              hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZhegvj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -6152,7 +6243,7 @@ try
                                                        ldb,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       info->info));
 }
 catch(...)
 {
@@ -6172,9 +6263,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvj(hipsolverHandle_t    handle,
                                                    float*               work,
                                                    int                  lwork,
                                                    int*                 devInfo,
-                                                   hipsolverSyevjInfo_t params)
+                                                   hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsygvj((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -6188,7 +6282,7 @@ try
                                             work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            info->info));
 }
 catch(...)
 {
@@ -6208,9 +6302,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsygvj(hipsolverHandle_t    handle,
                                                    double*              work,
                                                    int                  lwork,
                                                    int*                 devInfo,
-                                                   hipsolverSyevjInfo_t params)
+                                                   hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsygvj((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -6224,7 +6321,7 @@ try
                                             work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            info->info));
 }
 catch(...)
 {
@@ -6244,9 +6341,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvj(hipsolverHandle_t    handle,
                                                    hipFloatComplex*     work,
                                                    int                  lwork,
                                                    int*                 devInfo,
-                                                   hipsolverSyevjInfo_t params)
+                                                   hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnChegvj((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -6260,7 +6360,7 @@ try
                                             (cuComplex*)work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            info->info));
 }
 catch(...)
 {
@@ -6280,9 +6380,12 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvj(hipsolverHandle_t    handle,
                                                    hipDoubleComplex*    work,
                                                    int                  lwork,
                                                    int*                 devInfo,
-                                                   hipsolverSyevjInfo_t params)
+                                                   hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZhegvj((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -6296,7 +6399,7 @@ try
                                             (cuDoubleComplex*)work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            info->info));
 }
 catch(...)
 {

--- a/library/src/nvidia_detail/hipsolver.cpp
+++ b/library/src/nvidia_detail/hipsolver.cpp
@@ -3772,7 +3772,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3797,7 +3797,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3822,7 +3822,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3847,7 +3847,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4151,7 +4151,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4173,7 +4173,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4195,7 +4195,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4217,7 +4217,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4495,7 +4495,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4519,7 +4519,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4543,7 +4543,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4567,7 +4567,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4703,7 +4703,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4728,7 +4728,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4753,7 +4753,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -4778,7 +4778,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;

--- a/library/src/nvidia_detail/hipsolver.cpp
+++ b/library/src/nvidia_detail/hipsolver.cpp
@@ -79,7 +79,16 @@ catch(...)
 hipsolverStatus_t hipsolverCreateGesvdjInfo(hipsolverGesvdjInfo_t* info)
 try
 {
-    return cuda2hip_status(cusolverDnCreateGesvdjInfo((gesvdjInfo_t*)info));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    *info                    = new hipsolverGesvdjInfo;
+    hipsolverStatus_t result = (*info)->setup();
+
+    if(result != HIPSOLVER_STATUS_SUCCESS)
+        delete *info;
+
+    return result;
 }
 catch(...)
 {
@@ -89,7 +98,13 @@ catch(...)
 hipsolverStatus_t hipsolverDestroyGesvdjInfo(hipsolverGesvdjInfo_t info)
 try
 {
-    return cuda2hip_status(cusolverDnDestroyGesvdjInfo((gesvdjInfo_t)info));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    hipsolverStatus_t result = info->teardown();
+    delete info;
+
+    return result;
 }
 catch(...)
 {
@@ -99,7 +114,10 @@ catch(...)
 hipsolverStatus_t hipsolverXgesvdjSetMaxSweeps(hipsolverGesvdjInfo_t info, int max_sweeps)
 try
 {
-    return cuda2hip_status(cusolverDnXgesvdjSetMaxSweeps((gesvdjInfo_t)info, max_sweeps));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return cuda2hip_status(cusolverDnXgesvdjSetMaxSweeps(info->info, max_sweeps));
 }
 catch(...)
 {
@@ -109,7 +127,10 @@ catch(...)
 hipsolverStatus_t hipsolverXgesvdjSetSortEig(hipsolverGesvdjInfo_t info, int sort_eig)
 try
 {
-    return cuda2hip_status(cusolverDnXgesvdjSetSortEig((gesvdjInfo_t)info, sort_eig));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return cuda2hip_status(cusolverDnXgesvdjSetSortEig(info->info, sort_eig));
 }
 catch(...)
 {
@@ -119,7 +140,10 @@ catch(...)
 hipsolverStatus_t hipsolverXgesvdjSetTolerance(hipsolverGesvdjInfo_t info, double tolerance)
 try
 {
-    return cuda2hip_status(cusolverDnXgesvdjSetTolerance((gesvdjInfo_t)info, tolerance));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return cuda2hip_status(cusolverDnXgesvdjSetTolerance(info->info, tolerance));
 }
 catch(...)
 {
@@ -131,8 +155,11 @@ hipsolverStatus_t hipsolverXgesvdjGetResidual(hipsolverDnHandle_t   handle,
                                               double*               residual)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(
-        cusolverDnXgesvdjGetResidual((cusolverDnHandle_t)handle, (gesvdjInfo_t)info, residual));
+        cusolverDnXgesvdjGetResidual((cusolverDnHandle_t)handle, info->info, residual));
 }
 catch(...)
 {
@@ -144,8 +171,11 @@ hipsolverStatus_t hipsolverXgesvdjGetSweeps(hipsolverDnHandle_t   handle,
                                             int*                  executed_sweeps)
 try
 {
-    return cuda2hip_status(cusolverDnXgesvdjGetSweeps(
-        (cusolverDnHandle_t)handle, (gesvdjInfo_t)info, executed_sweeps));
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return cuda2hip_status(
+        cusolverDnXgesvdjGetSweeps((cusolverDnHandle_t)handle, info->info, executed_sweeps));
 }
 catch(...)
 {
@@ -2353,9 +2383,12 @@ hipsolverStatus_t hipsolverSgesvdj_bufferSize(hipsolverDnHandle_t   handle,
                                               const float*          V,
                                               int                   ldv,
                                               int*                  lwork,
-                                              hipsolverGesvdjInfo_t params)
+                                              hipsolverGesvdjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSgesvdj_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         econ,
@@ -2369,7 +2402,7 @@ try
                                                         V,
                                                         ldv,
                                                         lwork,
-                                                        (gesvdjInfo_t)params));
+                                                        info->info));
 }
 catch(...)
 {
@@ -2389,9 +2422,12 @@ hipsolverStatus_t hipsolverDgesvdj_bufferSize(hipsolverDnHandle_t   handle,
                                               const double*         V,
                                               int                   ldv,
                                               int*                  lwork,
-                                              hipsolverGesvdjInfo_t params)
+                                              hipsolverGesvdjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDgesvdj_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         econ,
@@ -2405,7 +2441,7 @@ try
                                                         V,
                                                         ldv,
                                                         lwork,
-                                                        (gesvdjInfo_t)params));
+                                                        info->info));
 }
 catch(...)
 {
@@ -2425,9 +2461,12 @@ hipsolverStatus_t hipsolverCgesvdj_bufferSize(hipsolverDnHandle_t    handle,
                                               const hipFloatComplex* V,
                                               int                    ldv,
                                               int*                   lwork,
-                                              hipsolverGesvdjInfo_t  params)
+                                              hipsolverGesvdjInfo_t  info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCgesvdj_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         econ,
@@ -2441,7 +2480,7 @@ try
                                                         (cuComplex*)V,
                                                         ldv,
                                                         lwork,
-                                                        (gesvdjInfo_t)params));
+                                                        info->info));
 }
 catch(...)
 {
@@ -2461,9 +2500,12 @@ hipsolverStatus_t hipsolverZgesvdj_bufferSize(hipsolverDnHandle_t     handle,
                                               const hipDoubleComplex* V,
                                               int                     ldv,
                                               int*                    lwork,
-                                              hipsolverGesvdjInfo_t   params)
+                                              hipsolverGesvdjInfo_t   info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZgesvdj_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         econ,
@@ -2477,7 +2519,7 @@ try
                                                         (cuDoubleComplex*)V,
                                                         ldv,
                                                         lwork,
-                                                        (gesvdjInfo_t)params));
+                                                        info->info));
 }
 catch(...)
 {
@@ -2499,9 +2541,12 @@ hipsolverStatus_t hipsolverSgesvdj(hipsolverDnHandle_t   handle,
                                    float*                work,
                                    int                   lwork,
                                    int*                  devInfo,
-                                   hipsolverGesvdjInfo_t params)
+                                   hipsolverGesvdjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSgesvdj((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              econ,
@@ -2517,7 +2562,7 @@ try
                                              work,
                                              lwork,
                                              devInfo,
-                                             (gesvdjInfo_t)params));
+                                             info->info));
 }
 catch(...)
 {
@@ -2539,9 +2584,12 @@ hipsolverStatus_t hipsolverDgesvdj(hipsolverDnHandle_t   handle,
                                    double*               work,
                                    int                   lwork,
                                    int*                  devInfo,
-                                   hipsolverGesvdjInfo_t params)
+                                   hipsolverGesvdjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDgesvdj((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              econ,
@@ -2557,7 +2605,7 @@ try
                                              work,
                                              lwork,
                                              devInfo,
-                                             (gesvdjInfo_t)params));
+                                             info->info));
 }
 catch(...)
 {
@@ -2579,9 +2627,12 @@ hipsolverStatus_t hipsolverCgesvdj(hipsolverDnHandle_t   handle,
                                    hipFloatComplex*      work,
                                    int                   lwork,
                                    int*                  devInfo,
-                                   hipsolverGesvdjInfo_t params)
+                                   hipsolverGesvdjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCgesvdj((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              econ,
@@ -2597,7 +2648,7 @@ try
                                              (cuComplex*)work,
                                              lwork,
                                              devInfo,
-                                             (gesvdjInfo_t)params));
+                                             info->info));
 }
 catch(...)
 {
@@ -2619,9 +2670,12 @@ hipsolverStatus_t hipsolverZgesvdj(hipsolverDnHandle_t   handle,
                                    hipDoubleComplex*     work,
                                    int                   lwork,
                                    int*                  devInfo,
-                                   hipsolverGesvdjInfo_t params)
+                                   hipsolverGesvdjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZgesvdj((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              econ,
@@ -2637,7 +2691,7 @@ try
                                              (cuDoubleComplex*)work,
                                              lwork,
                                              devInfo,
-                                             (gesvdjInfo_t)params));
+                                             info->info));
 }
 catch(...)
 {
@@ -2657,10 +2711,13 @@ hipsolverStatus_t hipsolverSgesvdjBatched_bufferSize(hipsolverDnHandle_t   handl
                                                      const float*          V,
                                                      int                   ldv,
                                                      int*                  lwork,
-                                                     hipsolverGesvdjInfo_t params,
+                                                     hipsolverGesvdjInfo_t info,
                                                      int                   batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSgesvdjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                hip2cuda_evect(jobz),
                                                                m,
@@ -2673,7 +2730,7 @@ try
                                                                V,
                                                                ldv,
                                                                lwork,
-                                                               (gesvdjInfo_t)params,
+                                                               info->info,
                                                                batch_count));
 }
 catch(...)
@@ -2693,10 +2750,13 @@ hipsolverStatus_t hipsolverDgesvdjBatched_bufferSize(hipsolverDnHandle_t   handl
                                                      const double*         V,
                                                      int                   ldv,
                                                      int*                  lwork,
-                                                     hipsolverGesvdjInfo_t params,
+                                                     hipsolverGesvdjInfo_t info,
                                                      int                   batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDgesvdjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                hip2cuda_evect(jobz),
                                                                m,
@@ -2709,7 +2769,7 @@ try
                                                                V,
                                                                ldv,
                                                                lwork,
-                                                               (gesvdjInfo_t)params,
+                                                               info->info,
                                                                batch_count));
 }
 catch(...)
@@ -2729,10 +2789,13 @@ hipsolverStatus_t hipsolverCgesvdjBatched_bufferSize(hipsolverDnHandle_t    hand
                                                      const hipFloatComplex* V,
                                                      int                    ldv,
                                                      int*                   lwork,
-                                                     hipsolverGesvdjInfo_t  params,
+                                                     hipsolverGesvdjInfo_t  info,
                                                      int                    batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCgesvdjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                hip2cuda_evect(jobz),
                                                                m,
@@ -2745,7 +2808,7 @@ try
                                                                (cuComplex*)V,
                                                                ldv,
                                                                lwork,
-                                                               (gesvdjInfo_t)params,
+                                                               info->info,
                                                                batch_count));
 }
 catch(...)
@@ -2765,10 +2828,13 @@ hipsolverStatus_t hipsolverZgesvdjBatched_bufferSize(hipsolverDnHandle_t     han
                                                      const hipDoubleComplex* V,
                                                      int                     ldv,
                                                      int*                    lwork,
-                                                     hipsolverGesvdjInfo_t   params,
+                                                     hipsolverGesvdjInfo_t   info,
                                                      int                     batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZgesvdjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                hip2cuda_evect(jobz),
                                                                m,
@@ -2781,7 +2847,7 @@ try
                                                                (cuDoubleComplex*)V,
                                                                ldv,
                                                                lwork,
-                                                               (gesvdjInfo_t)params,
+                                                               info->info,
                                                                batch_count));
 }
 catch(...)
@@ -2803,10 +2869,13 @@ hipsolverStatus_t hipsolverSgesvdjBatched(hipsolverDnHandle_t   handle,
                                           float*                work,
                                           int                   lwork,
                                           int*                  devInfo,
-                                          hipsolverGesvdjInfo_t params,
+                                          hipsolverGesvdjInfo_t info,
                                           int                   batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSgesvdjBatched((cusolverDnHandle_t)handle,
                                                     hip2cuda_evect(jobz),
                                                     m,
@@ -2821,7 +2890,7 @@ try
                                                     work,
                                                     lwork,
                                                     devInfo,
-                                                    (gesvdjInfo_t)params,
+                                                    info->info,
                                                     batch_count));
 }
 catch(...)
@@ -2843,10 +2912,13 @@ hipsolverStatus_t hipsolverDgesvdjBatched(hipsolverDnHandle_t   handle,
                                           double*               work,
                                           int                   lwork,
                                           int*                  devInfo,
-                                          hipsolverGesvdjInfo_t params,
+                                          hipsolverGesvdjInfo_t info,
                                           int                   batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDgesvdjBatched((cusolverDnHandle_t)handle,
                                                     hip2cuda_evect(jobz),
                                                     m,
@@ -2861,7 +2933,7 @@ try
                                                     work,
                                                     lwork,
                                                     devInfo,
-                                                    (gesvdjInfo_t)params,
+                                                    info->info,
                                                     batch_count));
 }
 catch(...)
@@ -2883,10 +2955,13 @@ hipsolverStatus_t hipsolverCgesvdjBatched(hipsolverDnHandle_t   handle,
                                           hipFloatComplex*      work,
                                           int                   lwork,
                                           int*                  devInfo,
-                                          hipsolverGesvdjInfo_t params,
+                                          hipsolverGesvdjInfo_t info,
                                           int                   batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCgesvdjBatched((cusolverDnHandle_t)handle,
                                                     hip2cuda_evect(jobz),
                                                     m,
@@ -2901,7 +2976,7 @@ try
                                                     (cuComplex*)work,
                                                     lwork,
                                                     devInfo,
-                                                    (gesvdjInfo_t)params,
+                                                    info->info,
                                                     batch_count));
 }
 catch(...)
@@ -2923,10 +2998,13 @@ hipsolverStatus_t hipsolverZgesvdjBatched(hipsolverDnHandle_t   handle,
                                           hipDoubleComplex*     work,
                                           int                   lwork,
                                           int*                  devInfo,
-                                          hipsolverGesvdjInfo_t params,
+                                          hipsolverGesvdjInfo_t info,
                                           int                   batch_count)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZgesvdjBatched((cusolverDnHandle_t)handle,
                                                     hip2cuda_evect(jobz),
                                                     m,
@@ -2941,7 +3019,7 @@ try
                                                     (cuDoubleComplex*)work,
                                                     lwork,
                                                     devInfo,
-                                                    (gesvdjInfo_t)params,
+                                                    info->info,
                                                     batch_count));
 }
 catch(...)

--- a/library/src/nvidia_detail/hipsolver.cpp
+++ b/library/src/nvidia_detail/hipsolver.cpp
@@ -45,7 +45,10 @@ try
     hipsolverStatus_t result = (*handle)->setup();
 
     if(result != HIPSOLVER_STATUS_SUCCESS)
+    {
         delete *handle;
+        *handle = nullptr;
+    }
 
     return result;
 }
@@ -107,7 +110,10 @@ try
     hipsolverStatus_t result = (*info)->setup();
 
     if(result != HIPSOLVER_STATUS_SUCCESS)
+    {
         delete *info;
+        *info = nullptr;
+    }
 
     return result;
 }
@@ -212,7 +218,10 @@ try
     hipsolverStatus_t result = (*info)->setup();
 
     if(result != HIPSOLVER_STATUS_SUCCESS)
+    {
         delete *info;
+        *info = nullptr;
+    }
 
     return result;
 }

--- a/library/src/nvidia_detail/hipsolver_refactor.cpp
+++ b/library/src/nvidia_detail/hipsolver_refactor.cpp
@@ -46,7 +46,10 @@ try
     hipsolverStatus_t result = (*handle)->setup();
 
     if(result != HIPSOLVER_STATUS_SUCCESS)
+    {
         delete *handle;
+        *handle = nullptr;
+    }
 
     return result;
 }

--- a/library/src/nvidia_detail/hipsolver_refactor.cpp
+++ b/library/src/nvidia_detail/hipsolver_refactor.cpp
@@ -29,6 +29,7 @@
 #include "exceptions.hpp"
 #include "hipsolver.h"
 #include "hipsolver_conversions.hpp"
+#include "hipsolver_types.hpp"
 
 #include <cusolverRf.h>
 

--- a/library/src/nvidia_detail/hipsolver_types.cpp
+++ b/library/src/nvidia_detail/hipsolver_types.cpp
@@ -24,6 +24,18 @@
 #include "hipsolver_types.hpp"
 #include "hipsolver_conversions.hpp"
 
+/******************** DN HANDLE ********************/
+hipsolverHandle::hipsolverHandle() {}
+
+hipsolverStatus_t hipsolverHandle::setup()
+{
+    return cuda2hip_status(cusolverDnCreate(&handle));
+}
+hipsolverStatus_t hipsolverHandle::teardown()
+{
+    return cuda2hip_status(cusolverDnDestroy(handle));
+}
+
 /******************** RF HANDLE ********************/
 hipsolverRfHandle::hipsolverRfHandle() {}
 

--- a/library/src/nvidia_detail/hipsolver_types.cpp
+++ b/library/src/nvidia_detail/hipsolver_types.cpp
@@ -24,6 +24,18 @@
 #include "hipsolver_types.hpp"
 #include "hipsolver_conversions.hpp"
 
+/******************** RF HANDLE ********************/
+hipsolverRfHandle::hipsolverRfHandle() {}
+
+hipsolverStatus_t hipsolverRfHandle::setup()
+{
+    return cuda2hip_status(cusolverRfCreate(&handle));
+}
+hipsolverStatus_t hipsolverRfHandle::teardown()
+{
+    return cuda2hip_status(cusolverRfDestroy(handle));
+}
+
 /******************** GESVDJ PARAMS ********************/
 hipsolverGesvdjInfo::hipsolverGesvdjInfo() {}
 

--- a/library/src/nvidia_detail/hipsolver_types.cpp
+++ b/library/src/nvidia_detail/hipsolver_types.cpp
@@ -1,0 +1,37 @@
+/* ************************************************************************
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#include "hipsolver_types.hpp"
+#include "hipsolver_conversions.hpp"
+
+/******************** SYEVJ PARAMS ********************/
+hipsolverSyevjInfo::hipsolverSyevjInfo() {}
+
+hipsolverStatus_t hipsolverSyevjInfo::setup()
+{
+    return cuda2hip_status(cusolverDnCreateSyevjInfo(&info));
+}
+hipsolverStatus_t hipsolverSyevjInfo::teardown()
+{
+    return cuda2hip_status(cusolverDnDestroySyevjInfo(info));
+}

--- a/library/src/nvidia_detail/hipsolver_types.cpp
+++ b/library/src/nvidia_detail/hipsolver_types.cpp
@@ -24,6 +24,18 @@
 #include "hipsolver_types.hpp"
 #include "hipsolver_conversions.hpp"
 
+/******************** GESVDJ PARAMS ********************/
+hipsolverGesvdjInfo::hipsolverGesvdjInfo() {}
+
+hipsolverStatus_t hipsolverGesvdjInfo::setup()
+{
+    return cuda2hip_status(cusolverDnCreateGesvdjInfo(&info));
+}
+hipsolverStatus_t hipsolverGesvdjInfo::teardown()
+{
+    return cuda2hip_status(cusolverDnDestroyGesvdjInfo(info));
+}
+
 /******************** SYEVJ PARAMS ********************/
 hipsolverSyevjInfo::hipsolverSyevjInfo() {}
 

--- a/library/src/nvidia_detail/hipsolver_types.hpp
+++ b/library/src/nvidia_detail/hipsolver_types.hpp
@@ -27,6 +27,26 @@
 #include <cusolverDn.h>
 #include <cusolverRf.h>
 
+struct hipsolverGesvdjInfo
+{
+    gesvdjInfo_t info;
+
+    // Constructor
+    hipsolverGesvdjInfo();
+
+    hipsolverGesvdjInfo(const hipsolverGesvdjInfo&) = delete;
+
+    hipsolverGesvdjInfo(hipsolverGesvdjInfo&&) = delete;
+
+    hipsolverGesvdjInfo& operator=(const hipsolverGesvdjInfo&) = delete;
+
+    hipsolverGesvdjInfo& operator=(hipsolverGesvdjInfo&&) = delete;
+
+    // Allocate resources
+    hipsolverStatus_t setup();
+    hipsolverStatus_t teardown();
+};
+
 struct hipsolverSyevjInfo
 {
     syevjInfo_t info;

--- a/library/src/nvidia_detail/hipsolver_types.hpp
+++ b/library/src/nvidia_detail/hipsolver_types.hpp
@@ -27,6 +27,26 @@
 #include <cusolverDn.h>
 #include <cusolverRf.h>
 
+struct hipsolverRfHandle
+{
+    cusolverRfHandle_t handle;
+
+    // Constructor
+    hipsolverRfHandle();
+
+    hipsolverRfHandle(const hipsolverRfHandle&) = delete;
+
+    hipsolverRfHandle(hipsolverRfHandle&&) = delete;
+
+    hipsolverRfHandle& operator=(const hipsolverRfHandle&) = delete;
+
+    hipsolverRfHandle& operator=(hipsolverRfHandle&&) = delete;
+
+    // Allocate resources
+    hipsolverStatus_t setup();
+    hipsolverStatus_t teardown();
+};
+
 struct hipsolverGesvdjInfo
 {
     gesvdjInfo_t info;

--- a/library/src/nvidia_detail/hipsolver_types.hpp
+++ b/library/src/nvidia_detail/hipsolver_types.hpp
@@ -1,0 +1,48 @@
+/* ************************************************************************
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#pragma once
+
+#include "hipsolver.h"
+#include <cusolverDn.h>
+#include <cusolverRf.h>
+
+struct hipsolverSyevjInfo
+{
+    syevjInfo_t info;
+
+    // Constructor
+    hipsolverSyevjInfo();
+
+    hipsolverSyevjInfo(const hipsolverSyevjInfo&) = delete;
+
+    hipsolverSyevjInfo(hipsolverSyevjInfo&&) = delete;
+
+    hipsolverSyevjInfo& operator=(const hipsolverSyevjInfo&) = delete;
+
+    hipsolverSyevjInfo& operator=(hipsolverSyevjInfo&&) = delete;
+
+    // Allocate resources
+    hipsolverStatus_t setup();
+    hipsolverStatus_t teardown();
+};

--- a/library/src/nvidia_detail/hipsolver_types.hpp
+++ b/library/src/nvidia_detail/hipsolver_types.hpp
@@ -27,6 +27,26 @@
 #include <cusolverDn.h>
 #include <cusolverRf.h>
 
+struct hipsolverHandle
+{
+    cusolverDnHandle_t handle;
+
+    // Constructor
+    hipsolverHandle();
+
+    hipsolverHandle(const hipsolverHandle&) = delete;
+
+    hipsolverHandle(hipsolverHandle&&) = delete;
+
+    hipsolverHandle& operator=(const hipsolverHandle&) = delete;
+
+    hipsolverHandle& operator=(hipsolverHandle&&) = delete;
+
+    // Allocate resources
+    hipsolverStatus_t setup();
+    hipsolverStatus_t teardown();
+};
+
 struct hipsolverRfHandle
 {
     cusolverRfHandle_t handle;


### PR DESCRIPTION
This PR converts hipsolverHandle_t, hipsolverRfHandle_t, hipsolverGesvdjInfo_t, and hipsolverSyevjInfo_t from void pointers into pointers to opaque types. This should improve type safety from the user perspective.

Unfortunately, I've not been able to get this to work in a way that is non-invasive. In particular, I've had to add argument checks to all functions to make sure these opaque pointers are not null before being dereferenced. However, this does have the added benefit of allowing us to enable some of the bad_arg tests with the cuSOLVER backend and improving robustness to null pointers. At some point, it might be worth considering adding null pointer checks for all pointers sent to the cuSOLVER backend.