### PR TITLE
SWDEV-419576 - Exclude hipsolver include folder from ASAN package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 
 
 ## hipSOLVER 1.8.1 for ROCm 5.7.0
+### Changed
+- Changed hipsolver-test sparse input data search paths to be relative to the test executable
 
 
 ## hipSOLVER 1.8.0 for ROCm 5.6.0

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -83,6 +83,7 @@ if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
     common/hipsolver_datatype2string.cpp
     common/lapack_host_reference.cpp
     common/utility.cpp
+    rocsolvercommon/rocsolver_test.cpp
   )
 
   prepend_path("${CMAKE_CURRENT_SOURCE_DIR}/" common_source_files common_source_paths)
@@ -91,7 +92,7 @@ if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
   # Copy and point to sparse test data
   file(COPY
     ${CMAKE_CURRENT_SOURCE_DIR}/sparsedata/
-    DESTINATION ${PROJECT_BINARY_DIR}/sparsedata/
+    DESTINATION ${PROJECT_BINARY_DIR}/staging/sparsedata/
   )
   install(DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}/sparsedata/

--- a/clients/rocsolvercommon/rocsolver_test.cpp
+++ b/clients/rocsolvercommon/rocsolver_test.cpp
@@ -1,0 +1,62 @@
+/* ************************************************************************
+ * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************ */
+
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "rocsolver_test.hpp"
+
+fs::path get_sparse_data_dir()
+{
+    // first check an environment variable
+    if(const char* datadir = std::getenv("HIPSOLVER_TEST_DATA"))
+        return fs::path{datadir};
+
+    std::vector<std::string> paths_considered;
+
+    // check relative to the running executable
+    fs::path              exe_path   = fs::path(hipsolver_exepath());
+    std::vector<fs::path> candidates = {"../share/hipsolver/test", "sparsedata"};
+    for(const fs::path& candidate : candidates)
+    {
+        fs::path        exe_relative_path = exe_path / candidate;
+        std::error_code err;
+        fs::path        canonical_path = fs::canonical(exe_relative_path, err);
+        if(!err)
+            return canonical_path;
+        paths_considered.push_back(exe_relative_path.string());
+    }
+
+    std::ostringstream oss;
+    oss << "Warning: default sparse data directories not found. "
+           "Defaulting to current working directory.\nExecutable location: "
+        << exe_path.string() << "\nPaths considered:\n";
+    for(const std::string& path : paths_considered)
+        oss << path << "\n";
+    std::cerr << oss.str();
+
+    return fs::current_path();
+}

--- a/clients/rocsolvercommon/rocsolver_test.hpp
+++ b/clients/rocsolvercommon/rocsolver_test.hpp
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <complex>
 #include <cstdarg>
 #include <cstdlib>
 #include <iomanip>
@@ -156,34 +157,4 @@ inline void rocsolver_bench_output(T arg, Ts... args)
 
 // location of the sparse data directory for the re-factorization tests
 
-inline fs::path get_sparse_data_dir()
-{
-    // first check an environment variable
-    if(const char* datadir = std::getenv("HIPSOLVER_TEST_DATA"))
-        return fs::path{datadir};
-
-    fs::path p            = fs::current_path();
-    fs::path p_parent     = p.parent_path();
-    fs::path installed    = p.root_directory() / "opt" / "rocm" / "share" / "hipsolver" / "test";
-    fs::path exe_relative = fs::path(hipsolver_exepath()) / ".." / "share" / "hipsolver" / "test";
-
-    // check relative to the current directory and relative to each parent
-    while(p != p_parent)
-    {
-        fs::path candidate = p / "clients" / "sparsedata";
-        if(fs::exists(candidate))
-            return candidate;
-        p        = p_parent;
-        p_parent = p.parent_path();
-    }
-
-    // check relative to the running executable
-    if(fs::exists(exe_relative))
-        return exe_relative;
-
-    // check relative to default install path
-    if(fs::exists(installed))
-        return installed;
-
-    return fs::current_path();
-}
+fs::path get_sparse_data_dir();

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -196,9 +196,12 @@ else( )
 endif( )
 
 if( UNIX )
-  # Force installation of .f90 module files
-  install(FILES "hipsolver_module.f90"
-          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/hipsolver")
+  # Exclude include folder for ASAN package
+  if( NOT ENABLE_ASAN_PACKAGING )
+    # Force installation of .f90 module files
+    install(FILES "hipsolver_module.f90"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/hipsolver")
+  endif( )
 endif( )
 
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)


### PR DESCRIPTION
ASAN package requries address-sanitizer libraries and license files. Include folder should not be added to ASAN package