### PR TITLE
Improved nullptr checks

### DIFF
--- a/clients/include/testing_csrrf_refactlu.hpp
+++ b/clients/include/testing_csrrf_refactlu.hpp
@@ -39,10 +39,8 @@ void csrrf_refactlu_checkBadArgs(hipsolverRfHandle_t handle,
                                  int*                pivP,
                                  int*                pivQ)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolverRfRefactor(nullptr), HIPSOLVER_STATUS_NOT_INITIALIZED);
-#endif
 }
 
 template <typename T>

--- a/clients/include/testing_gels.hpp
+++ b/clients/include/testing_gels.hpp
@@ -45,7 +45,6 @@ void gels_checkBadArgs(const hipsolverHandle_t handle,
                        int*                    info,
                        const int               bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_gels(API,
                                          false,
@@ -72,6 +71,7 @@ void gels_checkBadArgs(const hipsolverHandle_t handle,
     // values
     // N/A
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_gels(API,
                                          false,

--- a/clients/include/testing_gesv.hpp
+++ b/clients/include/testing_gesv.hpp
@@ -46,7 +46,6 @@ void gesv_checkBadArgs(const hipsolverHandle_t handle,
                        U                       dInfo,
                        const int               bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_gesv(API,
                                          false,
@@ -74,6 +73,7 @@ void gesv_checkBadArgs(const hipsolverHandle_t handle,
     // values
     // N/A
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_gesv(API,
                                          false,

--- a/clients/include/testing_gesvda.hpp
+++ b/clients/include/testing_gesvda.hpp
@@ -48,7 +48,6 @@ void gesvda_checkBadArgs(const hipsolverHandle_t handle,
                          double*                 hRnrmF,
                          const int               bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_gesvda(API,
                                            STRIDED,
@@ -101,6 +100,7 @@ void gesvda_checkBadArgs(const hipsolverHandle_t handle,
                                            bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_gesvda(API,
                                            STRIDED,

--- a/clients/include/testing_gesvdj.hpp
+++ b/clients/include/testing_gesvdj.hpp
@@ -48,7 +48,6 @@ void gesvdj_checkBadArgs(const hipsolverHandle_t     handle,
                          const hipsolverGesvdjInfo_t params,
                          const int                   bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_gesvdj(API,
                                            STRIDED,
@@ -101,6 +100,7 @@ void gesvdj_checkBadArgs(const hipsolverHandle_t     handle,
                                            bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_gesvdj(API,
                                            STRIDED,

--- a/clients/include/testing_getrf.hpp
+++ b/clients/include/testing_getrf.hpp
@@ -37,7 +37,6 @@ void getrf_checkBadArgs(const hipsolverHandle_t handle,
                         V                       dinfo,
                         const int               bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(
         hipsolver_getrf(
@@ -47,6 +46,7 @@ void getrf_checkBadArgs(const hipsolverHandle_t handle,
     // values
     // N/A
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(
         hipsolver_getrf(

--- a/clients/include/testing_syevdx_heevdx.hpp
+++ b/clients/include/testing_syevdx_heevdx.hpp
@@ -46,7 +46,6 @@ void syevdx_heevdx_checkBadArgs(const hipsolverHandle_t   handle,
                                 U                         dinfo,
                                 const int                 bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_syevdx_heevdx(API,
                                                   nullptr,
@@ -135,6 +134,7 @@ void syevdx_heevdx_checkBadArgs(const hipsolverHandle_t   handle,
                                                   bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_syevdx_heevdx(API,
                                                   handle,

--- a/clients/include/testing_syevj_heevj.hpp
+++ b/clients/include/testing_syevj_heevj.hpp
@@ -41,7 +41,6 @@ void syevj_heevj_checkBadArgs(const hipsolverHandle_t    handle,
                               const hipsolverSyevjInfo_t params,
                               const int                  bc)
 {
-#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // handle
     EXPECT_ROCBLAS_STATUS(hipsolver_syevj_heevj(API,
                                                 STRIDED,
@@ -97,6 +96,7 @@ void syevj_heevj_checkBadArgs(const hipsolverHandle_t    handle,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
 
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(hipsolver_syevj_heevj(API,
                                                 STRIDED,

--- a/library/src/amd_detail/hipsolver.cpp
+++ b/library/src/amd_detail/hipsolver.cpp
@@ -971,7 +971,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1008,7 +1008,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1045,7 +1045,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1082,7 +1082,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1253,7 +1253,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1283,7 +1283,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1319,7 +1319,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1355,7 +1355,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1523,7 +1523,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1558,7 +1558,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1593,7 +1593,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1628,7 +1628,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1797,7 +1797,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1846,7 +1846,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1895,7 +1895,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -1944,7 +1944,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2170,7 +2170,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2219,7 +2219,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2268,7 +2268,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2317,7 +2317,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2532,7 +2532,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2561,7 +2561,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2590,7 +2590,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2619,7 +2619,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2801,7 +2801,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2855,7 +2855,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2909,7 +2909,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -2963,7 +2963,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3213,7 +3213,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3243,7 +3243,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3273,7 +3273,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3303,7 +3303,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3465,7 +3465,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3513,7 +3513,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3561,7 +3561,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3609,7 +3609,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3829,7 +3829,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3880,7 +3880,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3931,7 +3931,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -3982,7 +3982,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -5432,7 +5432,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -5526,7 +5526,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -5620,7 +5620,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -5714,7 +5714,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6410,7 +6410,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6441,7 +6441,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6472,7 +6472,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6503,7 +6503,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6671,7 +6671,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6716,7 +6716,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6761,7 +6761,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6806,7 +6806,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -6990,7 +6990,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7020,7 +7020,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7054,7 +7054,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7088,7 +7088,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7240,7 +7240,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7275,7 +7275,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7310,7 +7310,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7345,7 +7345,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7498,7 +7498,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7528,7 +7528,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7562,7 +7562,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7596,7 +7596,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7750,7 +7750,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7787,7 +7787,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7824,7 +7824,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -7861,7 +7861,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8040,7 +8040,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8085,7 +8085,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8130,7 +8130,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8175,7 +8175,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8365,7 +8365,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8416,7 +8416,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8467,7 +8467,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8518,7 +8518,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8776,7 +8776,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8832,7 +8832,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8888,7 +8888,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -8944,7 +8944,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10048,7 +10048,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10105,7 +10105,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10162,7 +10162,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10219,7 +10219,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10507,7 +10507,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10569,7 +10569,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10631,7 +10631,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -10693,7 +10693,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11477,7 +11477,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11520,7 +11520,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11563,7 +11563,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11606,7 +11606,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11783,7 +11783,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11813,7 +11813,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11843,7 +11843,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;
@@ -11873,7 +11873,7 @@ try
 {
     if(!handle)
         return HIPSOLVER_STATUS_NOT_INITIALIZED;
-    if(lwork == nullptr)
+    if(!lwork)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     *lwork = 0;

--- a/library/src/nvidia_detail/hipsolver.cpp
+++ b/library/src/nvidia_detail/hipsolver.cpp
@@ -37,6 +37,9 @@ extern "C" {
 hipsolverStatus_t hipsolverCreate(hipsolverHandle_t* handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCreate((cusolverDnHandle_t*)handle));
 }
 catch(...)
@@ -47,6 +50,9 @@ catch(...)
 hipsolverStatus_t hipsolverDestroy(hipsolverHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDestroy((cusolverDnHandle_t)handle));
 }
 catch(...)
@@ -57,6 +63,9 @@ catch(...)
 hipsolverStatus_t hipsolverSetStream(hipsolverHandle_t handle, hipStream_t streamId)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSetStream((cusolverDnHandle_t)handle, streamId));
 }
 catch(...)
@@ -67,6 +76,9 @@ catch(...)
 hipsolverStatus_t hipsolverGetStream(hipsolverHandle_t handle, hipStream_t* streamId)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnGetStream((cusolverDnHandle_t)handle, streamId));
 }
 catch(...)
@@ -78,6 +90,9 @@ catch(...)
 hipsolverStatus_t hipsolverCreateGesvdjInfo(hipsolverGesvdjInfo_t* info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCreateGesvdjInfo((gesvdjInfo_t*)info));
 }
 catch(...)
@@ -88,6 +103,9 @@ catch(...)
 hipsolverStatus_t hipsolverDestroyGesvdjInfo(hipsolverGesvdjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDestroyGesvdjInfo((gesvdjInfo_t)info));
 }
 catch(...)
@@ -98,6 +116,9 @@ catch(...)
 hipsolverStatus_t hipsolverXgesvdjSetMaxSweeps(hipsolverGesvdjInfo_t info, int max_sweeps)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnXgesvdjSetMaxSweeps((gesvdjInfo_t)info, max_sweeps));
 }
 catch(...)
@@ -108,6 +129,9 @@ catch(...)
 hipsolverStatus_t hipsolverXgesvdjSetSortEig(hipsolverGesvdjInfo_t info, int sort_eig)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnXgesvdjSetSortEig((gesvdjInfo_t)info, sort_eig));
 }
 catch(...)
@@ -118,6 +142,9 @@ catch(...)
 hipsolverStatus_t hipsolverXgesvdjSetTolerance(hipsolverGesvdjInfo_t info, double tolerance)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnXgesvdjSetTolerance((gesvdjInfo_t)info, tolerance));
 }
 catch(...)
@@ -130,6 +157,9 @@ hipsolverStatus_t hipsolverXgesvdjGetResidual(hipsolverDnHandle_t   handle,
                                               double*               residual)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(
         cusolverDnXgesvdjGetResidual((cusolverDnHandle_t)handle, (gesvdjInfo_t)info, residual));
 }
@@ -143,6 +173,9 @@ hipsolverStatus_t hipsolverXgesvdjGetSweeps(hipsolverDnHandle_t   handle,
                                             int*                  executed_sweeps)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnXgesvdjGetSweeps(
         (cusolverDnHandle_t)handle, (gesvdjInfo_t)info, executed_sweeps));
 }
@@ -155,6 +188,9 @@ catch(...)
 hipsolverStatus_t hipsolverCreateSyevjInfo(hipsolverSyevjInfo_t* info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCreateSyevjInfo((syevjInfo_t*)info));
 }
 catch(...)
@@ -165,6 +201,9 @@ catch(...)
 hipsolverStatus_t hipsolverDestroySyevjInfo(hipsolverSyevjInfo_t info)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDestroySyevjInfo((syevjInfo_t)info));
 }
 catch(...)
@@ -175,6 +214,9 @@ catch(...)
 hipsolverStatus_t hipsolverXsyevjSetMaxSweeps(hipsolverSyevjInfo_t info, int max_sweeps)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnXsyevjSetMaxSweeps((syevjInfo_t)info, max_sweeps));
 }
 catch(...)
@@ -185,6 +227,9 @@ catch(...)
 hipsolverStatus_t hipsolverXsyevjSetSortEig(hipsolverSyevjInfo_t info, int sort_eig)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnXsyevjSetSortEig((syevjInfo_t)info, sort_eig));
 }
 catch(...)
@@ -195,6 +240,9 @@ catch(...)
 hipsolverStatus_t hipsolverXsyevjSetTolerance(hipsolverSyevjInfo_t info, double tolerance)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnXsyevjSetTolerance((syevjInfo_t)info, tolerance));
 }
 catch(...)
@@ -207,6 +255,9 @@ hipsolverStatus_t hipsolverXsyevjGetResidual(hipsolverDnHandle_t  handle,
                                              double*              residual)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(
         cusolverDnXsyevjGetResidual((cusolverDnHandle_t)handle, (syevjInfo_t)info, residual));
 }
@@ -220,6 +271,9 @@ hipsolverStatus_t hipsolverXsyevjGetSweeps(hipsolverDnHandle_t  handle,
                                            int*                 executed_sweeps)
 try
 {
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(
         cusolverDnXsyevjGetSweeps((cusolverDnHandle_t)handle, (syevjInfo_t)info, executed_sweeps));
 }
@@ -240,6 +294,9 @@ hipsolverStatus_t hipsolverSorgbr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSorgbr_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_side(side), m, n, k, A, lda, tau, lwork));
 }
@@ -259,6 +316,9 @@ hipsolverStatus_t hipsolverDorgbr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDorgbr_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_side(side), m, n, k, A, lda, tau, lwork));
 }
@@ -278,6 +338,9 @@ hipsolverStatus_t hipsolverCungbr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCungbr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        m,
@@ -304,6 +367,9 @@ hipsolverStatus_t hipsolverZungbr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZungbr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        m,
@@ -332,6 +398,9 @@ hipsolverStatus_t hipsolverSorgbr(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSorgbr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             m,
@@ -362,6 +431,9 @@ hipsolverStatus_t hipsolverDorgbr(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDorgbr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             m,
@@ -392,6 +464,9 @@ hipsolverStatus_t hipsolverCungbr(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCungbr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             m,
@@ -422,6 +497,9 @@ hipsolverStatus_t hipsolverZungbr(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZungbr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             m,
@@ -444,6 +522,9 @@ hipsolverStatus_t hipsolverSorgqr_bufferSize(
     hipsolverHandle_t handle, int m, int n, int k, float* A, int lda, float* tau, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnSorgqr_bufferSize((cusolverDnHandle_t)handle, m, n, k, A, lda, tau, lwork));
 }
@@ -456,6 +537,9 @@ hipsolverStatus_t hipsolverDorgqr_bufferSize(
     hipsolverHandle_t handle, int m, int n, int k, double* A, int lda, double* tau, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnDorgqr_bufferSize((cusolverDnHandle_t)handle, m, n, k, A, lda, tau, lwork));
 }
@@ -474,6 +558,9 @@ hipsolverStatus_t hipsolverCungqr_bufferSize(hipsolverHandle_t handle,
                                              int*              lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCungqr_bufferSize(
         (cusolverDnHandle_t)handle, m, n, k, (cuComplex*)A, lda, (cuComplex*)tau, lwork));
 }
@@ -492,6 +579,9 @@ hipsolverStatus_t hipsolverZungqr_bufferSize(hipsolverHandle_t handle,
                                              int*              lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZungqr_bufferSize((cusolverDnHandle_t)handle,
                                                        m,
                                                        n,
@@ -518,6 +608,9 @@ hipsolverStatus_t hipsolverSorgqr(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnSorgqr((cusolverDnHandle_t)handle, m, n, k, A, lda, tau, work, lwork, devInfo));
 }
@@ -538,6 +631,9 @@ hipsolverStatus_t hipsolverDorgqr(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnDorgqr((cusolverDnHandle_t)handle, m, n, k, A, lda, tau, work, lwork, devInfo));
 }
@@ -558,6 +654,9 @@ hipsolverStatus_t hipsolverCungqr(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCungqr((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -586,6 +685,9 @@ hipsolverStatus_t hipsolverZungqr(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZungqr((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -612,6 +714,9 @@ hipsolverStatus_t hipsolverSorgtr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSorgtr_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, tau, lwork));
 }
@@ -629,6 +734,9 @@ hipsolverStatus_t hipsolverDorgtr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDorgtr_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, tau, lwork));
 }
@@ -646,6 +754,9 @@ hipsolverStatus_t hipsolverCungtr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCungtr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_fill(uplo),
                                                        n,
@@ -668,6 +779,9 @@ hipsolverStatus_t hipsolverZungtr_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZungtr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_fill(uplo),
                                                        n,
@@ -692,6 +806,9 @@ hipsolverStatus_t hipsolverSorgtr(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSorgtr(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, tau, work, lwork, devInfo));
 }
@@ -711,6 +828,9 @@ hipsolverStatus_t hipsolverDorgtr(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDorgtr(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, tau, work, lwork, devInfo));
 }
