### PR TITLE
cmake: add blas/solver/sparse as package deps if building static lib

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -96,6 +96,8 @@ if( WIN32 )
   endif( )
 endif( )
 
+set( static_depends )
+
 # Build hipsolver from source on AMD platform
 if( NOT USE_CUDA )
   # Find rocBLAS
@@ -106,6 +108,7 @@ if( NOT USE_CUDA )
     else( )
       find_package( rocblas REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocblas )
     endif( )
+    list( APPEND static_depends PACKAGE rocblas )
   endif( )
 
   # Find rocSOLVER
@@ -116,6 +119,7 @@ if( NOT USE_CUDA )
     else( )
       find_package( rocsolver REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocsolver /usr/local/rocsolver )
     endif( )
+    list( APPEND static_depends PACKAGE rocsolver )
   endif( )
 
   target_link_libraries( hipsolver PRIVATE roc::rocblas roc::rocsolver hip::host )
@@ -133,6 +137,7 @@ if( NOT USE_CUDA )
       else( )
         find_package( rocsparse REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocsparse )
       endif( )
+      list( APPEND static_depends PACKAGE rocsparse )
     endif( )
 
     target_link_libraries( hipsolver PRIVATE roc::rocsparse suitesparseconfig cholmod )
@@ -211,6 +216,8 @@ if ( NOT USE_CUDA )
   rocm_export_targets(
     TARGETS roc::hipsolver
     DEPENDS PACKAGE hip
+    STATIC_DEPENDS
+      ${static_depends}
     NAMESPACE roc::
   )
 else( )


### PR DESCRIPTION
When a static library is built, no linking is done.  (Basically static libraries are just archives of object files.)

So if `libfoo.a` depends on `libbar.a`, CMake just has to remember that when you link `libfoo.a`, it also needs to pull in `libbar.a`.  The problem is that CMake only knows about `libbar.a` if a `find_package(bar)` is done.  This PR fixes our generated `foo-config.cmake` file to find this dependency, when we're building a static library.