### PR TITLE
Minor docs fix for hipsolverGesvdjInfo_t

### DIFF
--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -19,6 +19,12 @@ hipsolverHandle_t
 --------------------
 .. doxygentypedef:: hipsolverHandle_t
 
+.. _gesvdjinfo_t:
+
+hipsolverGesvdjInfo_t
+----------------------
+.. doxygentypedef:: hipsolverGesvdjInfo_t
+
 .. _syevjinfo_t:
 
 hipsolverSyevjInfo_t

--- a/docs/compat-api/types.rst
+++ b/docs/compat-api/types.rst
@@ -20,7 +20,7 @@ hipsolverDnHandle_t
 
 hipsolverGesvdjInfo_t
 ----------------------
-.. doxygentypedef:: hipsolverGesvdjInfo_t
+See :ref:`hipsolverGesvdjInfo_t <gesvdjinfo_t>`.
 
 hipsolverSyevjInfo_t
 --------------------


### PR DESCRIPTION
Gesvdj was added to the regular API in https://github.com/ROCmSoftwarePlatform/hipSOLVER/pull/141, but I neglected to add hipsolverGesvdjInfo_t to the regular API documentation.