@@ -730,6 +850,9 @@ hipsolverStatus_t hipsolverCungtr(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCungtr((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -756,6 +879,9 @@ hipsolverStatus_t hipsolverZungtr(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZungtr((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -786,6 +912,9 @@ hipsolverStatus_t hipsolverSormqr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSormqr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        hip2cuda_operation(trans),
@@ -818,6 +947,9 @@ hipsolverStatus_t hipsolverDormqr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDormqr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        hip2cuda_operation(trans),
@@ -850,6 +982,9 @@ hipsolverStatus_t hipsolverCunmqr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCunmqr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        hip2cuda_operation(trans),
@@ -882,6 +1017,9 @@ hipsolverStatus_t hipsolverZunmqr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZunmqr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        hip2cuda_operation(trans),
@@ -916,6 +1054,9 @@ hipsolverStatus_t hipsolverSormqr(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSormqr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             hip2cuda_operation(trans),
@@ -952,6 +1093,9 @@ hipsolverStatus_t hipsolverDormqr(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDormqr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             hip2cuda_operation(trans),
@@ -988,6 +1132,9 @@ hipsolverStatus_t hipsolverCunmqr(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCunmqr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             hip2cuda_operation(trans),
@@ -1024,6 +1171,9 @@ hipsolverStatus_t hipsolverZunmqr(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZunmqr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             hip2cuda_operation(trans),
@@ -1059,6 +1209,9 @@ hipsolverStatus_t hipsolverSormtr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSormtr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        hip2cuda_fill(uplo),
@@ -1091,6 +1244,9 @@ hipsolverStatus_t hipsolverDormtr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDormtr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        hip2cuda_fill(uplo),
@@ -1123,6 +1279,9 @@ hipsolverStatus_t hipsolverCunmtr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCunmtr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        hip2cuda_fill(uplo),
@@ -1155,6 +1314,9 @@ hipsolverStatus_t hipsolverZunmtr_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZunmtr_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_side(side),
                                                        hip2cuda_fill(uplo),
@@ -1189,6 +1351,9 @@ hipsolverStatus_t hipsolverSormtr(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSormtr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             hip2cuda_fill(uplo),
@@ -1225,6 +1390,9 @@ hipsolverStatus_t hipsolverDormtr(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDormtr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             hip2cuda_fill(uplo),
@@ -1261,6 +1429,9 @@ hipsolverStatus_t hipsolverCunmtr(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCunmtr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             hip2cuda_fill(uplo),
@@ -1297,6 +1468,9 @@ hipsolverStatus_t hipsolverZunmtr(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZunmtr((cusolverDnHandle_t)handle,
                                             hip2cuda_side(side),
                                             hip2cuda_fill(uplo),
@@ -1321,6 +1495,9 @@ catch(...)
 hipsolverStatus_t hipsolverSgebrd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgebrd_bufferSize((cusolverDnHandle_t)handle, m, n, lwork));
 }
 catch(...)
@@ -1331,6 +1508,9 @@ catch(...)
 hipsolverStatus_t hipsolverDgebrd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDgebrd_bufferSize((cusolverDnHandle_t)handle, m, n, lwork));
 }
 catch(...)
@@ -1341,6 +1521,9 @@ catch(...)
 hipsolverStatus_t hipsolverCgebrd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCgebrd_bufferSize((cusolverDnHandle_t)handle, m, n, lwork));
 }
 catch(...)
@@ -1351,6 +1534,9 @@ catch(...)
 hipsolverStatus_t hipsolverZgebrd_bufferSize(hipsolverHandle_t handle, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgebrd_bufferSize((cusolverDnHandle_t)handle, m, n, lwork));
 }
 catch(...)
@@ -1372,6 +1558,9 @@ hipsolverStatus_t hipsolverSgebrd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgebrd(
         (cusolverDnHandle_t)handle, m, n, A, lda, D, E, tauq, taup, work, lwork, devInfo));
 }
@@ -1394,6 +1583,9 @@ hipsolverStatus_t hipsolverDgebrd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDgebrd(
         (cusolverDnHandle_t)handle, m, n, A, lda, D, E, tauq, taup, work, lwork, devInfo));
 }
@@ -1416,6 +1608,9 @@ hipsolverStatus_t hipsolverCgebrd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCgebrd((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -1448,6 +1643,9 @@ hipsolverStatus_t hipsolverZgebrd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgebrd((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -1480,6 +1678,9 @@ hipsolverStatus_t hipsolverSSgels_bufferSize(hipsolverHandle_t handle,
                                              size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSSgels_bufferSize(
         (cusolverDnHandle_t)handle, m, n, nrhs, A, lda, B, ldb, X, ldx, nullptr, lwork));
 }
@@ -1501,6 +1702,9 @@ hipsolverStatus_t hipsolverDDgels_bufferSize(hipsolverHandle_t handle,
                                              size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDDgels_bufferSize(
         (cusolverDnHandle_t)handle, m, n, nrhs, A, lda, B, ldb, X, ldx, nullptr, lwork));
 }
@@ -1522,6 +1726,9 @@ hipsolverStatus_t hipsolverCCgels_bufferSize(hipsolverHandle_t handle,
                                              size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCCgels_bufferSize((cusolverDnHandle_t)handle,
                                                        m,
                                                        n,
@@ -1553,6 +1760,9 @@ hipsolverStatus_t hipsolverZZgels_bufferSize(hipsolverHandle_t handle,
                                              size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZZgels_bufferSize((cusolverDnHandle_t)handle,
                                                        m,
                                                        n,
@@ -1587,6 +1797,9 @@ hipsolverStatus_t hipsolverSSgels(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSSgels((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -1623,6 +1836,9 @@ hipsolverStatus_t hipsolverDDgels(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDDgels((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -1659,6 +1875,9 @@ hipsolverStatus_t hipsolverCCgels(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCCgels((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -1695,6 +1914,9 @@ hipsolverStatus_t hipsolverZZgels(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZZgels((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -1720,6 +1942,9 @@ hipsolverStatus_t hipsolverSgeqrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnSgeqrf_bufferSize((cusolverDnHandle_t)handle, m, n, A, lda, lwork));
 }
@@ -1732,6 +1957,9 @@ hipsolverStatus_t hipsolverDgeqrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnDgeqrf_bufferSize((cusolverDnHandle_t)handle, m, n, A, lda, lwork));
 }
@@ -1744,6 +1972,9 @@ hipsolverStatus_t hipsolverCgeqrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnCgeqrf_bufferSize((cusolverDnHandle_t)handle, m, n, (cuComplex*)A, lda, lwork));
 }
@@ -1756,6 +1987,9 @@ hipsolverStatus_t hipsolverZgeqrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgeqrf_bufferSize(
         (cusolverDnHandle_t)handle, m, n, (cuDoubleComplex*)A, lda, lwork));
 }
@@ -1775,6 +2009,9 @@ hipsolverStatus_t hipsolverSgeqrf(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnSgeqrf((cusolverDnHandle_t)handle, m, n, A, lda, tau, work, lwork, devInfo));
 }
@@ -1794,6 +2031,9 @@ hipsolverStatus_t hipsolverDgeqrf(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnDgeqrf((cusolverDnHandle_t)handle, m, n, A, lda, tau, work, lwork, devInfo));
 }
@@ -1813,6 +2053,9 @@ hipsolverStatus_t hipsolverCgeqrf(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCgeqrf((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -1839,6 +2082,9 @@ hipsolverStatus_t hipsolverZgeqrf(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgeqrf((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -1868,6 +2114,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSSgesv_bufferSize(hipsolverHandle_t 
                                                               size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSSgesv_bufferSize(
         (cusolverDnHandle_t)handle, n, nrhs, A, lda, devIpiv, B, ldb, X, ldx, nullptr, lwork));
 }
@@ -1889,6 +2138,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDDgesv_bufferSize(hipsolverHandle_t 
                                                               size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDDgesv_bufferSize(
         (cusolverDnHandle_t)handle, n, nrhs, A, lda, devIpiv, B, ldb, X, ldx, nullptr, lwork));
 }
@@ -1910,6 +2162,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCCgesv_bufferSize(hipsolverHandle_t 
                                                               size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCCgesv_bufferSize((cusolverDnHandle_t)handle,
                                                        n,
                                                        nrhs,
@@ -1941,6 +2196,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZZgesv_bufferSize(hipsolverHandle_t 
                                                               size_t*           lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZZgesv_bufferSize((cusolverDnHandle_t)handle,
                                                        n,
                                                        nrhs,
@@ -1975,6 +2233,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSSgesv(hipsolverHandle_t handle,
                                                    int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSSgesv((cusolverDnHandle_t)handle,
                                             n,
                                             nrhs,
@@ -2011,6 +2272,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDDgesv(hipsolverHandle_t handle,
                                                    int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDDgesv((cusolverDnHandle_t)handle,
                                             n,
                                             nrhs,
@@ -2047,6 +2311,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverCCgesv(hipsolverHandle_t handle,
                                                    int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCCgesv((cusolverDnHandle_t)handle,
                                             n,
                                             nrhs,
@@ -2083,6 +2350,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZZgesv(hipsolverHandle_t handle,
                                                    int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZZgesv((cusolverDnHandle_t)handle,
                                             n,
                                             nrhs,
@@ -2108,6 +2378,9 @@ hipsolverStatus_t hipsolverSgesvd_bufferSize(
     hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgesvd_bufferSize((cusolverDnHandle_t)handle, m, n, lwork));
 }
 catch(...)
@@ -2119,6 +2392,9 @@ hipsolverStatus_t hipsolverDgesvd_bufferSize(
     hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgesvd_bufferSize((cusolverDnHandle_t)handle, m, n, lwork));
 }
 catch(...)
@@ -2130,6 +2406,9 @@ hipsolverStatus_t hipsolverCgesvd_bufferSize(
     hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgesvd_bufferSize((cusolverDnHandle_t)handle, m, n, lwork));
 }
 catch(...)
@@ -2141,6 +2420,9 @@ hipsolverStatus_t hipsolverZgesvd_bufferSize(
     hipsolverHandle_t handle, signed char jobu, signed char jobv, int m, int n, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgesvd_bufferSize((cusolverDnHandle_t)handle, m, n, lwork));
 }
 catch(...)
@@ -2166,6 +2448,9 @@ hipsolverStatus_t hipsolverSgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgesvd((cusolverDnHandle_t)handle,
                                             jobu,
                                             jobv,
@@ -2206,6 +2491,9 @@ hipsolverStatus_t hipsolverDgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDgesvd((cusolverDnHandle_t)handle,
                                             jobu,
                                             jobv,
@@ -2246,6 +2534,9 @@ hipsolverStatus_t hipsolverCgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCgesvd((cusolverDnHandle_t)handle,
                                             jobu,
                                             jobv,
@@ -2286,6 +2577,9 @@ hipsolverStatus_t hipsolverZgesvd(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgesvd((cusolverDnHandle_t)handle,
                                             jobu,
                                             jobv,
@@ -2322,9 +2616,14 @@ hipsolverStatus_t hipsolverSgesvdj_bufferSize(hipsolverDnHandle_t   handle,
                                               const float*          V,
                                               int                   ldv,
                                               int*                  lwork,
-                                              hipsolverGesvdjInfo_t params)
+                                              hipsolverGesvdjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSgesvdj_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         econ,
@@ -2338,7 +2637,7 @@ try
                                                         V,
                                                         ldv,
                                                         lwork,
-                                                        (gesvdjInfo_t)params));
+                                                        (gesvdjInfo_t)info));
 }
 catch(...)
 {
@@ -2358,9 +2657,14 @@ hipsolverStatus_t hipsolverDgesvdj_bufferSize(hipsolverDnHandle_t   handle,
                                               const double*         V,
                                               int                   ldv,
                                               int*                  lwork,
-                                              hipsolverGesvdjInfo_t params)
+                                              hipsolverGesvdjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDgesvdj_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         econ,
@@ -2374,7 +2678,7 @@ try
                                                         V,
                                                         ldv,
                                                         lwork,
-                                                        (gesvdjInfo_t)params));
+                                                        (gesvdjInfo_t)info));
 }
 catch(...)
 {
@@ -2394,9 +2698,14 @@ hipsolverStatus_t hipsolverCgesvdj_bufferSize(hipsolverDnHandle_t    handle,
                                               const hipFloatComplex* V,
                                               int                    ldv,
                                               int*                   lwork,
-                                              hipsolverGesvdjInfo_t  params)
+                                              hipsolverGesvdjInfo_t  info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCgesvdj_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         econ,
@@ -2410,7 +2719,7 @@ try
                                                         (cuComplex*)V,
                                                         ldv,
                                                         lwork,
-                                                        (gesvdjInfo_t)params));
+                                                        (gesvdjInfo_t)info));
 }
 catch(...)
 {
@@ -2430,9 +2739,14 @@ hipsolverStatus_t hipsolverZgesvdj_bufferSize(hipsolverDnHandle_t     handle,
                                               const hipDoubleComplex* V,
                                               int                     ldv,
                                               int*                    lwork,
-                                              hipsolverGesvdjInfo_t   params)
+                                              hipsolverGesvdjInfo_t   info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZgesvdj_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         econ,
@@ -2446,7 +2760,7 @@ try
                                                         (cuDoubleComplex*)V,
                                                         ldv,
                                                         lwork,
-                                                        (gesvdjInfo_t)params));
+                                                        (gesvdjInfo_t)info));
 }
 catch(...)
 {
@@ -2468,9 +2782,14 @@ hipsolverStatus_t hipsolverSgesvdj(hipsolverDnHandle_t   handle,
                                    float*                work,
                                    int                   lwork,
                                    int*                  devInfo,
-                                   hipsolverGesvdjInfo_t params)
+                                   hipsolverGesvdjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSgesvdj((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              econ,
@@ -2486,7 +2805,7 @@ try
                                              work,
                                              lwork,
                                              devInfo,
-                                             (gesvdjInfo_t)params));
+                                             (gesvdjInfo_t)info));
 }
 catch(...)
 {
@@ -2508,9 +2827,14 @@ hipsolverStatus_t hipsolverDgesvdj(hipsolverDnHandle_t   handle,
                                    double*               work,
                                    int                   lwork,
                                    int*                  devInfo,
-                                   hipsolverGesvdjInfo_t params)
+                                   hipsolverGesvdjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDgesvdj((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              econ,
@@ -2526,7 +2850,7 @@ try
                                              work,
                                              lwork,
                                              devInfo,
-                                             (gesvdjInfo_t)params));
+                                             (gesvdjInfo_t)info));
 }
 catch(...)
 {
@@ -2548,9 +2872,14 @@ hipsolverStatus_t hipsolverCgesvdj(hipsolverDnHandle_t   handle,
                                    hipFloatComplex*      work,
                                    int                   lwork,
                                    int*                  devInfo,
-                                   hipsolverGesvdjInfo_t params)
+                                   hipsolverGesvdjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCgesvdj((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              econ,
@@ -2566,7 +2895,7 @@ try
                                              (cuComplex*)work,
                                              lwork,
                                              devInfo,
-                                             (gesvdjInfo_t)params));
+                                             (gesvdjInfo_t)info));
 }
 catch(...)
 {
@@ -2588,9 +2917,14 @@ hipsolverStatus_t hipsolverZgesvdj(hipsolverDnHandle_t   handle,
                                    hipDoubleComplex*     work,
                                    int                   lwork,
                                    int*                  devInfo,
-                                   hipsolverGesvdjInfo_t params)
+                                   hipsolverGesvdjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZgesvdj((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              econ,
@@ -2606,7 +2940,7 @@ try
                                              (cuDoubleComplex*)work,
                                              lwork,
                                              devInfo,
-                                             (gesvdjInfo_t)params));
+                                             (gesvdjInfo_t)info));
 }
 catch(...)
 {
@@ -2626,10 +2960,15 @@ hipsolverStatus_t hipsolverSgesvdjBatched_bufferSize(hipsolverDnHandle_t   handl
                                                      const float*          V,
                                                      int                   ldv,
                                                      int*                  lwork,
-                                                     hipsolverGesvdjInfo_t params,
+                                                     hipsolverGesvdjInfo_t info,
                                                      int                   batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSgesvdjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                hip2cuda_evect(jobz),
                                                                m,
@@ -2642,7 +2981,7 @@ try
                                                                V,
                                                                ldv,
                                                                lwork,
-                                                               (gesvdjInfo_t)params,
+                                                               (gesvdjInfo_t)info,
                                                                batch_count));
 }
 catch(...)
@@ -2662,10 +3001,15 @@ hipsolverStatus_t hipsolverDgesvdjBatched_bufferSize(hipsolverDnHandle_t   handl
                                                      const double*         V,
                                                      int                   ldv,
                                                      int*                  lwork,
-                                                     hipsolverGesvdjInfo_t params,
+                                                     hipsolverGesvdjInfo_t info,
                                                      int                   batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDgesvdjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                hip2cuda_evect(jobz),
                                                                m,
@@ -2678,7 +3022,7 @@ try
                                                                V,
                                                                ldv,
                                                                lwork,
-                                                               (gesvdjInfo_t)params,
+                                                               (gesvdjInfo_t)info,
                                                                batch_count));
 }
 catch(...)
@@ -2698,10 +3042,15 @@ hipsolverStatus_t hipsolverCgesvdjBatched_bufferSize(hipsolverDnHandle_t    hand
                                                      const hipFloatComplex* V,
                                                      int                    ldv,
                                                      int*                   lwork,
-                                                     hipsolverGesvdjInfo_t  params,
+                                                     hipsolverGesvdjInfo_t  info,
                                                      int                    batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCgesvdjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                hip2cuda_evect(jobz),
                                                                m,
@@ -2714,7 +3063,7 @@ try
                                                                (cuComplex*)V,
                                                                ldv,
                                                                lwork,
-                                                               (gesvdjInfo_t)params,
+                                                               (gesvdjInfo_t)info,
                                                                batch_count));
 }
 catch(...)
