### PR TITLE
Update ReadtheDocs links to new documentation sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,29 @@
 # Change Log for hipSOLVER
 
-Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](https://hipsolver.readthedocs.io/en/latest/).
-
+Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/index.html).
 
 ## (Unreleased) hipSOLVER
+
 ### Added
+
 ### Optimized
+
 ### Changed
+
 ### Deprecated
+
 ### Removed
+
 ### Fixed
+
 ### Known Issues
+
 ### Security
 
-
 ## hipSOLVER 2.1.0 for ROCm 6.1.0
+
 ### Added
+
 - Added compatibility API with hipsolverSp prefix
 - Added compatibility-only functions
   - csrlsvchol
@@ -26,42 +34,51 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 - Added hipSPARSE as an optional dependency to hipsolver-test. Use the `BUILD_WITH_SPARSE` CMake option to enable tests of the hipsolverSp API (on by default).
 
 ### Changed
+
 - Relax array length requirements for GESVDA.
 
 ### Fixed
+
 - Fixed incorrect singular vectors returned from GESVDA.
 
-
 ## hipSOLVER 2.0.0 for ROCm 6.0.0
+
 ### Added
+
 - Added hipBLAS as an optional dependency to hipsolver-test. Use the `BUILD_HIPBLAS_TESTS` CMake option to test compatibility between hipSOLVER and hipBLAS.
 
 ### Changed
+
 - Types hipsolverOperation_t, hipsolverFillMode_t, and hipsolverSideMode_t are now aliases of hipblasOperation_t, hipblasFillMode_t, and hipblasSideMode_t.
 
 ### Fixed
+
 - Fixed tests for hipsolver info updates in ORGBR/UNGBR, ORGQR/UNGQR,
   ORGTR/UNGTR, ORMQR/UNMQR, and ORMTR/UNMTR.
 
-
 ## hipSOLVER 1.8.2 for ROCm 5.7.1
+
 ### Fixed
+
 - Fixed conflicts between the hipsolver-dev and -asan packages by excluding
   hipsolver_module.f90 from the latter
   
-
 ## hipSOLVER 1.8.1 for ROCm 5.7.0
+
 ### Changed
+
 - Changed hipsolver-test sparse input data search paths to be relative to the test executable
 
-
 ## hipSOLVER 1.8.0 for ROCm 5.6.0
+
 ### Added
+
 - Added compatibility API with hipsolverRf prefix
 
-
 ## hipSOLVER 1.7.0 for ROCm 5.5.0
+
 ### Added
+
 - Added functions
   - gesvdj
     - hipsolverSgesvdj_bufferSize, hipsolverDgesvdj_bufferSize, hipsolverCgesvdj_bufferSize, hipsolverZgesvdj_bufferSize
@@ -70,17 +87,19 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
     - hipsolverSgesvdjBatched_bufferSize, hipsolverDgesvdjBatched_bufferSize, hipsolverCgesvdjBatched_bufferSize, hipsolverZgesvdjBatched_bufferSize
     - hipsolverSgesvdjBatched, hipsolverDgesvdjBatched, hipsolverCgesvdjBatched, hipsolverZgesvdjBatched
 
-
 ## hipSOLVER 1.6.0 for ROCm 5.4.0
+
 ### Added
+
 - Added compatibility-only functions
   - gesvdaStridedBatched
     - hipsolverDnSgesvdaStridedBatched_bufferSize, hipsolverDnDgesvdaStridedBatched_bufferSize, hipsolverDnCgesvdaStridedBatched_bufferSize, hipsolverDnZgesvdaStridedBatched_bufferSize
     - hipsolverDnSgesvdaStridedBatched, hipsolverDnDgesvdaStridedBatched, hipsolverDnCgesvdaStridedBatched, hipsolverDnZgesvdaStridedBatched
 
-
 ## hipSOLVER 1.5.0 for ROCm 5.3.0
+
 ### Added
+
 - Added functions
   - syevj
     - hipsolverSsyevj_bufferSize, hipsolverDsyevj_bufferSize, hipsolverCheevj_bufferSize, hipsolverZheevj_bufferSize
