### PR TITLE
Update changelog and version for ROCm 5.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](https://hipsolver.readthedocs.io/en/latest/).
 
+## hipSOLVER 1.8.2 for ROCm 5.7.1
+### Fixed
+- Fixed conflicts between the hipsolver-dev and -asan packages by excluding
+  include files from the latter
+
 
 ## hipSOLVER 1.8.1 for ROCm 5.7.0
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 ## hipSOLVER 1.8.2 for ROCm 5.7.1
 ### Fixed
 - Fixed conflicts between the hipsolver-dev and -asan packages by excluding
-  include files from the latter
+  hipsolver_module.f90 from the latter
 
 
 ## hipSOLVER 1.8.1 for ROCm 5.7.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ include( ROCMInstallSymlinks )
 include( ROCMClients )
 include( ROCMHeaderWrapper )
 
-set ( VERSION_STRING "1.8.1" )
+set ( VERSION_STRING "1.8.2" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 if( NOT DEFINED ENV{HIP_PATH})

--- a/bump_hipsolver_version.sh
+++ b/bump_hipsolver_version.sh
@@ -4,7 +4,7 @@
 # Edit script to bump versions for new development cycle/release.
 
 # for hipSOLVER version string
-OLD_HIPSOLVER_VERSION="1.8.1"
+OLD_HIPSOLVER_VERSION="1.8.2"
 NEW_HIPSOLVER_VERSION="1.9.0"
 sed -i "s/${OLD_HIPSOLVER_VERSION}/${NEW_HIPSOLVER_VERSION}/g" CMakeLists.txt
 


### PR DESCRIPTION
These changes are necessary to ensure that each release of the hipSOLVER library with a unique commit hash (1) has an entry in the changelog and (2) has a distinct version number.

I should have requested that these changes be included in #192. Mea culpa.