@@ -2734,10 +3083,15 @@ hipsolverStatus_t hipsolverZgesvdjBatched_bufferSize(hipsolverDnHandle_t     han
                                                      const hipDoubleComplex* V,
                                                      int                     ldv,
                                                      int*                    lwork,
-                                                     hipsolverGesvdjInfo_t   params,
+                                                     hipsolverGesvdjInfo_t   info,
                                                      int                     batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZgesvdjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                hip2cuda_evect(jobz),
                                                                m,
@@ -2750,7 +3104,7 @@ try
                                                                (cuDoubleComplex*)V,
                                                                ldv,
                                                                lwork,
-                                                               (gesvdjInfo_t)params,
+                                                               (gesvdjInfo_t)info,
                                                                batch_count));
 }
 catch(...)
@@ -2772,10 +3126,15 @@ hipsolverStatus_t hipsolverSgesvdjBatched(hipsolverDnHandle_t   handle,
                                           float*                work,
                                           int                   lwork,
                                           int*                  devInfo,
-                                          hipsolverGesvdjInfo_t params,
+                                          hipsolverGesvdjInfo_t info,
                                           int                   batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSgesvdjBatched((cusolverDnHandle_t)handle,
                                                     hip2cuda_evect(jobz),
                                                     m,
@@ -2790,7 +3149,7 @@ try
                                                     work,
                                                     lwork,
                                                     devInfo,
-                                                    (gesvdjInfo_t)params,
+                                                    (gesvdjInfo_t)info,
                                                     batch_count));
 }
 catch(...)
