### PR TITLE
Rename hipsolver-compat.h to hipsolver-dense.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ### Optimized
 ### Changed
 - The numerical factorization in csrlsvchol will now be performed on the GPU. (The symbolic factorization is still performed on the CPU.)
+- Renamed hipsolver-compat.h to hipsolver-dense.h.
 
 ### Deprecated
 ### Removed

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,6 +1,6 @@
 FROM readthedocs/build:latest
 
 USER root:root
-COPY .sphinx/requirements.txt requirements.txt
+COPY sphinx/requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 RUN rm requirements.txt

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -769,7 +769,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = ../../library/include \
-                         ../../library/include/internal
+                         ../../library/include/internal \
+                         ../../README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -951,7 +952,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ../README.md
+USE_MDFILE_AS_MAINPAGE = ../../README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/docs/howto/usage.rst
+++ b/docs/howto/usage.rst
@@ -30,10 +30,10 @@ Porting cuSOLVER applications to hipSOLVER
 ============================================
 
 Another purpose of hipSOLVER is to facilitate the translation of cuSOLVER applications to
-`AMD's open source ROCm platform <https://rocmdocs.amd.com/en/latest/index.html>`_ ecosystem. 
+`AMD's open source ROCm platform <https://rocmdocs.amd.com/en/latest/index.html>`_ ecosystem.
 hipSOLVER is designed to make it easy for users of cuSOLVER to port their existing applications to hipSOLVER, and provides two
 separate but interchangeable API patterns in order to facilitate a two-stage transition process. Users are encouraged to start with
-hipSOLVER's compatibility APIs, which use the :ref:`hipsolverDn <library_compat>`, :ref:`hipsolverSp <library_sparse>`, and
+hipSOLVER's compatibility APIs, which use the :ref:`hipsolverDn <library_dense>`, :ref:`hipsolverSp <library_sparse>`, and
 :ref:`hipsolverRf <library_refactor>` prefixes and have method signatures that are fully consistent with cuSOLVER functions.
 
 However, the compatibility APIs may introduce some performance drawbacks, especially when using the rocSOLVER backend. So, as a second
@@ -46,7 +46,7 @@ No matter which API is used, a hipSOLVER application can be executed, without mo
 rocSOLVER installed. However, using the regular API ensures the best performance out of both backends.
 
 
-.. _compat_api_differences:
+.. _dense_api_differences:
 
 Some considerations when using the hipsolverDn API
 ====================================================
@@ -63,19 +63,19 @@ Arguments not referenced by rocSOLVER
   return a value >= 0. In those cases where a rocSOLVER function does not accept `info` as an argument, hipSOLVER will
   set it to zero.
 
-- The `niters` argument of :ref:`hipsolverDnXXgels <compat_gels>` and :ref:`hipsolverDnXXgesv <compat_gesv>` is not referenced
+- The `niters` argument of :ref:`hipsolverDnXXgels <dense_gels>` and :ref:`hipsolverDnXXgesv <dense_gesv>` is not referenced
   by the rocSOLVER backend; there is no iterative refinement currently implemented in rocSOLVER.
 
-- The `hRnrmF` argument of :ref:`hipsolverDnXgesvdaStridedBatched <compat_gesvda_strided_batched>` is not referenced by the
+- The `hRnrmF` argument of :ref:`hipsolverDnXgesvdaStridedBatched <dense_gesvda_strided_batched>` is not referenced by the
   rocSOLVER backend.
 
-.. _compat_performance:
+.. _dense_performance:
 
 Performance implications of the hipsolverDn API
 ------------------------------------------------
 
 - To calculate the workspace required by function `gesvd` in rocSOLVER, the values of `jobu` and `jobv` are needed, however,
-  the function :ref:`hipsolverDnXgesvd_bufferSize <compat_gesvd_bufferSize>` does not accept these arguments. So, when using
+  the function :ref:`hipsolverDnXgesvd_bufferSize <dense_gesvd_bufferSize>` does not accept these arguments. So, when using
   the rocSOLVER backend, `hipsolverDnXgesvd_bufferSize` has to calculate internally the workspace for all possible values of `jobu` and `jobv`,
   and return the maximum.
 
@@ -83,15 +83,15 @@ Performance implications of the hipsolverDn API
   what is actually needed).
 
 - To properly use a user-provided workspace, rocSOLVER requires both the allocated pointer and its size. However, the function
-  :ref:`hipsolverDnXgetrf <compat_getrf>` does not accept `lwork` as an argument. In consequence, when using the rocSOLVER backend,
+  :ref:`hipsolverDnXgetrf <dense_getrf>` does not accept `lwork` as an argument. In consequence, when using the rocSOLVER backend,
   `hipsolverDnXgetrf` has to call internally `hipsolverDnXgetrf_bufferSize` to know the size of the workspace.
 
   (`hipsolverDnXgetrf_bufferSize` will be called twice in practice, once by the user before allocating the workspace, and once
   by hipSOLVER internally when executing the `hipsolverDnXgetrf` function. `hipsolverDnXgetrf` could be slightly slower than `hipsolverXgetrf`
   because of the extra call to the bufferSize helper).
 
