### PR TITLE
Fix failing CUDA build

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -78,7 +78,7 @@ if( NOT USE_CUDA )
     target_link_libraries( hipsolver-bench PRIVATE -lpthread -lm )
   endif()
 else( )
-  target_compile_definitions( hipsolver-bench PRIVATE __HIP_PLATFORM_NVCC__ )
+  target_compile_definitions( hipsolver-bench PRIVATE __HIP_PLATFORM_NVIDIA__ )
 
   target_include_directories( hipsolver-bench
     PRIVATE

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -138,7 +138,7 @@ if( NOT USE_CUDA )
     target_link_libraries( hipsolver-test PRIVATE -lpthread -lm )
   endif()
 else( )
-  target_compile_definitions( hipsolver-test PRIVATE __HIP_PLATFORM_NVCC__ )
+  target_compile_definitions( hipsolver-test PRIVATE __HIP_PLATFORM_NVIDIA__ )
 
   target_include_directories( hipsolver-test
     PRIVATE

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -52,7 +52,7 @@ foreach( exe example-c-basic;example-cpp-basic; )
     endif( )
 
   else( )
-    target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_NVCC__ )
+    target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_NVIDIA__ )
 
     target_include_directories( ${exe}
       PRIVATE

--- a/library/include/internal/hipsolver-compat.h
+++ b/library/include/internal/hipsolver-compat.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
@@ -13,7 +13,6 @@
 #ifndef HIPSOLVER_COMPAT_H
 #define HIPSOLVER_COMPAT_H
 
-#include "hipsolver-functions.h"
 #include "hipsolver-types.h"
 
 /*! \brief Provided for convenience when porting code from cuSOLVER.

--- a/library/include/internal/hipsolver-functions.h
+++ b/library/include/internal/hipsolver-functions.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
@@ -12,8 +12,6 @@
 #define HIPSOLVER_FUNCTIONS_H
 
 #include "hipsolver-types.h"
-#include <hip/hip_runtime_api.h>
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/library/include/internal/hipsolver-types.h
+++ b/library/include/internal/hipsolver-types.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 /*! \file
@@ -10,6 +10,7 @@
 #define HIPSOLVER_TYPES_H
 
 #include <hip/hip_complex.h>
+#include <hip/hip_runtime_api.h>
 
 typedef void* hipsolverHandle_t;
 

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -147,7 +147,7 @@ if( NOT USE_CUDA )
   endif( )
 
 else( )
-  target_compile_definitions( hipsolver PRIVATE __HIP_PLATFORM_NVCC__ )
+  target_compile_definitions( hipsolver PRIVATE __HIP_PLATFORM_NVIDIA__ )
 
   target_link_libraries( hipsolver PRIVATE ${CUDA_cusolver_LIBRARY} )
 


### PR DESCRIPTION
~The CUDA build of hipSOLVER is failing on CI, and I'm not able to reproduce the error on the machine I normally use for testing. It's not entirely clear to me what is causing the issue, but the error message suggests that it could be because a HIP header is being included multiple times, most likely through hipsolver-compat.h. I've adjusted the includes in our header files in the hope this will fix the issue.~

The CUDA build of hipSOLVER appears to be failing because we define HIP_PLATFORM_NVCC instead of HIP_PLATFORM_NVIDIA. This PR should address the issue, and will likely need to be backported to 6.1.