@@ -2812,10 +3171,15 @@ hipsolverStatus_t hipsolverDgesvdjBatched(hipsolverDnHandle_t   handle,
                                           double*               work,
                                           int                   lwork,
                                           int*                  devInfo,
-                                          hipsolverGesvdjInfo_t params,
+                                          hipsolverGesvdjInfo_t info,
                                           int                   batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDgesvdjBatched((cusolverDnHandle_t)handle,
                                                     hip2cuda_evect(jobz),
                                                     m,
@@ -2830,7 +3194,7 @@ try
                                                     work,
                                                     lwork,
                                                     devInfo,
-                                                    (gesvdjInfo_t)params,
+                                                    (gesvdjInfo_t)info,
                                                     batch_count));
 }
 catch(...)
@@ -2852,10 +3216,15 @@ hipsolverStatus_t hipsolverCgesvdjBatched(hipsolverDnHandle_t   handle,
                                           hipFloatComplex*      work,
                                           int                   lwork,
                                           int*                  devInfo,
-                                          hipsolverGesvdjInfo_t params,
+                                          hipsolverGesvdjInfo_t info,
                                           int                   batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCgesvdjBatched((cusolverDnHandle_t)handle,
                                                     hip2cuda_evect(jobz),
                                                     m,
@@ -2870,7 +3239,7 @@ try
                                                     (cuComplex*)work,
                                                     lwork,
                                                     devInfo,
-                                                    (gesvdjInfo_t)params,
+                                                    (gesvdjInfo_t)info,
                                                     batch_count));
 }
 catch(...)
@@ -2892,10 +3261,15 @@ hipsolverStatus_t hipsolverZgesvdjBatched(hipsolverDnHandle_t   handle,
                                           hipDoubleComplex*     work,
                                           int                   lwork,
                                           int*                  devInfo,
-                                          hipsolverGesvdjInfo_t params,
+                                          hipsolverGesvdjInfo_t info,
                                           int                   batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZgesvdjBatched((cusolverDnHandle_t)handle,
                                                     hip2cuda_evect(jobz),
                                                     m,
@@ -2910,7 +3284,7 @@ try
                                                     (cuDoubleComplex*)work,
                                                     lwork,
                                                     devInfo,
-                                                    (gesvdjInfo_t)params,
+                                                    (gesvdjInfo_t)info,
                                                     batch_count));
 }
 catch(...)
