### PR TITLE
Add hipsolver team as code owners for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 * @jzuniga-amd @tfalders @cgmb @qjojo
 # Documentation files
-docs/* @ROCm/rocm-documentation
-*.md @ROCm/rocm-documentation
-*.rst @ROCm/rocm-documentation
+docs/* @ROCm/rocm-documentation @jzuniga-amd @tfalders @cgmb @qjojo
+*.md @ROCm/rocm-documentation @jzuniga-amd @tfalders @cgmb @qjojo
+*.rst @ROCm/rocm-documentation @jzuniga-amd @tfalders @cgmb @qjojo
 # Header directory for Doxygen documentation
-library/include/* @ROCm/rocm-documentation
+library/include/* @ROCm/rocm-documentation @jzuniga-amd @tfalders @cgmb @qjojo


### PR DESCRIPTION
When a file matches multiple patterns in the CODEOWNERS file, it is assigned the code owners listed in the last matching pattern (not the union of all code owners in all matching patterns). This means that the additions to CODEOWNERS in d17c30edee853be0cb8413213e56ee9dadf348c6 implicitly removed the hipsolver team members from documentation files.