@@ -101,27 +120,32 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 - Added --mem_query option to hipsolver-bench, which will print the amount of device memory workspace required by the function.
 
 ### Changed
+
 - The rocSOLVER backend will now set `info` to zero if rocSOLVER does not reference `info`. (Applies to orgbr/ungbr, orgqr/ungqr, orgtr/ungtr, ormqr/unmqr, ormtr/unmtr, gebrd, geqrf, getrs, potrs, and sytrd/hetrd).
 - gesvdj will no longer require extra workspace to transpose `V` when `jobz` is `HIPSOLVER_EIG_MODE_VECTOR` and `econ` is 1.
 
 ### Fixed
+
 - Fixed Fortran return value declarations within hipsolver_module.f90
 - Fixed gesvdj_bufferSize returning `HIPSOLVER_STATUS_INVALID_VALUE` when `jobz` is `HIPSOLVER_EIG_MODE_NOVECTOR` and 1 <= `ldv` < `n`
 - Fixed gesvdj returning `HIPSOLVER_STATUS_INVALID_VALUE` when `jobz` is `HIPSOLVER_EIG_MODE_VECTOR`, `econ` is 1, and `m` < `n`
 
-
 ## hipSOLVER 1.4.0 for ROCm 5.2.0
+
 ### Added
+
 - Package generation for test and benchmark executables on all supported OSes using CPack.
 - File/Folder Reorg
   - Added File/Folder Reorg Changes with backward compatibility support using ROCM-CMAKE wrapper functions.
 
 ### Fixed
+
 - Fixed the ReadTheDocs documentation generation.
 
-
 ## hipSOLVER 1.3.0 for ROCm 5.1.0
+
 ### Added
+
 - Added functions
   - gels
     - hipsolverSSgels_bufferSize, hipsolverDDgels_bufferSize, hipsolverCCgels_bufferSize, hipsolverZZgels_bufferSize
@@ -146,28 +170,33 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
     - hipsolverDnSsygvj, hipsolverDnDsygvj, hipsolverDnChegvj, hipsolverDnZhegvj
 
 ### Changed
+
 - The rocSOLVER backend now allows hipsolverXXgels and hipsolverXXgesv to be called in-place when B == X.
 - The rocSOLVER backend now allows rwork to be passed as a null pointer to hipsolverXgesvd.
 
 ### Fixed
+
 - bufferSize functions will now return HIPSOLVER_STATUS_NOT_INITIALIZED instead of HIPSOLVER_STATUS_INVALID_VALUE when both handle and lwork are null.
 - Fixed rare memory allocation failure in syevd/heevd and sygvd/hegvd caused by improper workspace array allocation outside of rocSOLVER.
 
-
 ## hipSOLVER 1.2.0 for ROCm 5.0.0
+
 ### Added
+
 - Added functions
   - sytrf
     - hipsolverSsytrf_bufferSize, hipsolverDsytrf_bufferSize, hipsolverCsytrf_bufferSize, hipsolverZsytrf_bufferSize
     - hipsolverSsytrf, hipsolverDsytrf, hipsolverCsytrf, hipsolverZsytrf
 
 ### Fixed