@@ -2939,6 +3313,9 @@ hipsolverStatus_t hipsolverDnSgesvdaStridedBatched_bufferSize(hipsolverHandle_t 
                                                               int                batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgesvdaStridedBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                       hip2cuda_evect(jobz),
                                                                       rank,
@@ -2983,6 +3360,9 @@ hipsolverStatus_t hipsolverDnDgesvdaStridedBatched_bufferSize(hipsolverHandle_t 
                                                               int                batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDgesvdaStridedBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                       hip2cuda_evect(jobz),
                                                                       rank,
@@ -3027,6 +3407,9 @@ hipsolverStatus_t hipsolverDnCgesvdaStridedBatched_bufferSize(hipsolverHandle_t 
                                                               int                    batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCgesvdaStridedBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                       hip2cuda_evect(jobz),
                                                                       rank,
@@ -3071,6 +3454,9 @@ hipsolverStatus_t hipsolverDnZgesvdaStridedBatched_bufferSize(hipsolverHandle_t 
                                                               int                     batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgesvdaStridedBatched_bufferSize((cusolverDnHandle_t)handle,
                                                                       hip2cuda_evect(jobz),
                                                                       rank,
@@ -3118,6 +3504,9 @@ hipsolverStatus_t hipsolverDnSgesvdaStridedBatched(hipsolverHandle_t  handle,
                                                    int                batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgesvdaStridedBatched((cusolverDnHandle_t)handle,
                                                            hip2cuda_evect(jobz),
                                                            rank,
@@ -3168,6 +3557,9 @@ hipsolverStatus_t hipsolverDnDgesvdaStridedBatched(hipsolverHandle_t  handle,
                                                    int                batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDgesvdaStridedBatched((cusolverDnHandle_t)handle,
                                                            hip2cuda_evect(jobz),
                                                            rank,
@@ -3218,6 +3610,9 @@ hipsolverStatus_t hipsolverDnCgesvdaStridedBatched(hipsolverHandle_t      handle
                                                    int                    batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCgesvdaStridedBatched((cusolverDnHandle_t)handle,
                                                            hip2cuda_evect(jobz),
                                                            rank,
@@ -3268,6 +3663,9 @@ hipsolverStatus_t hipsolverDnZgesvdaStridedBatched(hipsolverHandle_t       handl
                                                    int                     batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgesvdaStridedBatched((cusolverDnHandle_t)handle,
                                                            hip2cuda_evect(jobz),
                                                            rank,
@@ -3300,6 +3698,9 @@ hipsolverStatus_t hipsolverSgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnSgetrf_bufferSize((cusolverDnHandle_t)handle, m, n, A, lda, lwork));
 }
@@ -3312,6 +3713,9 @@ hipsolverStatus_t hipsolverDgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnDgetrf_bufferSize((cusolverDnHandle_t)handle, m, n, A, lda, lwork));
 }
@@ -3324,6 +3728,9 @@ hipsolverStatus_t hipsolverCgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnCgetrf_bufferSize((cusolverDnHandle_t)handle, m, n, (cuComplex*)A, lda, lwork));
 }
@@ -3336,6 +3743,9 @@ hipsolverStatus_t hipsolverZgetrf_bufferSize(
     hipsolverHandle_t handle, int m, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgetrf_bufferSize(
         (cusolverDnHandle_t)handle, m, n, (cuDoubleComplex*)A, lda, lwork));
 }
@@ -3355,6 +3765,9 @@ hipsolverStatus_t hipsolverSgetrf(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnSgetrf((cusolverDnHandle_t)handle, m, n, A, lda, work, devIpiv, devInfo));
 }
@@ -3374,6 +3787,9 @@ hipsolverStatus_t hipsolverDgetrf(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnDgetrf((cusolverDnHandle_t)handle, m, n, A, lda, work, devIpiv, devInfo));
 }
@@ -3393,6 +3809,9 @@ hipsolverStatus_t hipsolverCgetrf(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCgetrf(
         (cusolverDnHandle_t)handle, m, n, (cuComplex*)A, lda, (cuComplex*)work, devIpiv, devInfo));
 }
@@ -3412,6 +3831,9 @@ hipsolverStatus_t hipsolverZgetrf(hipsolverHandle_t handle,
                                   int*              devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgetrf((cusolverDnHandle_t)handle,
                                             m,
                                             n,
@@ -3439,6 +3861,11 @@ hipsolverStatus_t hipsolverSgetrs_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -3459,6 +3886,11 @@ hipsolverStatus_t hipsolverDgetrs_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -3479,6 +3911,11 @@ hipsolverStatus_t hipsolverCgetrs_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -3499,6 +3936,11 @@ hipsolverStatus_t hipsolverZgetrs_bufferSize(hipsolverHandle_t    handle,
                                              int*                 lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -3521,6 +3963,9 @@ hipsolverStatus_t hipsolverSgetrs(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSgetrs((cusolverDnHandle_t)handle,
                                             hip2cuda_operation(trans),
                                             n,
@@ -3551,6 +3996,9 @@ hipsolverStatus_t hipsolverDgetrs(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDgetrs((cusolverDnHandle_t)handle,
                                             hip2cuda_operation(trans),
                                             n,
@@ -3581,6 +4029,9 @@ hipsolverStatus_t hipsolverCgetrs(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCgetrs((cusolverDnHandle_t)handle,
                                             hip2cuda_operation(trans),
                                             n,
@@ -3611,6 +4062,9 @@ hipsolverStatus_t hipsolverZgetrs(hipsolverHandle_t    handle,
                                   int*                 devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZgetrs((cusolverDnHandle_t)handle,
                                             hip2cuda_operation(trans),
                                             n,
@@ -3632,6 +4086,9 @@ hipsolverStatus_t hipsolverSpotrf_bufferSize(
     hipsolverHandle_t handle, hipsolverFillMode_t uplo, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSpotrf_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, lwork));
 }
@@ -3644,6 +4101,9 @@ hipsolverStatus_t hipsolverDpotrf_bufferSize(
     hipsolverHandle_t handle, hipsolverFillMode_t uplo, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDpotrf_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, lwork));
 }
@@ -3660,6 +4120,9 @@ hipsolverStatus_t hipsolverCpotrf_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCpotrf_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, (cuComplex*)A, lda, lwork));
 }
@@ -3676,6 +4139,9 @@ hipsolverStatus_t hipsolverZpotrf_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZpotrf_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, (cuDoubleComplex*)A, lda, lwork));
 }
@@ -3694,6 +4160,9 @@ hipsolverStatus_t hipsolverSpotrf(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSpotrf(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, work, lwork, devInfo));
 }
@@ -3712,6 +4181,9 @@ hipsolverStatus_t hipsolverDpotrf(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDpotrf(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, work, lwork, devInfo));
 }
@@ -3730,6 +4202,9 @@ hipsolverStatus_t hipsolverCpotrf(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCpotrf((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -3754,6 +4229,9 @@ hipsolverStatus_t hipsolverZpotrf(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZpotrf((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -3778,6 +4256,11 @@ hipsolverStatus_t hipsolverSpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -3795,6 +4278,11 @@ hipsolverStatus_t hipsolverDpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -3812,6 +4300,11 @@ hipsolverStatus_t hipsolverCpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -3829,6 +4322,11 @@ hipsolverStatus_t hipsolverZpotrfBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -3848,6 +4346,9 @@ hipsolverStatus_t hipsolverSpotrfBatched(hipsolverHandle_t   handle,
                                          int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSpotrfBatched(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, devInfo, batch_count));
 }
@@ -3867,6 +4368,9 @@ hipsolverStatus_t hipsolverDpotrfBatched(hipsolverHandle_t   handle,
                                          int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDpotrfBatched(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, devInfo, batch_count));
 }
@@ -3886,6 +4390,9 @@ hipsolverStatus_t hipsolverCpotrfBatched(hipsolverHandle_t   handle,
                                          int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCpotrfBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_fill(uplo),
                                                    n,
@@ -3910,6 +4417,9 @@ hipsolverStatus_t hipsolverZpotrfBatched(hipsolverHandle_t   handle,
                                          int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZpotrfBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_fill(uplo),
                                                    n,
@@ -3928,6 +4438,9 @@ hipsolverStatus_t hipsolverSpotri_bufferSize(
     hipsolverHandle_t handle, hipsolverFillMode_t uplo, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSpotri_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, lwork));
 }
@@ -3940,6 +4453,9 @@ hipsolverStatus_t hipsolverDpotri_bufferSize(
     hipsolverHandle_t handle, hipsolverFillMode_t uplo, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDpotri_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, lwork));
 }
@@ -3956,6 +4472,9 @@ hipsolverStatus_t hipsolverCpotri_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCpotri_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, (cuComplex*)A, lda, lwork));
 }
@@ -3972,6 +4491,9 @@ hipsolverStatus_t hipsolverZpotri_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZpotri_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, (cuDoubleComplex*)A, lda, lwork));
 }
@@ -3990,6 +4512,9 @@ hipsolverStatus_t hipsolverSpotri(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSpotri(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, work, lwork, devInfo));
 }
@@ -4008,6 +4533,9 @@ hipsolverStatus_t hipsolverDpotri(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDpotri(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, work, lwork, devInfo));
 }