-- The functions :ref:`hipsolverDnXgetrs <compat_getrs>`, :ref:`hipsolverDnXpotrs <compat_potrs>`, :ref:`hipsolverDnXpotrsBatched <compat_potrs_batched>`, and
-  :ref:`hipsolverDnXpotrfBatched <compat_potrf_batched>` do not accept `work` and `lwork` as arguments. However, this functionality does require a non-zero workspace
+- The functions :ref:`hipsolverDnXgetrs <dense_getrs>`, :ref:`hipsolverDnXpotrs <dense_potrs>`, :ref:`hipsolverDnXpotrsBatched <dense_potrs_batched>`, and
+  :ref:`hipsolverDnXpotrfBatched <dense_potrf_batched>` do not accept `work` and `lwork` as arguments. However, this functionality does require a non-zero workspace
   in rocSOLVER. As a result, when using the rocSOLVER backend, these functions will switch to the automatic workspace management model (see :ref:`here <mem_model>`).
 
   (Users must keep in mind that even if the compatibility API does not have bufferSize helpers for the mentioned functions, these functions do require

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@
 hipSOLVER documentation
 ********************************************************************
 
-hipSOLVER is a LAPACK marshalling library, with multiple supported backends. It sits between the application and a 'worker' LAPACK library, marshalling inputs into the backend library and marshalling results back to the application. hipSOLVER supports rocSOLVER and cuSOLVER as backends. hipSOLVER exports an interface that does not require the client to change, regardless of the chosen backend. 
+hipSOLVER is a LAPACK marshalling library, with multiple supported backends. It sits between the application and a 'worker' LAPACK library, marshalling inputs into the backend library and marshalling results back to the application. hipSOLVER supports rocSOLVER and cuSOLVER as backends. hipSOLVER exports an interface that does not require the client to change, regardless of the chosen backend.
 
 The code is open and hosted at: https://github.com/ROCm/hipSOLVER
 
@@ -29,11 +29,11 @@ The hipSOLVER documentation is structured as follows:
 
     * :ref:`api-intro`
     * :ref:`library_api`
-    * :ref:`library_compat` 
-    * :ref:`library_sparse` 
-    * :ref:`library_refactor` 
+    * :ref:`library_dense`
+    * :ref:`library_sparse`
+    * :ref:`library_refactor`
 
-:ref:`usage_label` is the starting point for new users of the library. For a list of currently implemented routines in the different APIs refer to :ref:`api-intro`. 
+:ref:`usage_label` is the starting point for new users of the library. For a list of currently implemented routines in the different APIs refer to :ref:`api-intro`.
 
 To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/index.html>`_.
 

--- a/docs/reference/api/index.rst
+++ b/docs/reference/api/index.rst
@@ -17,10 +17,10 @@ the best performance out of both backends. Generally, this involves the addition
 Refer to :ref:`usage_label` for a complete list of :ref:`API differences <api_differences>`.
 
 Users interested in using hipSOLVER without these adjustments, so that the interface matches cuSOLVER, should instead consult the
-:ref:`Compatibility API documentation <library_compat>`. See also :ref:`the porting section <porting>` for more details.
+:ref:`Compatibility API documentation <library_dense>`. See also :ref:`the porting section <porting>` for more details.
 
   * :ref:`library_types`
-  * :ref:`api_helpers` 
+  * :ref:`api_helpers`
   * :ref:`library_auxiliary`
   * :ref:`lapackfunc`
   * :ref:`lapacklike`

--- a/docs/reference/dense-api/auxiliary.rst
+++ b/docs/reference/dense-api/auxiliary.rst
@@ -2,21 +2,21 @@
   :description: hipSOLVER documentation and API reference library
   :keywords: hipSOLVER, rocSOLVER, ROCm, API, documentation
 
-.. _compat_auxiliary:
+.. _dense_auxiliary:
 
 ****************************************
 Dense matrix LAPACK auxiliary functions
 ****************************************
 
-These are functions that support more :ref:`advanced LAPACK routines <compat_lapackfunc>`.
+These are functions that support more :ref:`advanced LAPACK routines <dense_lapackfunc>`.
 The auxiliary functions are divided into the following categories:
 
-* :ref:`compat_orthonormal`. Generation and application of orthonormal matrices.
-* :ref:`compat_unitary`. Generation and application of unitary matrices.
+* :ref:`dense_orthonormal`. Generation and application of orthonormal matrices.
+* :ref:`dense_unitary`. Generation and application of unitary matrices.
 
 
 
-.. _compat_orthonormal:
+.. _dense_orthonormal:
 
 Orthonormal matrices
 ==================================
@@ -25,7 +25,7 @@ Orthonormal matrices
    :local:
    :backlinks: top
 
-.. _compat_orgbr_bufferSize:
+.. _dense_orgbr_bufferSize:
 
 hipsolverDn<type>orgbr_bufferSize()
 ---------------------------------------
@@ -33,7 +33,7 @@ hipsolverDn<type>orgbr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSorgbr_bufferSize
 
-.. _compat_orgbr:
+.. _dense_orgbr:
 
 hipsolverDn<type>orgbr()
 ---------------------------------------
@@ -41,7 +41,7 @@ hipsolverDn<type>orgbr()
    :outline:
 .. doxygenfunction:: hipsolverDnSorgbr
 
-.. _compat_orgqr_bufferSize:
+.. _dense_orgqr_bufferSize:
 
 hipsolverDn<type>orgqr_bufferSize()
 ---------------------------------------
@@ -49,7 +49,7 @@ hipsolverDn<type>orgqr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSorgqr_bufferSize
 
-.. _compat_orgqr:
+.. _dense_orgqr:
 
 hipsolverDn<type>orgqr()
 ---------------------------------------
@@ -57,7 +57,7 @@ hipsolverDn<type>orgqr()
    :outline:
 .. doxygenfunction:: hipsolverDnSorgqr
 
-.. _compat_orgtr_bufferSize:
+.. _dense_orgtr_bufferSize:
 
 hipsolverDn<type>orgtr_bufferSize()
 ---------------------------------------
@@ -65,7 +65,7 @@ hipsolverDn<type>orgtr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSorgtr_bufferSize
 
-.. _compat_orgtr:
+.. _dense_orgtr:
 
 hipsolverDn<type>orgtr()
 ---------------------------------------
@@ -73,7 +73,7 @@ hipsolverDn<type>orgtr()
    :outline:
 .. doxygenfunction:: hipsolverDnSorgtr
 
-.. _compat_ormqr_bufferSize:
+.. _dense_ormqr_bufferSize:
 
 hipsolverDn<type>ormqr_bufferSize()
 ---------------------------------------
@@ -81,7 +81,7 @@ hipsolverDn<type>ormqr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSormqr_bufferSize
 
-.. _compat_ormqr:
+.. _dense_ormqr:
 
 hipsolverDn<type>ormqr()
 ---------------------------------------
@@ -89,7 +89,7 @@ hipsolverDn<type>ormqr()
    :outline:
 .. doxygenfunction:: hipsolverDnSormqr
 
-.. _compat_ormtr_bufferSize:
+.. _dense_ormtr_bufferSize:
 
 hipsolverDn<type>ormtr_bufferSize()
 ---------------------------------------
@@ -97,7 +97,7 @@ hipsolverDn<type>ormtr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSormtr_bufferSize
 
-.. _compat_ormtr:
+.. _dense_ormtr:
 
 hipsolverDn<type>ormtr()
 ---------------------------------------
@@ -107,7 +107,7 @@ hipsolverDn<type>ormtr()
 
 
 
-.. _compat_unitary:
+.. _dense_unitary:
 
 Unitary matrices
 ==================================
@@ -116,7 +116,7 @@ Unitary matrices
    :local:
    :backlinks: top
 
-.. _compat_ungbr_bufferSize:
+.. _dense_ungbr_bufferSize:
 
 hipsolverDn<type>ungbr_bufferSize()
 ---------------------------------------
@@ -124,7 +124,7 @@ hipsolverDn<type>ungbr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnCungbr_bufferSize
 
-.. _compat_ungbr:
+.. _dense_ungbr:
 
 hipsolverDn<type>ungbr()
 ---------------------------------------
@@ -132,7 +132,7 @@ hipsolverDn<type>ungbr()
    :outline:
 .. doxygenfunction:: hipsolverDnCungbr
 
-.. _compat_ungqr_bufferSize:
+.. _dense_ungqr_bufferSize:
 
 hipsolverDn<type>ungqr_bufferSize()
 ---------------------------------------
@@ -140,7 +140,7 @@ hipsolverDn<type>ungqr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnCungqr_bufferSize
 
-.. _compat_ungqr:
+.. _dense_ungqr:
 
 hipsolverDn<type>ungqr()
 ---------------------------------------
@@ -148,7 +148,7 @@ hipsolverDn<type>ungqr()
    :outline:
 .. doxygenfunction:: hipsolverDnCungqr
 
-.. _compat_ungtr_bufferSize:
+.. _dense_ungtr_bufferSize:
 
 hipsolverDn<type>ungtr_bufferSize()
 ---------------------------------------
@@ -156,7 +156,7 @@ hipsolverDn<type>ungtr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnCungtr_bufferSize
 
-.. _compat_ungtr:
+.. _dense_ungtr:
 
 hipsolverDn<type>ungtr()
 ---------------------------------------
@@ -164,7 +164,7 @@ hipsolverDn<type>ungtr()
    :outline:
 .. doxygenfunction:: hipsolverDnCungtr
 
-.. _compat_unmqr_bufferSize:
+.. _dense_unmqr_bufferSize:
 
 hipsolverDn<type>unmqr_bufferSize()
 ---------------------------------------
@@ -172,7 +172,7 @@ hipsolverDn<type>unmqr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnCunmqr_bufferSize
 
-.. _compat_unmqr:
+.. _dense_unmqr:
 
 hipsolverDn<type>unmqr()
 ---------------------------------------
@@ -180,7 +180,7 @@ hipsolverDn<type>unmqr()
    :outline:
 .. doxygenfunction:: hipsolverDnCunmqr
 
-.. _compat_unmtr_bufferSize:
+.. _dense_unmtr_bufferSize:
 
 hipsolverDn<type>unmtr_bufferSize()
 ---------------------------------------
@@ -188,7 +188,7 @@ hipsolverDn<type>unmtr_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnCunmtr_bufferSize
 
-.. _compat_unmtr:
+.. _dense_unmtr:
 
 hipsolverDn<type>unmtr()
 ---------------------------------------

--- a/docs/reference/dense-api/helpers.rst
+++ b/docs/reference/dense-api/helpers.rst
@@ -2,7 +2,7 @@
   :description: hipSOLVER documentation and API reference library
   :keywords: hipSOLVER, rocSOLVER, ROCm, API, documentation
 
-.. _compat_helpers:
+.. _dense_helpers:
 
 *****************************************
 Dense matrix helper functions
@@ -11,13 +11,13 @@ Dense matrix helper functions
 These are helper functions that control aspects of the hipSOLVER library. They are divided
 into the following categories:
 
-* :ref:`compat_initialize` functions used to initialize and cleanup the library handle
-* :ref:`compat_stream` functions provide functionality to manipulate streams
-* :ref:`compat_gesvdj_info` functions provide functionality to manipulate gesvdj parameters
-* :ref:`compat_syevj_info` functions provide functionality to manipulate syevj parameters
+* :ref:`dense_initialize` functions used to initialize and cleanup the library handle
+* :ref:`dense_stream` functions provide functionality to manipulate streams
+* :ref:`dense_gesvdj_info` functions provide functionality to manipulate gesvdj parameters
+* :ref:`dense_syevj_info` functions provide functionality to manipulate syevj parameters
 
 
-.. _compat_initialize:
+.. _dense_initialize:
 
 Handle set-up and tear-down
 ===============================
@@ -36,7 +36,7 @@ hipsolverDnDestroy()
 
 
 
-.. _compat_stream:
+.. _dense_stream:
 
 Stream manipulation
 ==============================
@@ -55,7 +55,7 @@ hipsolverDnGetStream()
 
 
 
-.. _compat_gesvdj_info:
+.. _dense_gesvdj_info:
 
 Gesvdj parameter manipulation
 ===============================
@@ -72,31 +72,31 @@ hipsolverDnDestroyGesvdjInfo()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnDestroyGesvdjInfo
 
-.. _compat_gesvdj_set_max_sweeps:
+.. _dense_gesvdj_set_max_sweeps:
 
 hipsolverDnXgesvdjSetMaxSweeps()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnXgesvdjSetMaxSweeps
 
-.. _compat_gesvdj_set_sort_eig:
+.. _dense_gesvdj_set_sort_eig:
 
 hipsolverDnXgesvdjSetSortEig()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnXgesvdjSetSortEig
 
-.. _compat_gesvdj_set_tolerance:
+.. _dense_gesvdj_set_tolerance:
 
 hipsolverDnXgesvdjSetTolerance()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnXgesvdjSetTolerance
 
-.. _compat_gesvdj_get_residual:
+.. _dense_gesvdj_get_residual:
 
 hipsolverDnXgesvdjGetResidual()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnXgesvdjGetResidual
 
-.. _compat_gesvdj_get_sweeps:
+.. _dense_gesvdj_get_sweeps:
 
 hipsolverDnXgesvdjGetSweeps()
 ---------------------------------
@@ -104,7 +104,7 @@ hipsolverDnXgesvdjGetSweeps()
 
 
 
-.. _compat_syevj_info:
+.. _dense_syevj_info:
 
 Syevj parameter manipulation
 ===============================
@@ -121,31 +121,31 @@ hipsolverDnDestroySyevjInfo()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnDestroySyevjInfo
 
-.. _compat_syevj_set_max_sweeps:
+.. _dense_syevj_set_max_sweeps:
 
 hipsolverDnXsyevjSetMaxSweeps()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnXsyevjSetMaxSweeps
 
-.. _compat_syevj_set_sort_eig:
+.. _dense_syevj_set_sort_eig:
 
 hipsolverDnXsyevjSetSortEig()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnXsyevjSetSortEig
 
-.. _compat_syevj_set_tolerance:
+.. _dense_syevj_set_tolerance:
 
 hipsolverDnXsyevjSetTolerance()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnXsyevjSetTolerance
 
-.. _compat_syevj_get_residual:
+.. _dense_syevj_get_residual:
 
 hipsolverDnXsyevjGetResidual()
 ---------------------------------
 .. doxygenfunction:: hipsolverDnXsyevjGetResidual
 
-.. _compat_syevj_get_sweeps:
+.. _dense_syevj_get_sweeps:
 
 hipsolverDnXsyevjGetSweeps()
 ---------------------------------

--- a/docs/reference/dense-api/index.rst
+++ b/docs/reference/dense-api/index.rst
@@ -2,7 +2,7 @@
   :description: hipSOLVER documentation and API reference library
   :keywords: hipSOLVER, rocSOLVER, ROCm, API, documentation
 
-.. _library_compat:
+.. _library_dense:
 
 ********************************************************************
 hipSOLVER compatibility API - Dense Matrices
@@ -13,15 +13,15 @@ For a complete description of the functions' behavior and arguments, see the cor
 at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/>`_ and/or `rocSOLVER API <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/index.html>`_.
 
 For ease of porting from existing cuSOLVER applications to hipSOLVER, functions in the hipsolverDn compatibility API are designed to have
-method signatures that are consistent with the cusolverDn interface. However, :ref:`performance issues <compat_performance>` may arise when
+method signatures that are consistent with the cusolverDn interface. However, :ref:`performance issues <dense_performance>` may arise when
 using the rocSOLVER backend due to differing workspace requirements. Therefore, users interested in achieving the best performance with
 the rocSOLVER backend should consult the :ref:`regular API documentation <library_api>`, and transition from the compatibility API to
 the regular API at the earliest convenience. Please refer to :ref:`usage_label` for additional :ref:`considerations regarding the use of
-the compatibility API <compat_api_differences>`.
+the compatibility API <dense_api_differences>`.
 
-  * :ref:`compat_types`
-  * :ref:`compat_helpers` 
-  * :ref:`compat_auxiliary`
-  * :ref:`compat_lapackfunc`
-  * :ref:`compat_lapacklike`
+  * :ref:`dense_types`
+  * :ref:`dense_helpers`
+  * :ref:`dense_auxiliary`
+  * :ref:`dense_lapackfunc`
+  * :ref:`dense_lapacklike`
 

--- a/docs/reference/dense-api/lapack.rst
+++ b/docs/reference/dense-api/lapack.rst
@@ -2,7 +2,7 @@
   :description: hipSOLVER documentation and API reference library
   :keywords: hipSOLVER, rocSOLVER, ROCm, API, documentation
 
-.. _compat_lapackfunc:
+.. _dense_lapackfunc:
 
 *********************************
 Dense matrix LAPACK functions
@@ -11,17 +11,17 @@ Dense matrix LAPACK functions
 LAPACK routines solve complex Numerical Linear Algebra problems. These functions are organized
 in the following categories:
 
-* :ref:`compat_triangular`. Based on Gaussian elimination.
-* :ref:`compat_orthogonal`. Based on Householder reflections.
-* :ref:`compat_reductions`. Transformation of matrices and problems into equivalent forms.
-* :ref:`compat_linears`. Based on triangular factorizations.
-* :ref:`compat_leastsqr`. Based on orthogonal factorizations.
-* :ref:`compat_eigens`. Eigenproblems for symmetric matrices.
-* :ref:`compat_svds`. Singular values and related problems for general matrices.
+* :ref:`dense_triangular`. Based on Gaussian elimination.
+* :ref:`dense_orthogonal`. Based on Householder reflections.
+* :ref:`dense_reductions`. Transformation of matrices and problems into equivalent forms.
+* :ref:`dense_linears`. Based on triangular factorizations.
+* :ref:`dense_leastsqr`. Based on orthogonal factorizations.
+* :ref:`dense_eigens`. Eigenproblems for symmetric matrices.
+* :ref:`dense_svds`. Singular values and related problems for general matrices.
 
 
 
-.. _compat_triangular:
+.. _dense_triangular:
 
 Triangular factorizations
 ================================
@@ -30,7 +30,7 @@ Triangular factorizations
    :local:
    :backlinks: top
 
-.. _compat_potrf_bufferSize:
+.. _dense_potrf_bufferSize:
 
 hipsolverDn<type>potrf_bufferSize()
 ---------------------------------------------------
@@ -42,7 +42,7 @@ hipsolverDn<type>potrf_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSpotrf_bufferSize
 
-.. _compat_potrf:
+.. _dense_potrf:
 
 hipsolverDn<type>potrf()
 ---------------------------------------------------
@@ -54,7 +54,7 @@ hipsolverDn<type>potrf()
    :outline:
 .. doxygenfunction:: hipsolverDnSpotrf
 
-.. _compat_potrf_batched:
+.. _dense_potrf_batched:
 
 hipsolverDn<type>potrfBatched()
 ---------------------------------------------------
@@ -66,7 +66,7 @@ hipsolverDn<type>potrfBatched()
    :outline:
 .. doxygenfunction:: hipsolverDnSpotrfBatched
 
-.. _compat_getrf_bufferSize:
+.. _dense_getrf_bufferSize:
 
 hipsolverDn<type>getrf_bufferSize()
 ---------------------------------------------------
@@ -78,7 +78,7 @@ hipsolverDn<type>getrf_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSgetrf_bufferSize
 
-.. _compat_getrf:
+.. _dense_getrf:
 
 hipsolverDn<type>getrf()
 ---------------------------------------------------
@@ -90,7 +90,7 @@ hipsolverDn<type>getrf()
    :outline:
 .. doxygenfunction:: hipsolverDnSgetrf
 
-.. _compat_sytrf_bufferSize:
+.. _dense_sytrf_bufferSize:
 
 hipsolverDn<type>sytrf_bufferSize()
 ---------------------------------------------------
@@ -102,7 +102,7 @@ hipsolverDn<type>sytrf_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSsytrf_bufferSize
 
-.. _compat_sytrf:
+.. _dense_sytrf:
 
 hipsolverDn<type>sytrf()
 ---------------------------------------------------
@@ -116,7 +116,7 @@ hipsolverDn<type>sytrf()
 
 
 
-.. _compat_orthogonal:
+.. _dense_orthogonal:
 
 Orthogonal factorizations
 ================================
@@ -125,7 +125,7 @@ Orthogonal factorizations
    :local:
    :backlinks: top
 
-.. _compat_geqrf_bufferSize:
+.. _dense_geqrf_bufferSize:
 
 hipsolverDn<type>geqrf_bufferSize()
 ---------------------------------------------------
@@ -137,7 +137,7 @@ hipsolverDn<type>geqrf_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSgeqrf_bufferSize
 
-.. _compat_geqrf:
+.. _dense_geqrf:
 
 hipsolverDn<type>geqrf()
 ---------------------------------------------------
@@ -151,7 +151,7 @@ hipsolverDn<type>geqrf()
 
 
 
-.. _compat_reductions:
+.. _dense_reductions:
 
 Problem and matrix reductions
 ================================
@@ -160,7 +160,7 @@ Problem and matrix reductions
    :local:
    :backlinks: top
 
-.. _compat_gebrd_bufferSize:
+.. _dense_gebrd_bufferSize:
 
 hipsolverDn<type>gebrd_bufferSize()
 ---------------------------------------------------
@@ -172,7 +172,7 @@ hipsolverDn<type>gebrd_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSgebrd_bufferSize
 
-.. _compat_gebrd:
+.. _dense_gebrd:
 
 hipsolverDn<type>gebrd()
 ---------------------------------------------------
@@ -184,7 +184,7 @@ hipsolverDn<type>gebrd()
    :outline:
 .. doxygenfunction:: hipsolverDnSgebrd
 
-.. _compat_sytrd_bufferSize:
+.. _dense_sytrd_bufferSize:
 
 hipsolverDn<type>sytrd_bufferSize()
 ---------------------------------------------------
@@ -192,7 +192,7 @@ hipsolverDn<type>sytrd_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSsytrd_bufferSize
 
-.. _compat_hetrd_bufferSize:
+.. _dense_hetrd_bufferSize:
 
 hipsolverDn<type>hetrd_bufferSize()
 ---------------------------------------------------
@@ -200,7 +200,7 @@ hipsolverDn<type>hetrd_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnChetrd_bufferSize
 
-.. _compat_sytrd:
+.. _dense_sytrd:
 
 hipsolverDn<type>sytrd()
 ---------------------------------------------------
@@ -208,7 +208,7 @@ hipsolverDn<type>sytrd()
    :outline:
 .. doxygenfunction:: hipsolverDnSsytrd
 
-.. _compat_hetrd:
+.. _dense_hetrd:
 
 hipsolverDn<type>hetrd()
 ---------------------------------------------------
@@ -218,7 +218,7 @@ hipsolverDn<type>hetrd()
 
 
 
-.. _compat_linears:
+.. _dense_linears:
 
 Linear-systems solvers
 ================================
@@ -227,7 +227,7 @@ Linear-systems solvers
    :local:
    :backlinks: top
 
-.. _compat_potri_bufferSize:
+.. _dense_potri_bufferSize:
 
 hipsolverDn<type>potri_bufferSize()
 ---------------------------------------------------
@@ -239,7 +239,7 @@ hipsolverDn<type>potri_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSpotri_bufferSize
 
-.. _compat_potri:
+.. _dense_potri:
 
 hipsolverDn<type>potri()
 ---------------------------------------------------
@@ -251,7 +251,7 @@ hipsolverDn<type>potri()
    :outline:
 .. doxygenfunction:: hipsolverDnSpotri
 
-.. _compat_potrs:
+.. _dense_potrs:
 
 hipsolverDn<type>potrs()
 ---------------------------------------------------
@@ -263,7 +263,7 @@ hipsolverDn<type>potrs()
    :outline:
 .. doxygenfunction:: hipsolverDnSpotrs
 
-.. _compat_potrs_batched:
+.. _dense_potrs_batched:
 
 hipsolverDn<type>potrsBatched()
 ---------------------------------------------------
@@ -275,7 +275,7 @@ hipsolverDn<type>potrsBatched()
    :outline:
 .. doxygenfunction:: hipsolverDnSpotrsBatched
 
-.. _compat_getrs:
+.. _dense_getrs:
 
 hipsolverDn<type>getrs()
 ---------------------------------------------------
@@ -287,7 +287,7 @@ hipsolverDn<type>getrs()
    :outline:
 .. doxygenfunction:: hipsolverDnSgetrs
 
-.. _compat_gesv_bufferSize:
+.. _dense_gesv_bufferSize:
 
 hipsolverDn<type><type>gesv_bufferSize()
 ---------------------------------------------------
@@ -299,7 +299,7 @@ hipsolverDn<type><type>gesv_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSSgesv_bufferSize
 
-.. _compat_gesv:
+.. _dense_gesv:
 
 hipsolverDn<type><type>gesv()
 ---------------------------------------------------
@@ -313,7 +313,7 @@ hipsolverDn<type><type>gesv()
 
 
 
-.. _compat_leastsqr:
+.. _dense_leastsqr:
 
 Least-squares solvers
 ================================
@@ -322,7 +322,7 @@ Least-squares solvers
    :local:
    :backlinks: top
 
-.. _compat_gels_bufferSize:
+.. _dense_gels_bufferSize:
 
 hipsolverDn<type><type>gels_bufferSize()
 ---------------------------------------------------
@@ -334,7 +334,7 @@ hipsolverDn<type><type>gels_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSSgels_bufferSize
 
-.. _compat_gels:
+.. _dense_gels:
 
 hipsolverDn<type><type>gels()
 ---------------------------------------------------
@@ -348,7 +348,7 @@ hipsolverDn<type><type>gels()
 
 
 
-.. _compat_eigens:
+.. _dense_eigens:
 
 Symmetric eigensolvers
 ================================
@@ -357,7 +357,7 @@ Symmetric eigensolvers
    :local:
    :backlinks: top
 
-.. _compat_syevd_bufferSize:
+.. _dense_syevd_bufferSize:
 
 hipsolverDn<type>syevd_bufferSize()
 ---------------------------------------------------
@@ -365,7 +365,7 @@ hipsolverDn<type>syevd_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSsyevd_bufferSize
 
-.. _compat_heevd_bufferSize:
+.. _dense_heevd_bufferSize:
 
 hipsolverDn<type>heevd_bufferSize()
 ---------------------------------------------------
@@ -373,7 +373,7 @@ hipsolverDn<type>heevd_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnCheevd_bufferSize
 
-.. _compat_syevd:
+.. _dense_syevd:
 
 hipsolverDn<type>syevd()
 ---------------------------------------------------
@@ -381,7 +381,7 @@ hipsolverDn<type>syevd()
    :outline:
 .. doxygenfunction:: hipsolverDnSsyevd
 
-.. _compat_heevd:
+.. _dense_heevd:
 
 hipsolverDn<type>heevd()
 ---------------------------------------------------
@@ -389,7 +389,7 @@ hipsolverDn<type>heevd()
    :outline:
 .. doxygenfunction:: hipsolverDnCheevd
 
-.. _compat_sygvd_bufferSize:
+.. _dense_sygvd_bufferSize:
 
 hipsolverDn<type>sygvd_bufferSize()
 ---------------------------------------------------
@@ -397,7 +397,7 @@ hipsolverDn<type>sygvd_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSsygvd_bufferSize
 
-.. _compat_hegvd_bufferSize:
+.. _dense_hegvd_bufferSize:
 
 hipsolverDn<type>hegvd_bufferSize()
 ---------------------------------------------------
@@ -405,7 +405,7 @@ hipsolverDn<type>hegvd_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnChegvd_bufferSize
 
-.. _compat_sygvd:
+.. _dense_sygvd:
 
 hipsolverDn<type>sygvd()
 ---------------------------------------------------
@@ -413,7 +413,7 @@ hipsolverDn<type>sygvd()
    :outline:
 .. doxygenfunction:: hipsolverDnSsygvd
 
-.. _compat_hegvd:
+.. _dense_hegvd:
 
 hipsolverDn<type>hegvd()
 ---------------------------------------------------
@@ -423,7 +423,7 @@ hipsolverDn<type>hegvd()
 
 
 
-.. _compat_svds:
+.. _dense_svds:
 
 Singular value decomposition
 ================================
@@ -432,7 +432,7 @@ Singular value decomposition
    :local:
    :backlinks: top
 
-.. _compat_gesvd_bufferSize:
+.. _dense_gesvd_bufferSize:
 
 hipsolverDn<type>gesvd_bufferSize()
 ---------------------------------------------------
@@ -444,7 +444,7 @@ hipsolverDn<type>gesvd_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSgesvd_bufferSize
 
-.. _compat_gesvd:
+.. _dense_gesvd:
 
 hipsolverDn<type>gesvd()
 ---------------------------------------------------

--- a/docs/reference/dense-api/lapacklike.rst
+++ b/docs/reference/dense-api/lapacklike.rst
@@ -2,7 +2,7 @@
   :description: hipSOLVER documentation and API reference library
   :keywords: hipSOLVER, rocSOLVER, ROCm, API, documentation
 
-.. _compat_lapacklike:
+.. _dense_lapacklike:
 
 ************************************
 Dense matrix LAPACK-like functions
@@ -10,12 +10,12 @@ Dense matrix LAPACK-like functions
 
 Other Lapack-like routines provided by hipSOLVER. These are divided into the following subcategories:
 
-* :ref:`compat_likeeigens`. Eigenproblems for symmetric matrices.
-* :ref:`compat_likesvds`. Singular values and related problems for general matrices.
+* :ref:`dense_likeeigens`. Eigenproblems for symmetric matrices.
+* :ref:`dense_likesvds`. Singular values and related problems for general matrices.
 
 
 
-.. _compat_likeeigens:
+.. _dense_likeeigens:
 
 Symmetric eigensolvers
 ================================
@@ -24,7 +24,7 @@ Symmetric eigensolvers
    :local:
    :backlinks: top
 
-.. _compat_syevdx_bufferSize:
+.. _dense_syevdx_bufferSize:
 
 hipsolverDn<type>syevdx_bufferSize()
 ---------------------------------------------------
@@ -32,7 +32,7 @@ hipsolverDn<type>syevdx_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSsyevdx_bufferSize
 
-.. _compat_heevdx_bufferSize:
+.. _dense_heevdx_bufferSize:
 
 hipsolverDn<type>heevdx_bufferSize()
 ---------------------------------------------------
@@ -40,7 +40,7 @@ hipsolverDn<type>heevdx_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnCheevdx_bufferSize
 
-.. _compat_syevdx:
+.. _dense_syevdx:
 
 hipsolverDn<type>syevdx()
 ---------------------------------------------------
@@ -48,7 +48,7 @@ hipsolverDn<type>syevdx()
    :outline:
 .. doxygenfunction:: hipsolverDnSsyevdx
 
-.. _compat_heevdx:
+.. _dense_heevdx:
 
 hipsolverDn<type>heevdx()
 ---------------------------------------------------
@@ -56,7 +56,7 @@ hipsolverDn<type>heevdx()
    :outline:
 .. doxygenfunction:: hipsolverDnCheevdx
 
-.. _compat_syevj_bufferSize:
+.. _dense_syevj_bufferSize:
 
 hipsolverDn<type>syevj_bufferSize()
 ---------------------------------------------------
@@ -64,7 +64,7 @@ hipsolverDn<type>syevj_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSsyevj_bufferSize
 
-.. _compat_heevj_bufferSize:
+.. _dense_heevj_bufferSize:
 
 hipsolverDn<type>heevj_bufferSize()
 ---------------------------------------------------
@@ -72,7 +72,7 @@ hipsolverDn<type>heevj_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnCheevj_bufferSize
 
-.. _compat_syevj_batched_bufferSize:
+.. _dense_syevj_batched_bufferSize:
 
 hipsolverDn<type>syevjBatched_bufferSize()
 ---------------------------------------------------
@@ -80,7 +80,7 @@ hipsolverDn<type>syevjBatched_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSsyevjBatched_bufferSize
 
-.. _compat_heevj_batched_bufferSize:
+.. _dense_heevj_batched_bufferSize:
 
 hipsolverDn<type>heevjBatched_bufferSize()
 ---------------------------------------------------
@@ -88,7 +88,7 @@ hipsolverDn<type>heevjBatched_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnCheevjBatched_bufferSize
 
-.. _compat_syevj:
+.. _dense_syevj:
 
 hipsolverDn<type>syevj()
 ---------------------------------------------------
@@ -96,7 +96,7 @@ hipsolverDn<type>syevj()
    :outline:
 .. doxygenfunction:: hipsolverDnSsyevj
 
-.. _compat_heevj:
+.. _dense_heevj:
 
 hipsolverDn<type>heevj()
 ---------------------------------------------------
@@ -104,7 +104,7 @@ hipsolverDn<type>heevj()
    :outline:
 .. doxygenfunction:: hipsolverDnCheevj
 
-.. _compat_syevj_batched:
+.. _dense_syevj_batched:
 
 hipsolverDn<type>syevjBatched()
 ---------------------------------------------------
@@ -112,7 +112,7 @@ hipsolverDn<type>syevjBatched()
    :outline:
 .. doxygenfunction:: hipsolverDnSsyevjBatched
 
-.. _compat_heevj_batched:
+.. _dense_heevj_batched:
 
 hipsolverDn<type>heevjBatched()
 ---------------------------------------------------
@@ -120,7 +120,7 @@ hipsolverDn<type>heevjBatched()
    :outline:
 .. doxygenfunction:: hipsolverDnCheevjBatched
 
-.. _compat_sygvdx_bufferSize:
+.. _dense_sygvdx_bufferSize:
 
 hipsolverDn<type>sygvdx_bufferSize()
 ---------------------------------------------------
@@ -128,7 +128,7 @@ hipsolverDn<type>sygvdx_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSsygvdx_bufferSize
 
-.. _compat_hegvdx_bufferSize:
+.. _dense_hegvdx_bufferSize:
 
 hipsolverDn<type>hegvdx_bufferSize()
 ---------------------------------------------------
@@ -136,7 +136,7 @@ hipsolverDn<type>hegvdx_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnChegvdx_bufferSize
 
-.. _compat_sygvdx:
+.. _dense_sygvdx:
 
 hipsolverDn<type>sygvdx()
 ---------------------------------------------------
@@ -144,7 +144,7 @@ hipsolverDn<type>sygvdx()
    :outline:
 .. doxygenfunction:: hipsolverDnSsygvdx
 
-.. _compat_hegvdx:
+.. _dense_hegvdx:
 
 hipsolverDn<type>hegvdx()
 ---------------------------------------------------
@@ -152,7 +152,7 @@ hipsolverDn<type>hegvdx()
    :outline:
 .. doxygenfunction:: hipsolverDnChegvdx
 
-.. _compat_sygvj_bufferSize:
+.. _dense_sygvj_bufferSize:
 
 hipsolverDn<type>sygvj_bufferSize()
 ---------------------------------------------------
@@ -160,7 +160,7 @@ hipsolverDn<type>sygvj_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSsygvj_bufferSize
 
-.. _compat_hegvj_bufferSize:
+.. _dense_hegvj_bufferSize:
 
 hipsolverDn<type>hegvj_bufferSize()
 ---------------------------------------------------
@@ -168,7 +168,7 @@ hipsolverDn<type>hegvj_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnChegvj_bufferSize
 
-.. _compat_sygvj:
+.. _dense_sygvj:
 
 hipsolverDn<type>sygvj()
 ---------------------------------------------------
@@ -176,7 +176,7 @@ hipsolverDn<type>sygvj()
    :outline:
 .. doxygenfunction:: hipsolverDnSsygvj
 
-.. _compat_hegvj:
+.. _dense_hegvj:
 
 hipsolverDn<type>hegvj()
 ---------------------------------------------------
@@ -186,7 +186,7 @@ hipsolverDn<type>hegvj()
 
 
 
-.. _compat_likesvds:
+.. _dense_likesvds:
 
 Singular value decomposition
 ================================
@@ -195,7 +195,7 @@ Singular value decomposition
    :local:
    :backlinks: top
 
-.. _compat_gesvdj_bufferSize:
+.. _dense_gesvdj_bufferSize:
 
 hipsolverDn<type>gesvdj_bufferSize()
 ---------------------------------------------------
@@ -207,7 +207,7 @@ hipsolverDn<type>gesvdj_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSgesvdj_bufferSize
 
-.. _compat_gesvdj_batched_bufferSize:
+.. _dense_gesvdj_batched_bufferSize:
 
 hipsolverDn<type>gesvdjBatched_bufferSize()
 ---------------------------------------------------
@@ -219,7 +219,7 @@ hipsolverDn<type>gesvdjBatched_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSgesvdjBatched_bufferSize
 
-.. _compat_gesvdj:
+.. _dense_gesvdj:
 
 hipsolverDn<type>gesvdj()
 ---------------------------------------------------
@@ -231,7 +231,7 @@ hipsolverDn<type>gesvdj()
    :outline:
 .. doxygenfunction:: hipsolverDnSgesvdj
 
-.. _compat_gesvdj_batched:
+.. _dense_gesvdj_batched:
 
 hipsolverDn<type>gesvdjBatched()
 ---------------------------------------------------
@@ -243,7 +243,7 @@ hipsolverDn<type>gesvdjBatched()
    :outline:
 .. doxygenfunction:: hipsolverDnSgesvdjBatched
 
-.. _compat_gesvda_strided_batched_bufferSize:
+.. _dense_gesvda_strided_batched_bufferSize:
 
 hipsolverDn<type>gesvdaStridedBatched_bufferSize()
 ---------------------------------------------------
@@ -255,7 +255,7 @@ hipsolverDn<type>gesvdaStridedBatched_bufferSize()
    :outline:
 .. doxygenfunction:: hipsolverDnSgesvdaStridedBatched_bufferSize
 
-.. _compat_gesvda_strided_batched:
+.. _dense_gesvda_strided_batched:
 
 hipsolverDn<type>gesvdaStridedBatched()
 ---------------------------------------------------

--- a/docs/reference/dense-api/types.rst
+++ b/docs/reference/dense-api/types.rst
@@ -2,7 +2,7 @@
   :description: hipSOLVER documentation and API reference library
   :keywords: hipSOLVER, rocSOLVER, ROCm, API, documentation
 
-.. _compat_types:
+.. _dense_types:
 
 ********************************************************************
 Dense matrix datatypes

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -8,11 +8,11 @@
 Reference
 ********************************************************************
 
-This section provides technical descriptions and important information about 
+This section provides technical descriptions and important information about
 the different hipSOLVER APIs and library components.
 
 * :ref:`api-intro`
 * :ref:`library_api`
-* :ref:`library_compat` 
-* :ref:`library_sparse` 
-* :ref:`library_refactor` 
+* :ref:`library_dense`
+* :ref:`library_sparse`
+* :ref:`library_refactor`

--- a/docs/reference/intro.rst
+++ b/docs/reference/intro.rst
@@ -8,7 +8,7 @@
 Introduction to hipSOLVER API
 *******************************
 
-.. note:: 
+.. note::
     The hipSOLVER library remains in active development. New features are being continuously added, with new functionality documented at each release of the ROCm platform.
 
 The following tables summarize the wrapper functions that are implemented in the regular API for the different supported precisions in
@@ -136,10 +136,10 @@ LAPACK-like functions
 .. csv-table:: Singular value decomposition
     :header: "Function", "single", "double", "single complex", "double complex"
 
-    :ref:`hipsolverDnXgesvdj_bufferSize <compat_gesvdj_bufferSize>`, x, x, x, x
-    :ref:`hipsolverDnXgesvdj <compat_gesvdj>`, x, x, x, x
-    :ref:`hipsolverDnXgesvdjBatched_bufferSize <compat_gesvdj_batched_bufferSize>`, x, x, x, x
-    :ref:`hipsolverDnXgesvdjBatched <compat_gesvdj_batched>`, x, x, x, x
+    :ref:`hipsolverDnXgesvdj_bufferSize <dense_gesvdj_bufferSize>`, x, x, x, x
+    :ref:`hipsolverDnXgesvdj <dense_gesvdj>`, x, x, x, x
+    :ref:`hipsolverDnXgesvdjBatched_bufferSize <dense_gesvdj_batched_bufferSize>`, x, x, x, x
+    :ref:`hipsolverDnXgesvdjBatched <dense_gesvdj_batched>`, x, x, x, x
 
 
 Compatibility-only functions
@@ -158,14 +158,14 @@ Partial eigensolvers have been implemented in rocSOLVER, but at present they do 
 .. csv-table:: Symmetric eigensolvers
     :header: "Function", "single", "double", "single complex", "double complex"
 
-    :ref:`hipsolverDnXsyevdx_bufferSize <compat_syevdx_bufferSize>`, x, x, ,
-    :ref:`hipsolverDnXsyevdx <compat_syevdx>`, x, x, ,
-    :ref:`hipsolverDnXsygvdx_bufferSize <compat_sygvdx_bufferSize>`, x, x, ,
-    :ref:`hipsolverDnXsygvdx <compat_sygvdx>`, x, x, ,
-    :ref:`hipsolverDnXheevdx_bufferSize <compat_heevdx_bufferSize>`, , , x, x
-    :ref:`hipsolverDnXheevdx <compat_heevdx>`, , , x, x
-    :ref:`hipsolverDnXhegvdx_bufferSize <compat_hegvdx_bufferSize>`, , , x, x
-    :ref:`hipsolverDnXhegvdx <compat_hegvdx>`, , , x, x
+    :ref:`hipsolverDnXsyevdx_bufferSize <dense_syevdx_bufferSize>`, x, x, ,
+    :ref:`hipsolverDnXsyevdx <dense_syevdx>`, x, x, ,
+    :ref:`hipsolverDnXsygvdx_bufferSize <dense_sygvdx_bufferSize>`, x, x, ,
+    :ref:`hipsolverDnXsygvdx <dense_sygvdx>`, x, x, ,
+    :ref:`hipsolverDnXheevdx_bufferSize <dense_heevdx_bufferSize>`, , , x, x
+    :ref:`hipsolverDnXheevdx <dense_heevdx>`, , , x, x
+    :ref:`hipsolverDnXhegvdx_bufferSize <dense_hegvdx_bufferSize>`, , , x, x
+    :ref:`hipsolverDnXhegvdx <dense_hegvdx>`, , , x, x
 
 Partial SVD functions
 ------------------------------
@@ -175,15 +175,15 @@ Partial SVD has been implemented in rocSOLVER, but at present it does not use an
 .. csv-table:: Singular value decomposition
     :header: "Function", "single", "double", "single complex", "double complex"
 
-    :ref:`hipsolverDnXgesvdaStridedBatched_bufferSize <compat_gesvda_strided_batched_bufferSize>`, x, x, x, x
-    :ref:`hipsolverDnXgesvdaStridedBatched <compat_gesvda_strided_batched>`, x, x, x, x
+    :ref:`hipsolverDnXgesvdaStridedBatched_bufferSize <dense_gesvda_strided_batched_bufferSize>`, x, x, x, x
+    :ref:`hipsolverDnXgesvdaStridedBatched <dense_gesvda_strided_batched>`, x, x, x, x
 
 Sparse matrix routines
 ------------------------------
 
 Sparse matrix routines and direct solvers for sparse matrices are in the very earliest stages of development.
-Due to unsupported backend functionality, there are a number of intricacies and possible performance implications 
-that users will want to be aware of when using these routines. 
+Due to unsupported backend functionality, there are a number of intricacies and possible performance implications
+that users will want to be aware of when using these routines.
 Refer to the :ref:`hipsolverSp compatibility API <library_sparse>` for more details and a full listing of supported functions.
 
 .. csv-table:: Combined factorization and linear-system solvers

--- a/docs/run_doxygen.sh
+++ b/docs/run_doxygen.sh
@@ -7,5 +7,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # Build the doxygen info
 rm -rf docBin
-cd .doxygen
+cd doxygen
 doxygen Doxyfile

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -7,7 +7,7 @@ entries:
   - file: installation/install.rst
 - file: howto/index.rst
   entries:
-  - file: howto/usage.rst      
+  - file: howto/usage.rst
 - file: reference/index.rst
   entries:
   - file: reference/intro.rst
@@ -18,13 +18,13 @@ entries:
     - file: reference/api/auxiliary.rst
     - file: reference/api/lapack.rst
     - file: reference/api/lapacklike.rst
-  - file: reference/compat-api/index.rst
+  - file: reference/dense-api/index.rst
     entries:
-    - file: reference/compat-api/types.rst
-    - file: reference/compat-api/helpers.rst
-    - file: reference/compat-api/auxiliary.rst
-    - file: reference/compat-api/lapack.rst
-    - file: reference/compat-api/lapacklike.rst
+    - file: reference/dense-api/types.rst
+    - file: reference/dense-api/helpers.rst
+    - file: reference/dense-api/auxiliary.rst
+    - file: reference/dense-api/lapack.rst
+    - file: reference/dense-api/lapacklike.rst
   - file: reference/sparse-api/index.rst
     entries:
     - file: reference/sparse-api/types.rst

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -60,6 +60,7 @@ set( hipsolver_headers_public
   include/hipsolver.h
   include/internal/hipsolver-types.h
   include/internal/hipsolver-functions.h
+  include/internal/hipsolver-compat.h
   include/internal/hipsolver-dense.h
   include/internal/hipsolver-refactor.h
   include/internal/hipsolver-sparse.h

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -60,8 +60,9 @@ set( hipsolver_headers_public
   include/hipsolver.h
   include/internal/hipsolver-types.h
   include/internal/hipsolver-functions.h
-  include/internal/hipsolver-compat.h
+  include/internal/hipsolver-dense.h
   include/internal/hipsolver-refactor.h
+  include/internal/hipsolver-sparse.h
   ${PROJECT_BINARY_DIR}/include/hipsolver/internal/hipsolver-version.h
 )
 

--- a/library/include/hipsolver.h
+++ b/library/include/hipsolver.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 // HIP = Heterogeneous-compute Interface for Portability
@@ -27,7 +27,7 @@
 /* Defines functions with the hipsolverDn prefix. APIs match those from cuSOLVER but may
  * result in degraded rocSOLVER performance.
  */
-#include "internal/hipsolver-compat.h"
+#include "internal/hipsolver-dense.h"
 
 /* Defines functions and types with the hipsolverRf prefix. APIs match those from cuSOLVER.
  */

--- a/library/include/internal/hipsolver-compat.h
+++ b/library/include/internal/hipsolver-compat.h
@@ -2,7 +2,8 @@
  * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
-#pragma once
+#ifndef HIPSOLVER_COMPAT_H
+#define HIPSOLVER_COMPAT_H
 
 #if defined(_MSC_VER)
 #pragma message(": warning: This file is deprecated. Use hipsolver-dense.h instead.")
@@ -11,3 +12,5 @@
 #endif
 
 #include "hipsolver-dense.h"
+
+#endif // HIPSOLVER_COMPAT_H

--- a/library/include/internal/hipsolver-compat.h
+++ b/library/include/internal/hipsolver-compat.h
@@ -1,0 +1,13 @@
+/* ************************************************************************
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+
+#if defined(_MSC_VER)
+#pragma message(": warning: This file is deprecated. Use hipsolver-dense.h instead.")
+#elif defined(__GNUC__)
+#warning "This file is deprecated. Use hipsolver-dense.h instead."
+#endif
+
+#include "hipsolver-dense.h"

--- a/library/include/internal/hipsolver-dense.h
+++ b/library/include/internal/hipsolver-dense.h
@@ -3,15 +3,15 @@
  * ************************************************************************ */
 
 /*! \file
- *  \brief hipsolver-compat.h provides a compatibility API for users of
+ *  \brief hipsolver-dense.h provides a compatibility API for users of
  *  cuSOLVER wishing to transition to hipSOLVER. Functions in this file
  *  have parameter lists matching those of cuSOLVER, but may suffer from
  *  performance issues when using the rocSOLVER backend. Switching to the
  *  use of functions from hipsolver-functions.h is recommended.
  */
 
-#ifndef HIPSOLVER_COMPAT_H
-#define HIPSOLVER_COMPAT_H
+#ifndef HIPSOLVER_DENSE_H
+#define HIPSOLVER_DENSE_H
 
 #include "hipsolver-types.h"
 
@@ -2672,4 +2672,4 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverDnZsytrf(hipsolverHandle_t handle,
 }
 #endif
 
-#endif // HIPSOLVER_COMPAT_H
+#endif // HIPSOLVER_DENSE_H

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -44,19 +44,19 @@ if( NOT USE_CUDA )
   set( hipsolver_source
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_conversions.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_compat.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_dense.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_refactor.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_sparse.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/common/hipsolver_compat_common.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/common/hipsolver_dense_common.cpp"
   )
 else( )
   set( hipsolver_source
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_conversions.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_compat.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_dense.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_refactor.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_sparse.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/common/hipsolver_compat_common.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/common/hipsolver_dense_common.cpp"
   )
 endif( )
 

--- a/library/src/amd_detail/hipsolver_dense.cpp
+++ b/library/src/amd_detail/hipsolver_dense.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/library/src/common/hipsolver_dense_common.cpp
+++ b/library/src/common/hipsolver_dense_common.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,7 @@
  * ************************************************************************ */
 
 /*! \file
- *  \brief hipsolver_compat_common.cpp provides implementations of the compatibility APIs
+ *  \brief hipsolver_dense_common.cpp provides implementations of the compatibility APIs
  *  that are equivalent for both cuSOLVER and rocSOLVER. These simply call hipSOLVER's
  *  regular APIs.
  */

--- a/library/src/nvidia_detail/hipsolver_dense.cpp
+++ b/library/src/nvidia_detail/hipsolver_dense.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
To ensure better consistency with the newest compatibility APIs, I'm renaming hipsolver-compat to hipsolver-dense. The header hipsolver-compat.h is now deprecated and will be removed in a later release.

This PR also ports the changes from https://github.com/ROCm/rocSOLVER/pull/671 to hipSOLVER.