### PR TITLE
Fix info tests for unitary generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed tests for hipsolver info updates in ORGBR/UNGBR, ORGQR/UNGQR,
+  ORGTR/UNGTR, ORMQR/UNMQR, and ORMTR/UNMTR.
+
 ### Known Issues
 ### Security
 

--- a/clients/include/testing_orgbr_ungbr.hpp
+++ b/clients/include/testing_orgbr_ungbr.hpp
@@ -221,7 +221,7 @@ void orgbr_ungbr_getError(const hipsolverHandle_t   handle,
     // check info
     EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
-        *max_err++;
+        *max_err += 1;
 }
 
 template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>

--- a/clients/include/testing_orgqr_ungqr.hpp
+++ b/clients/include/testing_orgqr_ungqr.hpp
@@ -176,7 +176,7 @@ void orgqr_ungqr_getError(const hipsolverHandle_t handle,
     // check info
     EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
-        *max_err++;
+        *max_err += 1;
 }
 
 template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>

--- a/clients/include/testing_orgtr_ungtr.hpp
+++ b/clients/include/testing_orgtr_ungtr.hpp
@@ -179,7 +179,7 @@ void orgtr_ungtr_getError(const hipsolverHandle_t   handle,
     // check info
     EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
-        *max_err++;
+        *max_err += 1;
 }
 
 template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>

--- a/clients/include/testing_ormqr_unmqr.hpp
+++ b/clients/include/testing_ormqr_unmqr.hpp
@@ -357,7 +357,7 @@ void ormqr_unmqr_getError(const hipsolverHandle_t    handle,
     // check info
     EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
-        *max_err++;
+        *max_err += 1;
 }
 
 template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -387,7 +387,7 @@ void ormtr_unmtr_getError(const hipsolverHandle_t    handle,
     // check info
     EXPECT_EQ(hInfo[0][0], hInfoRes[0][0]);
     if(hInfo[0][0] != hInfoRes[0][0])
-        *max_err++;
+        *max_err += 1;
 }
 
 template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>


### PR DESCRIPTION
The operator++ has greater precedence than operator*, so the original form of this check merely incremented the pointer and then dereferenced it. On Windows, that resulted in the warning:

```cpp
<builddir>/clients/benchmarks/../include/testing_ormtr_unmtr.hpp:390:9: warning: expression result unused [-Wunused-value]
        *max_err++;
        ^~~~~~~~~~
```