@@ -4026,6 +4554,9 @@ hipsolverStatus_t hipsolverCpotri(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCpotri((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -4050,6 +4581,9 @@ hipsolverStatus_t hipsolverZpotri(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZpotri((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -4076,6 +4610,11 @@ hipsolverStatus_t hipsolverSpotrs_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -4095,6 +4634,11 @@ hipsolverStatus_t hipsolverDpotrs_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -4114,6 +4658,11 @@ hipsolverStatus_t hipsolverCpotrs_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -4133,6 +4682,11 @@ hipsolverStatus_t hipsolverZpotrs_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -4154,6 +4708,9 @@ hipsolverStatus_t hipsolverSpotrs(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSpotrs(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, nrhs, A, lda, B, ldb, devInfo));
 }
@@ -4175,6 +4732,9 @@ hipsolverStatus_t hipsolverDpotrs(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDpotrs(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, nrhs, A, lda, B, ldb, devInfo));
 }
@@ -4196,6 +4756,9 @@ hipsolverStatus_t hipsolverCpotrs(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCpotrs((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -4224,6 +4787,9 @@ hipsolverStatus_t hipsolverZpotrs(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZpotrs((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -4252,6 +4818,11 @@ hipsolverStatus_t hipsolverSpotrsBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -4272,6 +4843,11 @@ hipsolverStatus_t hipsolverDpotrsBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -4292,6 +4868,11 @@ hipsolverStatus_t hipsolverCpotrsBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -4312,6 +4893,11 @@ hipsolverStatus_t hipsolverZpotrsBatched_bufferSize(hipsolverHandle_t   handle,
                                                     int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!lwork)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     *lwork = 0;
     return HIPSOLVER_STATUS_SUCCESS;
 }
@@ -4334,6 +4920,9 @@ hipsolverStatus_t hipsolverSpotrsBatched(hipsolverHandle_t   handle,
                                          int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSpotrsBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_fill(uplo),
                                                    n,
@@ -4364,6 +4953,9 @@ hipsolverStatus_t hipsolverDpotrsBatched(hipsolverHandle_t   handle,
                                          int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDpotrsBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_fill(uplo),
                                                    n,
@@ -4394,6 +4986,9 @@ hipsolverStatus_t hipsolverCpotrsBatched(hipsolverHandle_t   handle,
                                          int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCpotrsBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_fill(uplo),
                                                    n,
@@ -4424,6 +5019,9 @@ hipsolverStatus_t hipsolverZpotrsBatched(hipsolverHandle_t   handle,
                                          int                 batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZpotrsBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_fill(uplo),
                                                    n,
@@ -4451,6 +5049,9 @@ hipsolverStatus_t hipsolverSsyevd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsyevd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -4475,6 +5076,9 @@ hipsolverStatus_t hipsolverDsyevd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsyevd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -4499,6 +5103,9 @@ hipsolverStatus_t hipsolverCheevd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCheevd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -4523,6 +5130,9 @@ hipsolverStatus_t hipsolverZheevd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZheevd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -4549,6 +5159,9 @@ hipsolverStatus_t hipsolverSsyevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsyevd((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -4577,6 +5190,9 @@ hipsolverStatus_t hipsolverDsyevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsyevd((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -4605,6 +5221,9 @@ hipsolverStatus_t hipsolverCheevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCheevd((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -4633,6 +5252,9 @@ hipsolverStatus_t hipsolverZheevd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZheevd((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -4666,6 +5288,9 @@ hipsolverStatus_t hipsolverDnSsyevdx_bufferSize(hipsolverHandle_t   handle,
                                                 int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsyevdx_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         hip2cuda_erange(range),
@@ -4702,6 +5327,9 @@ hipsolverStatus_t hipsolverDnDsyevdx_bufferSize(hipsolverHandle_t   handle,
                                                 int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsyevdx_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         hip2cuda_erange(range),
@@ -4738,6 +5366,9 @@ hipsolverStatus_t hipsolverDnCheevdx_bufferSize(hipsolverHandle_t      handle,
                                                 int*                   lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCheevdx_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         hip2cuda_erange(range),
@@ -4774,6 +5405,9 @@ hipsolverStatus_t hipsolverDnZheevdx_bufferSize(hipsolverHandle_t       handle,
                                                 int*                    lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZheevdx_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_evect(jobz),
                                                         hip2cuda_erange(range),
@@ -4812,6 +5446,9 @@ hipsolverStatus_t hipsolverDnSsyevdx(hipsolverHandle_t   handle,
                                      int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsyevdx((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              hip2cuda_erange(range),
@@ -4852,6 +5489,9 @@ hipsolverStatus_t hipsolverDnDsyevdx(hipsolverHandle_t   handle,
                                      int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsyevdx((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              hip2cuda_erange(range),
@@ -4892,6 +5532,9 @@ hipsolverStatus_t hipsolverDnCheevdx(hipsolverHandle_t   handle,
                                      int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCheevdx((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              hip2cuda_erange(range),
@@ -4932,6 +5575,9 @@ hipsolverStatus_t hipsolverDnZheevdx(hipsolverHandle_t   handle,
                                      int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZheevdx((cusolverDnHandle_t)handle,
                                              hip2cuda_evect(jobz),
                                              hip2cuda_erange(range),
@@ -4963,9 +5609,14 @@ hipsolverStatus_t hipsolverSsyevj_bufferSize(hipsolverDnHandle_t  handle,
                                              int                  lda,
                                              float*               W,
                                              int*                 lwork,
-                                             hipsolverSyevjInfo_t params)
+                                             hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsyevj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -4974,7 +5625,7 @@ try
                                                        lda,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -4989,9 +5640,14 @@ hipsolverStatus_t hipsolverDsyevj_bufferSize(hipsolverDnHandle_t  handle,
                                              int                  lda,
                                              double*              W,
                                              int*                 lwork,
-                                             hipsolverSyevjInfo_t params)
+                                             hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsyevj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -5000,7 +5656,7 @@ try
                                                        lda,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -5015,9 +5671,14 @@ hipsolverStatus_t hipsolverCheevj_bufferSize(hipsolverDnHandle_t  handle,
                                              int                  lda,
                                              float*               W,
                                              int*                 lwork,
-                                             hipsolverSyevjInfo_t params)
+                                             hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCheevj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -5026,7 +5687,7 @@ try
                                                        lda,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -5041,9 +5702,14 @@ hipsolverStatus_t hipsolverZheevj_bufferSize(hipsolverDnHandle_t  handle,
                                              int                  lda,
                                              double*              W,
                                              int*                 lwork,
-                                             hipsolverSyevjInfo_t params)
+                                             hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZheevj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_evect(jobz),
                                                        hip2cuda_fill(uplo),
@@ -5052,7 +5718,7 @@ try
                                                        lda,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -5069,9 +5735,14 @@ hipsolverStatus_t hipsolverSsyevj(hipsolverDnHandle_t  handle,
                                   float*               work,
                                   int                  lwork,
                                   int*                 devInfo,
-                                  hipsolverSyevjInfo_t params)
+                                  hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsyevj((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -5082,7 +5753,7 @@ try
                                             work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -5099,9 +5770,14 @@ hipsolverStatus_t hipsolverDsyevj(hipsolverDnHandle_t  handle,
                                   double*              work,
                                   int                  lwork,
                                   int*                 devInfo,
-                                  hipsolverSyevjInfo_t params)
+                                  hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsyevj((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -5112,7 +5788,7 @@ try
                                             work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -5129,9 +5805,14 @@ hipsolverStatus_t hipsolverCheevj(hipsolverDnHandle_t  handle,
                                   hipFloatComplex*     work,
                                   int                  lwork,
                                   int*                 devInfo,
-                                  hipsolverSyevjInfo_t params)
+                                  hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCheevj((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -5142,7 +5823,7 @@ try
                                             (cuComplex*)work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -5159,9 +5840,14 @@ hipsolverStatus_t hipsolverZheevj(hipsolverDnHandle_t  handle,
                                   hipDoubleComplex*    work,
                                   int                  lwork,
                                   int*                 devInfo,
-                                  hipsolverSyevjInfo_t params)
+                                  hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZheevj((cusolverDnHandle_t)handle,
                                             hip2cuda_evect(jobz),
                                             hip2cuda_fill(uplo),
@@ -5172,7 +5858,7 @@ try
                                             (cuDoubleComplex*)work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -5188,10 +5874,15 @@ hipsolverStatus_t hipsolverSsyevjBatched_bufferSize(hipsolverDnHandle_t  handle,
                                                     int                  lda,
                                                     float*               W,
                                                     int*                 lwork,
-                                                    hipsolverSyevjInfo_t params,
+                                                    hipsolverSyevjInfo_t info,
                                                     int                  batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsyevjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                               hip2cuda_evect(jobz),
                                                               hip2cuda_fill(uplo),
@@ -5200,7 +5891,7 @@ try
                                                               lda,
                                                               W,
                                                               lwork,
-                                                              (syevjInfo_t)params,
+                                                              (syevjInfo_t)info,
                                                               batch_count));
 }
 catch(...)
@@ -5216,10 +5907,15 @@ hipsolverStatus_t hipsolverDsyevjBatched_bufferSize(hipsolverDnHandle_t  handle,
                                                     int                  lda,
                                                     double*              W,
                                                     int*                 lwork,
-                                                    hipsolverSyevjInfo_t params,
+                                                    hipsolverSyevjInfo_t info,
                                                     int                  batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsyevjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                               hip2cuda_evect(jobz),
                                                               hip2cuda_fill(uplo),
@@ -5228,7 +5924,7 @@ try
                                                               lda,
                                                               W,
                                                               lwork,
-                                                              (syevjInfo_t)params,
+                                                              (syevjInfo_t)info,
                                                               batch_count));
 }
 catch(...)
@@ -5244,10 +5940,15 @@ hipsolverStatus_t hipsolverCheevjBatched_bufferSize(hipsolverDnHandle_t  handle,
                                                     int                  lda,
                                                     float*               W,
                                                     int*                 lwork,
-                                                    hipsolverSyevjInfo_t params,
+                                                    hipsolverSyevjInfo_t info,
                                                     int                  batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCheevjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                               hip2cuda_evect(jobz),
                                                               hip2cuda_fill(uplo),
@@ -5256,7 +5957,7 @@ try
                                                               lda,
                                                               W,
                                                               lwork,
-                                                              (syevjInfo_t)params,
+                                                              (syevjInfo_t)info,
                                                               batch_count));
 }
 catch(...)
@@ -5272,10 +5973,15 @@ hipsolverStatus_t hipsolverZheevjBatched_bufferSize(hipsolverDnHandle_t  handle,
                                                     int                  lda,
                                                     double*              W,
                                                     int*                 lwork,
-                                                    hipsolverSyevjInfo_t params,
+                                                    hipsolverSyevjInfo_t info,
                                                     int                  batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZheevjBatched_bufferSize((cusolverDnHandle_t)handle,
                                                               hip2cuda_evect(jobz),
                                                               hip2cuda_fill(uplo),
@@ -5284,7 +5990,7 @@ try
                                                               lda,
                                                               W,
                                                               lwork,
-                                                              (syevjInfo_t)params,
+                                                              (syevjInfo_t)info,
                                                               batch_count));
 }
 catch(...)
@@ -5302,10 +6008,15 @@ hipsolverStatus_t hipsolverSsyevjBatched(hipsolverDnHandle_t  handle,
                                          float*               work,
                                          int                  lwork,
                                          int*                 devInfo,
-                                         hipsolverSyevjInfo_t params,
+                                         hipsolverSyevjInfo_t info,
                                          int                  batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsyevjBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_evect(jobz),
                                                    hip2cuda_fill(uplo),
@@ -5316,7 +6027,7 @@ try
                                                    work,
                                                    lwork,
                                                    devInfo,
-                                                   (syevjInfo_t)params,
+                                                   (syevjInfo_t)info,
                                                    batch_count));
 }
 catch(...)
@@ -5334,10 +6045,15 @@ hipsolverStatus_t hipsolverDsyevjBatched(hipsolverDnHandle_t  handle,
                                          double*              work,
                                          int                  lwork,
                                          int*                 devInfo,
-                                         hipsolverSyevjInfo_t params,
+                                         hipsolverSyevjInfo_t info,
                                          int                  batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsyevjBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_evect(jobz),
                                                    hip2cuda_fill(uplo),
@@ -5348,7 +6064,7 @@ try
                                                    work,
                                                    lwork,
                                                    devInfo,
-                                                   (syevjInfo_t)params,
+                                                   (syevjInfo_t)info,
                                                    batch_count));
 }
 catch(...)
@@ -5366,10 +6082,15 @@ hipsolverStatus_t hipsolverCheevjBatched(hipsolverDnHandle_t  handle,
                                          hipFloatComplex*     work,
                                          int                  lwork,
                                          int*                 devInfo,
-                                         hipsolverSyevjInfo_t params,
+                                         hipsolverSyevjInfo_t info,
                                          int                  batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnCheevjBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_evect(jobz),
                                                    hip2cuda_fill(uplo),
@@ -5380,7 +6101,7 @@ try
                                                    (cuComplex*)work,
                                                    lwork,
                                                    devInfo,
-                                                   (syevjInfo_t)params,
+                                                   (syevjInfo_t)info,
                                                    batch_count));
 }
 catch(...)
@@ -5398,10 +6119,15 @@ hipsolverStatus_t hipsolverZheevjBatched(hipsolverDnHandle_t  handle,
                                          hipDoubleComplex*    work,
                                          int                  lwork,
                                          int*                 devInfo,
-                                         hipsolverSyevjInfo_t params,
+                                         hipsolverSyevjInfo_t info,
                                          int                  batch_count)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZheevjBatched((cusolverDnHandle_t)handle,
                                                    hip2cuda_evect(jobz),
                                                    hip2cuda_fill(uplo),
@@ -5412,7 +6138,7 @@ try
                                                    (cuDoubleComplex*)work,
                                                    lwork,
                                                    devInfo,
-                                                   (syevjInfo_t)params,
+                                                   (syevjInfo_t)info,
                                                    batch_count));
 }
 catch(...)
@@ -5434,6 +6160,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvd_bufferSize(hipsolverHandle_t 
                                                               int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsygvd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -5464,6 +6193,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsygvd_bufferSize(hipsolverHandle_t 
                                                               int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsygvd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -5494,6 +6226,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd_bufferSize(hipsolverHandle_t 
                                                               int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnChegvd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -5524,6 +6259,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd_bufferSize(hipsolverHandle_t 
                                                               int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZhegvd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -5556,6 +6294,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsygvd((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -5590,6 +6331,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsygvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsygvd((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -5624,6 +6368,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnChegvd((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -5658,6 +6405,9 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvd(hipsolverHandle_t   handle,
                                                    int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZhegvd((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -5697,6 +6447,9 @@ hipsolverStatus_t hipsolverDnSsygvdx_bufferSize(hipsolverHandle_t   handle,
                                                 int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsygvdx_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_eform(itype),
                                                         hip2cuda_evect(jobz),
@@ -5739,6 +6492,9 @@ hipsolverStatus_t hipsolverDnDsygvdx_bufferSize(hipsolverHandle_t   handle,
                                                 int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsygvdx_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_eform(itype),
                                                         hip2cuda_evect(jobz),
@@ -5781,6 +6537,9 @@ hipsolverStatus_t hipsolverDnChegvdx_bufferSize(hipsolverHandle_t      handle,
                                                 int*                   lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnChegvdx_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_eform(itype),
                                                         hip2cuda_evect(jobz),
@@ -5823,6 +6582,9 @@ hipsolverStatus_t hipsolverDnZhegvdx_bufferSize(hipsolverHandle_t       handle,
                                                 int*                    lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZhegvdx_bufferSize((cusolverDnHandle_t)handle,
                                                         hip2cuda_eform(itype),
                                                         hip2cuda_evect(jobz),
@@ -5867,6 +6629,9 @@ hipsolverStatus_t hipsolverDnSsygvdx(hipsolverHandle_t   handle,
                                      int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsygvdx((cusolverDnHandle_t)handle,
                                              hip2cuda_eform(itype),
                                              hip2cuda_evect(jobz),
@@ -5913,6 +6678,9 @@ hipsolverStatus_t hipsolverDnDsygvdx(hipsolverHandle_t   handle,
                                      int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsygvdx((cusolverDnHandle_t)handle,
                                              hip2cuda_eform(itype),
                                              hip2cuda_evect(jobz),
@@ -5959,6 +6727,9 @@ hipsolverStatus_t hipsolverDnChegvdx(hipsolverHandle_t   handle,
                                      int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnChegvdx((cusolverDnHandle_t)handle,
                                              hip2cuda_eform(itype),
                                              hip2cuda_evect(jobz),
@@ -6005,6 +6776,9 @@ hipsolverStatus_t hipsolverDnZhegvdx(hipsolverHandle_t   handle,
                                      int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZhegvdx((cusolverDnHandle_t)handle,
                                              hip2cuda_eform(itype),
                                              hip2cuda_evect(jobz),
@@ -6042,9 +6816,14 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvj_bufferSize(hipsolverHandle_t 
                                                               int                  ldb,
                                                               float*               W,
                                                               int*                 lwork,
-                                                              hipsolverSyevjInfo_t params)
+                                                              hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsygvj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -6056,7 +6835,7 @@ try
                                                        ldb,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -6074,9 +6853,14 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsygvj_bufferSize(hipsolverHandle_t 
                                                               int                  ldb,
                                                               double*              W,
                                                               int*                 lwork,
-                                                              hipsolverSyevjInfo_t params)
+                                                              hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsygvj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -6088,7 +6872,7 @@ try
                                                        ldb,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -6106,9 +6890,14 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvj_bufferSize(hipsolverHandle_t 
                                                               int                  ldb,
                                                               float*               W,
                                                               int*                 lwork,
-                                                              hipsolverSyevjInfo_t params)
+                                                              hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnChegvj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -6120,7 +6909,7 @@ try
                                                        ldb,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -6138,9 +6927,14 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvj_bufferSize(hipsolverHandle_t 
                                                               int                  ldb,
                                                               double*              W,
                                                               int*                 lwork,
-                                                              hipsolverSyevjInfo_t params)
+                                                              hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZhegvj_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_eform(itype),
                                                        hip2cuda_evect(jobz),
@@ -6152,7 +6946,7 @@ try
                                                        ldb,
                                                        W,
                                                        lwork,
-                                                       (syevjInfo_t)params));
+                                                       (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -6172,9 +6966,14 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSsygvj(hipsolverHandle_t    handle,
                                                    float*               work,
                                                    int                  lwork,
                                                    int*                 devInfo,
-                                                   hipsolverSyevjInfo_t params)
+                                                   hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnSsygvj((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -6188,7 +6987,7 @@ try
                                             work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -6208,9 +7007,14 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDsygvj(hipsolverHandle_t    handle,
                                                    double*              work,
                                                    int                  lwork,
                                                    int*                 devInfo,
-                                                   hipsolverSyevjInfo_t params)
+                                                   hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnDsygvj((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -6224,7 +7028,7 @@ try
                                             work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -6244,9 +7048,14 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverChegvj(hipsolverHandle_t    handle,
                                                    hipFloatComplex*     work,
                                                    int                  lwork,
                                                    int*                 devInfo,
-                                                   hipsolverSyevjInfo_t params)
+                                                   hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnChegvj((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -6260,7 +7069,7 @@ try
                                             (cuComplex*)work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -6280,9 +7089,14 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverZhegvj(hipsolverHandle_t    handle,
                                                    hipDoubleComplex*    work,
                                                    int                  lwork,
                                                    int*                 devInfo,
-                                                   hipsolverSyevjInfo_t params)
+                                                   hipsolverSyevjInfo_t info)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!info)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
     return cuda2hip_status(cusolverDnZhegvj((cusolverDnHandle_t)handle,
                                             hip2cuda_eform(itype),
                                             hip2cuda_evect(jobz),
@@ -6296,7 +7110,7 @@ try
                                             (cuDoubleComplex*)work,
                                             lwork,
                                             devInfo,
-                                            (syevjInfo_t)params));
+                                            (syevjInfo_t)info));
 }
 catch(...)
 {
@@ -6315,6 +7129,9 @@ hipsolverStatus_t hipsolverSsytrd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsytrd_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, D, E, tau, lwork));
 }
@@ -6334,6 +7151,9 @@ hipsolverStatus_t hipsolverDsytrd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsytrd_bufferSize(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, D, E, tau, lwork));
 }
@@ -6353,6 +7173,9 @@ hipsolverStatus_t hipsolverChetrd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnChetrd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_fill(uplo),
                                                        n,
@@ -6379,6 +7202,9 @@ hipsolverStatus_t hipsolverZhetrd_bufferSize(hipsolverHandle_t   handle,
                                              int*                lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZhetrd_bufferSize((cusolverDnHandle_t)handle,
                                                        hip2cuda_fill(uplo),
                                                        n,
@@ -6407,6 +7233,9 @@ hipsolverStatus_t hipsolverSsytrd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsytrd((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -6437,6 +7266,9 @@ hipsolverStatus_t hipsolverDsytrd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsytrd((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -6467,6 +7299,9 @@ hipsolverStatus_t hipsolverChetrd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnChetrd((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -6497,6 +7332,9 @@ hipsolverStatus_t hipsolverZhetrd(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZhetrd((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -6519,6 +7357,9 @@ hipsolverStatus_t
     hipsolverSsytrf_bufferSize(hipsolverHandle_t handle, int n, float* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnSsytrf_bufferSize((cusolverDnHandle_t)handle, n, A, lda, lwork));
 }
@@ -6531,6 +7372,9 @@ hipsolverStatus_t
     hipsolverDsytrf_bufferSize(hipsolverHandle_t handle, int n, double* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnDsytrf_bufferSize((cusolverDnHandle_t)handle, n, A, lda, lwork));
 }
@@ -6543,6 +7387,9 @@ hipsolverStatus_t hipsolverCsytrf_bufferSize(
     hipsolverHandle_t handle, int n, hipFloatComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverDnCsytrf_bufferSize((cusolverDnHandle_t)handle, n, (cuComplex*)A, lda, lwork));
 }
@@ -6555,6 +7402,9 @@ hipsolverStatus_t hipsolverZsytrf_bufferSize(
     hipsolverHandle_t handle, int n, hipDoubleComplex* A, int lda, int* lwork)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZsytrf_bufferSize(
         (cusolverDnHandle_t)handle, n, (cuDoubleComplex*)A, lda, lwork));
 }
@@ -6574,6 +7424,9 @@ hipsolverStatus_t hipsolverSsytrf(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnSsytrf(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, ipiv, work, lwork, devInfo));
 }
@@ -6593,6 +7446,9 @@ hipsolverStatus_t hipsolverDsytrf(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnDsytrf(
         (cusolverDnHandle_t)handle, hip2cuda_fill(uplo), n, A, lda, ipiv, work, lwork, devInfo));
 }
@@ -6612,6 +7468,9 @@ hipsolverStatus_t hipsolverCsytrf(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnCsytrf((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,
@@ -6638,6 +7497,9 @@ hipsolverStatus_t hipsolverZsytrf(hipsolverHandle_t   handle,
                                   int*                devInfo)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverDnZsytrf((cusolverDnHandle_t)handle,
                                             hip2cuda_fill(uplo),
                                             n,

--- a/library/src/nvidia_detail/hipsolver_refactor.cpp
+++ b/library/src/nvidia_detail/hipsolver_refactor.cpp
@@ -38,6 +38,9 @@ extern "C" {
 hipsolverStatus_t hipsolverRfCreate(hipsolverRfHandle_t* handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfCreate((cusolverRfHandle_t*)handle));
 }
 catch(...)
@@ -48,6 +51,9 @@ catch(...)
 hipsolverStatus_t hipsolverRfDestroy(hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfDestroy((cusolverRfHandle_t)handle));
 }
 catch(...)
@@ -74,6 +80,9 @@ hipsolverStatus_t hipsolverRfSetupDevice(int                 n,
                                          hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfSetupDevice(n,
                                                  nnzA,
                                                  csrRowPtrA,
@@ -114,6 +123,9 @@ hipsolverStatus_t hipsolverRfSetupHost(int                 n,
                                        hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfSetupHost(n,
                                                nnzA,
                                                h_csrRowPtrA,
@@ -140,6 +152,9 @@ hipsolverStatus_t hipsolverRfAccessBundledFactorsDevice(
     hipsolverRfHandle_t handle, int* nnzM, int** Mp, int** Mi, double** Mx)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverRfAccessBundledFactorsDevice((cusolverRfHandle_t)handle, nnzM, Mp, Mi, Mx));
 }
@@ -151,6 +166,9 @@ catch(...)
 hipsolverStatus_t hipsolverRfAnalyze(hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfAnalyze((cusolverRfHandle_t)handle));
 }
 catch(...)
@@ -162,6 +180,9 @@ hipsolverStatus_t hipsolverRfExtractBundledFactorsHost(
     hipsolverRfHandle_t handle, int* h_nnzM, int** h_Mp, int** h_Mi, double** h_Mx)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverRfExtractBundledFactorsHost((cusolverRfHandle_t)handle, h_nnzM, h_Mp, h_Mi, h_Mx));
 }
@@ -181,6 +202,9 @@ hipsolverStatus_t hipsolverRfExtractSplitFactorsHost(hipsolverRfHandle_t handle,
                                                      double**            h_Ux)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfExtractSplitFactorsHost(
         (cusolverRfHandle_t)handle, h_nnzL, h_Lp, h_Li, h_Lx, h_nnzU, h_Up, h_Ui, h_Ux));
 }
@@ -194,6 +218,8 @@ hipsolverStatus_t hipsolverRfGet_Algs(hipsolverRfHandle_t           handle,
                                       hipsolverRfTriangularSolve_t* solve_alg)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(!fact_alg)
         return HIPSOLVER_STATUS_INVALID_VALUE;
     if(!solve_alg)
@@ -218,6 +244,8 @@ hipsolverStatus_t hipsolverRfGetMatrixFormat(hipsolverRfHandle_t        handle,
                                              hipsolverRfUnitDiagonal_t* diag)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(!format)
         return HIPSOLVER_STATUS_INVALID_VALUE;
     if(!diag)
@@ -241,6 +269,8 @@ hipsolverStatus_t hipsolverRfGetNumericBoostReport(hipsolverRfHandle_t          
                                                    hipsolverRfNumericBoostReport_t* report)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(!report)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -259,6 +289,9 @@ hipsolverStatus_t
     hipsolverRfGetNumericProperties(hipsolverRfHandle_t handle, double* zero, double* boost)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfGetNumericProperties((cusolverRfHandle_t)handle, zero, boost));
 }
 catch(...)
@@ -270,6 +303,8 @@ hipsolverStatus_t hipsolverRfGetResetValuesFastMode(hipsolverRfHandle_t         
                                                     hipsolverRfResetValuesFastMode_t* fastMode)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
     if(!fastMode)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
@@ -288,6 +323,9 @@ catch(...)
 hipsolverStatus_t hipsolverRfRefactor(hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfRefactor((cusolverRfHandle_t)handle));
 }
 catch(...)
@@ -305,6 +343,9 @@ hipsolverStatus_t hipsolverRfResetValues(int                 n,
                                          hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfResetValues(
         n, nnzA, csrRowPtrA, csrColIndA, csrValA, P, Q, (cusolverRfHandle_t)handle));
 }
@@ -318,6 +359,9 @@ hipsolverStatus_t hipsolverRfSetAlgs(hipsolverRfHandle_t          handle,
                                      hipsolverRfTriangularSolve_t solve_alg)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfSetAlgs((cusolverRfHandle_t)handle,
                                              hip2cuda_factorization(fact_alg),
                                              hip2cuda_trisolve(solve_alg)));
@@ -332,6 +376,9 @@ hipsolverStatus_t hipsolverRfSetMatrixFormat(hipsolverRfHandle_t       handle,
                                              hipsolverRfUnitDiagonal_t diag)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfSetMatrixFormat(
         (cusolverRfHandle_t)handle, hip2cuda_matrixformat(format), hip2cuda_unitdiag(diag)));
 }
@@ -345,6 +392,9 @@ hipsolverStatus_t hipsolverRfSetNumericProperties(hipsolverRfHandle_t handle,
                                                   double              boost_val)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverRfSetNumericProperties((cusolverRfHandle_t)handle, effective_zero, boost_val));
 }
@@ -357,6 +407,9 @@ hipsolverStatus_t hipsolverRfSetResetValuesFastMode(hipsolverRfHandle_t         
                                                     hipsolverRfResetValuesFastMode_t fastMode)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfSetResetValuesFastMode((cusolverRfHandle_t)handle,
                                                             hip2cuda_resetvalsfm(fastMode)));
 }
@@ -375,6 +428,9 @@ hipsolverStatus_t hipsolverRfSolve(hipsolverRfHandle_t handle,
                                    int                 ldxf)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverRfSolve((cusolverRfHandle_t)handle, P, Q, nrhs, Temp, ldt, XF, ldxf));
 }
@@ -403,6 +459,9 @@ hipsolverStatus_t hipsolverRfBatchSetupHost(int                 batchSize,
                                             hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfBatchSetupHost(batchSize,
                                                     n,
                                                     nnzA,
@@ -429,6 +488,9 @@ catch(...)
 hipsolverStatus_t hipsolverRfBatchAnalyze(hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfBatchAnalyze((cusolverRfHandle_t)handle));
 }
 catch(...)
@@ -439,6 +501,9 @@ catch(...)
 hipsolverStatus_t hipsolverRfBatchRefactor(hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfBatchRefactor((cusolverRfHandle_t)handle));
 }
 catch(...)
@@ -457,6 +522,9 @@ hipsolverStatus_t hipsolverRfBatchResetValues(int                 batchSize,
                                               hipsolverRfHandle_t handle)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfBatchResetValues(batchSize,
                                                       n,
                                                       nnzA,
@@ -482,6 +550,9 @@ hipsolverStatus_t hipsolverRfBatchSolve(hipsolverRfHandle_t handle,
                                         int                 ldxf)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(
         cusolverRfBatchSolve((cusolverRfHandle_t)handle, P, Q, nrhs, Temp, ldt, XF_array, ldxf));
 }
@@ -493,6 +564,9 @@ catch(...)
 hipsolverStatus_t hipsolverRfBatchZeroPivot(hipsolverRfHandle_t handle, int* position)
 try
 {
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+
     return cuda2hip_status(cusolverRfBatchZeroPivot((cusolverRfHandle_t)handle, position));
 }
 catch(...)


### PR DESCRIPTION
Per our last meeting, we will no longer be converting the void pointer typedefs into opaque types, but still wish to keep the null pointer checks introduced for cuSOLVER.