+
 - Fixed use of incorrect `HIP_PATH` when building from source (#40).
   Thanks [@jakub329homola](https://github.com/jakub329homola)!
 
-
 ## hipSOLVER 1.1.0 for ROCm 4.5.0
+
 ### Added
+
 - Added functions
   - gesv
     - hipsolverSSgesv_bufferSize, hipsolverDDgesv_bufferSize, hipsolverCCgesv_bufferSize, hipsolverZZgesv_bufferSize
@@ -231,10 +260,11 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
     - hipsolverSetStream, hipsolverGetStream
 
 ### Changed
+
 - hipSOLVER functions will now return HIPSOLVER_STATUS_INVALID_ENUM or HIPSOLVER_STATUS_UNKNOWN status codes rather than throw exceptions.
 - hipsolverXgetrf functions now take lwork as an argument.
 
 ### Removed
+
 - Removed unused HIPSOLVER_FILL_MODE_FULL enum value.
 - Removed hipsolverComplex and hipsolverDoubleComplex from the library. Use hipFloatComplex and hipDoubleComplex instead.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for hipSOLVER
 
-Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](https://hipsolver.readthedocs.io/en/latest/).
+Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/index.html).
 
 
 ## (Unreleased) hipSOLVER

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,21 @@
 # Change Log for hipSOLVER
 
-Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/index.html).
+Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](https://hipsolver.readthedocs.io/en/latest/).
+
 
 ## (Unreleased) hipSOLVER
-
 ### Added
-
 ### Optimized
-
 ### Changed
-
 ### Deprecated
-
 ### Removed
-
 ### Fixed
-
 ### Known Issues
-
 ### Security
 
+
 ## hipSOLVER 2.1.0 for ROCm 6.1.0
-
 ### Added
-
 - Added compatibility API with hipsolverSp prefix
 - Added compatibility-only functions
   - csrlsvchol
@@ -34,51 +26,42 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 - Added hipSPARSE as an optional dependency to hipsolver-test. Use the `BUILD_WITH_SPARSE` CMake option to enable tests of the hipsolverSp API (on by default).
 
 ### Changed
-
 - Relax array length requirements for GESVDA.
 
 ### Fixed
-
 - Fixed incorrect singular vectors returned from GESVDA.
 
+
 ## hipSOLVER 2.0.0 for ROCm 6.0.0
-
 ### Added
-
 - Added hipBLAS as an optional dependency to hipsolver-test. Use the `BUILD_HIPBLAS_TESTS` CMake option to test compatibility between hipSOLVER and hipBLAS.
 
 ### Changed
-
 - Types hipsolverOperation_t, hipsolverFillMode_t, and hipsolverSideMode_t are now aliases of hipblasOperation_t, hipblasFillMode_t, and hipblasSideMode_t.
 
 ### Fixed
-
 - Fixed tests for hipsolver info updates in ORGBR/UNGBR, ORGQR/UNGQR,
   ORGTR/UNGTR, ORMQR/UNMQR, and ORMTR/UNMTR.
 
+
 ## hipSOLVER 1.8.2 for ROCm 5.7.1
-
 ### Fixed
-
 - Fixed conflicts between the hipsolver-dev and -asan packages by excluding
   hipsolver_module.f90 from the latter
   
+
 ## hipSOLVER 1.8.1 for ROCm 5.7.0
-
 ### Changed
-
 - Changed hipsolver-test sparse input data search paths to be relative to the test executable
 
+
 ## hipSOLVER 1.8.0 for ROCm 5.6.0
-
 ### Added
-
 - Added compatibility API with hipsolverRf prefix
 
+
 ## hipSOLVER 1.7.0 for ROCm 5.5.0
-
 ### Added
-
 - Added functions
   - gesvdj
     - hipsolverSgesvdj_bufferSize, hipsolverDgesvdj_bufferSize, hipsolverCgesvdj_bufferSize, hipsolverZgesvdj_bufferSize
@@ -87,19 +70,17 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
     - hipsolverSgesvdjBatched_bufferSize, hipsolverDgesvdjBatched_bufferSize, hipsolverCgesvdjBatched_bufferSize, hipsolverZgesvdjBatched_bufferSize
     - hipsolverSgesvdjBatched, hipsolverDgesvdjBatched, hipsolverCgesvdjBatched, hipsolverZgesvdjBatched
 
+
 ## hipSOLVER 1.6.0 for ROCm 5.4.0
-
 ### Added
-
 - Added compatibility-only functions
   - gesvdaStridedBatched
     - hipsolverDnSgesvdaStridedBatched_bufferSize, hipsolverDnDgesvdaStridedBatched_bufferSize, hipsolverDnCgesvdaStridedBatched_bufferSize, hipsolverDnZgesvdaStridedBatched_bufferSize
     - hipsolverDnSgesvdaStridedBatched, hipsolverDnDgesvdaStridedBatched, hipsolverDnCgesvdaStridedBatched, hipsolverDnZgesvdaStridedBatched
 
+
 ## hipSOLVER 1.5.0 for ROCm 5.3.0
-
 ### Added
-
 - Added functions
   - syevj
     - hipsolverSsyevj_bufferSize, hipsolverDsyevj_bufferSize, hipsolverCheevj_bufferSize, hipsolverZheevj_bufferSize
@@ -120,32 +101,27 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 - Added --mem_query option to hipsolver-bench, which will print the amount of device memory workspace required by the function.
 
 ### Changed
-
 - The rocSOLVER backend will now set `info` to zero if rocSOLVER does not reference `info`. (Applies to orgbr/ungbr, orgqr/ungqr, orgtr/ungtr, ormqr/unmqr, ormtr/unmtr, gebrd, geqrf, getrs, potrs, and sytrd/hetrd).
 - gesvdj will no longer require extra workspace to transpose `V` when `jobz` is `HIPSOLVER_EIG_MODE_VECTOR` and `econ` is 1.
 
 ### Fixed
-
 - Fixed Fortran return value declarations within hipsolver_module.f90
 - Fixed gesvdj_bufferSize returning `HIPSOLVER_STATUS_INVALID_VALUE` when `jobz` is `HIPSOLVER_EIG_MODE_NOVECTOR` and 1 <= `ldv` < `n`
 - Fixed gesvdj returning `HIPSOLVER_STATUS_INVALID_VALUE` when `jobz` is `HIPSOLVER_EIG_MODE_VECTOR`, `econ` is 1, and `m` < `n`
 
+
 ## hipSOLVER 1.4.0 for ROCm 5.2.0
-
 ### Added
-
 - Package generation for test and benchmark executables on all supported OSes using CPack.
 - File/Folder Reorg
   - Added File/Folder Reorg Changes with backward compatibility support using ROCM-CMAKE wrapper functions.
 
 ### Fixed
-
 - Fixed the ReadTheDocs documentation generation.
 
+
 ## hipSOLVER 1.3.0 for ROCm 5.1.0
-
 ### Added
-
 - Added functions
   - gels
     - hipsolverSSgels_bufferSize, hipsolverDDgels_bufferSize, hipsolverCCgels_bufferSize, hipsolverZZgels_bufferSize
@@ -170,33 +146,28 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
     - hipsolverDnSsygvj, hipsolverDnDsygvj, hipsolverDnChegvj, hipsolverDnZhegvj
 
 ### Changed
-
 - The rocSOLVER backend now allows hipsolverXXgels and hipsolverXXgesv to be called in-place when B == X.
 - The rocSOLVER backend now allows rwork to be passed as a null pointer to hipsolverXgesvd.
 
 ### Fixed
-
 - bufferSize functions will now return HIPSOLVER_STATUS_NOT_INITIALIZED instead of HIPSOLVER_STATUS_INVALID_VALUE when both handle and lwork are null.
 - Fixed rare memory allocation failure in syevd/heevd and sygvd/hegvd caused by improper workspace array allocation outside of rocSOLVER.
 
+
 ## hipSOLVER 1.2.0 for ROCm 5.0.0
-
 ### Added
-
 - Added functions
   - sytrf
     - hipsolverSsytrf_bufferSize, hipsolverDsytrf_bufferSize, hipsolverCsytrf_bufferSize, hipsolverZsytrf_bufferSize
     - hipsolverSsytrf, hipsolverDsytrf, hipsolverCsytrf, hipsolverZsytrf
 
 ### Fixed
-
 - Fixed use of incorrect `HIP_PATH` when building from source (#40).
   Thanks [@jakub329homola](https://github.com/jakub329homola)!
 
+
 ## hipSOLVER 1.1.0 for ROCm 4.5.0
-
 ### Added
-
 - Added functions
   - gesv
     - hipsolverSSgesv_bufferSize, hipsolverDDgesv_bufferSize, hipsolverCCgesv_bufferSize, hipsolverZZgesv_bufferSize
@@ -260,11 +231,9 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
     - hipsolverSetStream, hipsolverGetStream
 
 ### Changed
-
 - hipSOLVER functions will now return HIPSOLVER_STATUS_INVALID_ENUM or HIPSOLVER_STATUS_UNKNOWN status codes rather than throw exceptions.
 - hipsolverXgetrf functions now take lwork as an argument.
 
 ### Removed
-
 - Removed unused HIPSOLVER_FILL_MODE_FULL enum value.
 - Removed hipsolverComplex and hipsolverDoubleComplex from the library. Use hipFloatComplex and hipDoubleComplex instead.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # hipSOLVER
+
 hipSOLVER is a LAPACK marshalling library, with multiple supported backends.  It sits between the application and a 'worker' LAPACK library, marshalling inputs into the backend library and marshalling results back to the application.  hipSOLVER exports an interface that does not require the client to change, regardless of the chosen backend.  Currently, hipSOLVER supports [rocSOLVER](https://github.com/ROCmSoftwarePlatform/rocSOLVER) and [cuSOLVER](https://developer.nvidia.com/cusolver) as backends.
 
 ## Documentation
 
-For a detailed description of the hipSOLVER library, its implemented routines, the installation process and user guide, see the [hipSOLVER documentation](https://hipsolver.readthedocs.io/en/latest/).
+For a detailed description of the hipSOLVER library, its implemented routines, the installation process and user guide, see the [hipSOLVER Documentation](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/index.html).
 
 ### How to build documentation
 
@@ -30,10 +31,11 @@ hipSOLVER requires either cuSOLVER or rocSOLVER + SuiteSparse to be installed on
 
 Once installed, hipSOLVER can be used just like any other library with a C API. The header file will need to be included in the user code, and the hipSOLVER library will become a link-time and run-time dependency for the user application.
 
-For more information on building and installing hipSOLVER, see the [hipSOLVER install guide](https://hipsolver.readthedocs.io/en/latest/userguide_install.html)
+For more information on building and installing hipSOLVER, see the [hipSOLVER install guide](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/userguide/install.html)
 
 ## Using the hipSOLVER Interface
-The hipSOLVER interface is compatible with the rocSOLVER and cuSOLVER-v11 APIs. Porting a CUDA application that originally calls the cuSOLVER API to an application calling the hipSOLVER API should be fairly straightforward (see [porting a cuSOLVER application to hipSOLVER](https://hipsolver.readthedocs.io/en/latest/userguide_intro.html#porting-a-cusolver-application-to-hipsolver)). For example, the hipSOLVER SGEQRF interface is
+
+The hipSOLVER interface is compatible with the rocSOLVER and cuSOLVER-v11 APIs. Porting a CUDA application that originally calls the cuSOLVER API to an application calling the hipSOLVER API should be fairly straightforward (see [porting a cuSOLVER application to hipSOLVER](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/userguide/usage.html#porting-cusolver-applications-to-hipsolver)). For example, the hipSOLVER SGEQRF interface is
 
 ```c
 hipsolverStatus_t
@@ -59,4 +61,5 @@ hipsolverSgeqrf(hipsolverHandle_t handle,
 ```
 
 ## Supported Functionality
-For a complete listing of all supported functions, see the [hipSOLVER user guide](https://hipsolver.readthedocs.io/en/latest/userguide_intro.html) and/or [API documentation](https://hipsolver.readthedocs.io/en/latest/api_index.html).
+
+For a complete listing of all supported functions, see the [hipSOLVER user guide](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/userguide/index.html) and/or [API documentation](https://rocm.docs.amd.com/projects/hipSOLVER/en/latest/api/index.html).

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -6,7 +6,7 @@ hipSOLVER Regular API
 
 Currently, this API document only provides the method signatures for the wrapper functions that are currently implemented in hipSOLVER.
 For a complete description of the functions' behavior and arguments, see the corresponding backends' documentation
-at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/>`_ and/or `rocSOLVER API <https://rocsolver.readthedocs.io/>`_.
+at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/>`_ and/or `rocSOLVER API <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/index.html>`_.
 
 The hipSOLVER API is designed to be similar to the cusolver and rocSOLVER interfaces, but it requires some minor adjustments to ensure
 the best performance out of both backends. Generally, this involves the addition of workspace parameters and some additional API methods.

--- a/docs/compat-api/index.rst
+++ b/docs/compat-api/index.rst
@@ -6,7 +6,7 @@ hipSOLVER Compatibility API (Dense Matrices)
 
 Currently, this API document only provides the method signatures for the wrapper functions that are currently implemented in hipSOLVER.
 For a complete description of the functions' behavior and arguments, see the corresponding backends' documentation
-at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/>`_ and/or `rocSOLVER API <https://rocsolver.readthedocs.io/>`_.
+at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/>`_ and/or `rocSOLVER API <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/index.html>`_.
 
 For ease of porting from existing cuSOLVER applications to hipSOLVER, functions in the hipsolverDn compatibility API are designed to have
 method signatures that are consistent with the cusolverDn interface. However, :ref:`performance issues <compat_performance>` may arise when

--- a/docs/refactor-api/index.rst
+++ b/docs/refactor-api/index.rst
@@ -6,7 +6,7 @@ hipSOLVER Compatibility API (Refactorization)
 
 Currently, this API document only provides the method signatures for the wrapper functions that are currently implemented in hipSOLVER.
 For a complete description of the functions' behavior and arguments, see the corresponding backends' documentation
-at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/index.html#cuds-api>`_ and/or `rocSOLVER API <https://rocsolver.readthedocs.io/en/latest/api_index.html>`_.
+at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/index.html#cuds-api>`_ and/or `rocSOLVER API <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/index.html>`_.
 
 For ease of porting from existing cuSOLVER applications to hipSOLVER, functions in the hipsolverRf compatibility API are designed to have
 method signatures that are consistent with the cusolverRf interface. At present, equivalent functions have not been added to hipSOLVER's

--- a/docs/sparse-api/index.rst
+++ b/docs/sparse-api/index.rst
@@ -6,7 +6,7 @@ hipSOLVER Compatibility API (Sparse Matrices)
 
 Currently, this API document only provides the method signatures for the wrapper functions that are currently implemented in hipSOLVER.
 For a complete description of the functions' behavior and arguments, see the corresponding backends' documentation
-at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/index.html#cuds-api>`_ and/or `rocSOLVER API <https://rocsolver.readthedocs.io/en/latest/api_index.html>`_.
+at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/index.html#cuds-api>`_ and/or `rocSOLVER API <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/index.html>`_.
 
 For ease of porting from existing cuSOLVER applications to hipSOLVER, functions in the hipsolverSp compatibility API are designed to have
 method signatures that are consistent with the cusolverSp interface. At present, equivalent functions have not been added to hipSOLVER's

--- a/docs/userguide/install.rst
+++ b/docs/userguide/install.rst
@@ -120,8 +120,8 @@ install the respective library via:
 
 * ``./install.sh -i``
 
-More details can be found in the `hipBLAS documentation <https://hipblas.readthedocs.io/en/latest/install.html>`_ and the `hipSPARSE documentation
-<https://github.com/ROCmSoftwarePlatform/hipSPARSE/wiki/Build>`_.
+More details can be found in the `hipBLAS documentation <https://rocm.docs.amd.com/projects/hipBLAS/en/latest/index.html>`_
+and the `hipSPARSE documentation <https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/index.html>`_.
 
 Library and clients
 --------------------

--- a/docs/userguide/usage.rst
+++ b/docs/userguide/usage.rst
@@ -225,7 +225,7 @@ Using rocSOLVER's memory model
 
 Most hipSOLVER functions take a workspace pointer and size as arguments, allowing the user to manage the device memory used
 internally by the backends. rocSOLVER, however, can maintain the device workspace automatically by default
-(see `rocSOLVER's memory model <https://rocsolver.readthedocs.io/en/master/userguide_memory.html>`_ for more details). In order to take
+(see `rocSOLVER's memory model <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/userguide/memory.html>`_ for more details). In order to take
 advantage of this feature, users may pass a null pointer for the `work` argument or a zero size for the `lwork` argument of any function
 when using the rocSOLVER backend, and the workspace will be automatically managed behind-the-scenes. It is recommended, however, to use
 a consistent strategy for workspace management, as performance issues may arise if the internal workspace is made to flip-flop between


### PR DESCRIPTION
Replaces ReadtheDocs for Community links (.io) (being retired) with for Business (.com)

Also applies some automatic Markdown formatting changes to the changelog