### PR TITLE
All tests now use testAPI_t

### DIFF
--- a/clients/gtest/gebrd_gtest.cpp
+++ b/clients/gtest/gebrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -83,7 +83,7 @@ Arguments gebrd_setup_arguments(gebrd_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class GEBRD_BASE : public ::TestWithParam<gebrd_tuple>
 {
 protected:
@@ -97,18 +97,18 @@ protected:
         Arguments arg = gebrd_setup_arguments(GetParam());
 
         if(arg.peek<rocblas_int>("m") == -1 && arg.peek<rocblas_int>("n") == -1)
-            testing_gebrd_bad_arg<FORTRAN, BATCHED, STRIDED, T>();
+            testing_gebrd_bad_arg<API, BATCHED, STRIDED, T>();
 
         arg.batch_count = 1;
-        testing_gebrd<FORTRAN, BATCHED, STRIDED, T>(arg);
+        testing_gebrd<API, BATCHED, STRIDED, T>(arg);
     }
 };
 
-class GEBRD : public GEBRD_BASE<false>
+class GEBRD : public GEBRD_BASE<API_NORMAL>
 {
 };
 
-class GEBRD_FORTRAN : public GEBRD_BASE<true>
+class GEBRD_FORTRAN : public GEBRD_BASE<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/geqrf_gtest.cpp
+++ b/clients/gtest/geqrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -83,7 +83,7 @@ Arguments geqrf_setup_arguments(geqrf_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class GEQRF_BASE : public ::TestWithParam<geqrf_tuple>
 {
 protected:
@@ -97,18 +97,18 @@ protected:
         Arguments arg = geqrf_setup_arguments(GetParam());
 
         if(arg.peek<rocblas_int>("m") == -1 && arg.peek<rocblas_int>("n") == -1)
-            testing_geqrf_bad_arg<FORTRAN, BATCHED, STRIDED, T>();
+            testing_geqrf_bad_arg<API, BATCHED, STRIDED, T>();
 
         arg.batch_count = 1;
-        testing_geqrf<FORTRAN, BATCHED, STRIDED, T>(arg);
+        testing_geqrf<API, BATCHED, STRIDED, T>(arg);
     }
 };
 
-class GEQRF : public GEQRF_BASE<false>
+class GEQRF : public GEQRF_BASE<API_NORMAL>
 {
 };
 
-class GEQRF_FORTRAN : public GEQRF_BASE<true>
+class GEQRF_FORTRAN : public GEQRF_BASE<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/orgbr_ungbr_gtest.cpp
+++ b/clients/gtest/orgbr_ungbr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -99,7 +99,7 @@ Arguments orgbr_setup_arguments(orgbr_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class ORGBR_UNGBR : public ::TestWithParam<orgbr_tuple>
 {
 protected:
@@ -114,25 +114,25 @@ protected:
 
         if(arg.peek<rocblas_int>("m") == -1 && arg.peek<rocblas_int>("n") == 1
            && arg.get<char>("side") == 'L')
-            testing_orgbr_ungbr_bad_arg<FORTRAN, T>();
+            testing_orgbr_ungbr_bad_arg<API, T>();
 
-        testing_orgbr_ungbr<FORTRAN, T>(arg);
+        testing_orgbr_ungbr<API, T>(arg);
     }
 };
 
-class ORGBR : public ORGBR_UNGBR<false>
+class ORGBR : public ORGBR_UNGBR<API_NORMAL>
 {
 };
 
-class UNGBR : public ORGBR_UNGBR<false>
+class UNGBR : public ORGBR_UNGBR<API_NORMAL>
 {
 };
 
-class ORGBR_FORTRAN : public ORGBR_UNGBR<true>
+class ORGBR_FORTRAN : public ORGBR_UNGBR<API_FORTRAN>
 {
 };
 
-class UNGBR_FORTRAN : public ORGBR_UNGBR<true>
+class UNGBR_FORTRAN : public ORGBR_UNGBR<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/orgqr_ungqr_gtest.cpp
+++ b/clients/gtest/orgqr_ungqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -85,7 +85,7 @@ Arguments orgqr_setup_arguments(orgqr_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class ORGQR_UNGQR : public ::TestWithParam<orgqr_tuple>
 {
 protected:
@@ -99,25 +99,25 @@ protected:
         Arguments arg = orgqr_setup_arguments(GetParam());
 
         if(arg.peek<rocblas_int>("m") == -1 && arg.peek<rocblas_int>("n") == -1)
-            testing_orgqr_ungqr_bad_arg<FORTRAN, T>();
+            testing_orgqr_ungqr_bad_arg<API, T>();
 
-        testing_orgqr_ungqr<FORTRAN, T>(arg);
+        testing_orgqr_ungqr<API, T>(arg);
     }
 };
 
-class ORGQR : public ORGQR_UNGQR<false>
+class ORGQR : public ORGQR_UNGQR<API_NORMAL>
 {
 };
 
-class UNGQR : public ORGQR_UNGQR<false>
+class UNGQR : public ORGQR_UNGQR<API_NORMAL>
 {
 };
 
-class ORGQR_FORTRAN : public ORGQR_UNGQR<true>
+class ORGQR_FORTRAN : public ORGQR_UNGQR<API_FORTRAN>
 {
 };
 
-class UNGQR_FORTRAN : public ORGQR_UNGQR<true>
+class UNGQR_FORTRAN : public ORGQR_UNGQR<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/orgtr_ungtr_gtest.cpp
+++ b/clients/gtest/orgtr_ungtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -69,7 +69,7 @@ Arguments orgtr_setup_arguments(orgtr_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class ORGTR_UNGTR : public ::TestWithParam<orgtr_tuple>
 {
 protected:
@@ -83,25 +83,25 @@ protected:
         Arguments arg = orgtr_setup_arguments(GetParam());
 
         if(arg.peek<rocblas_int>("n") == -1 && arg.peek<char>("uplo") == 'U')
-            testing_orgtr_ungtr_bad_arg<FORTRAN, T>();
+            testing_orgtr_ungtr_bad_arg<API, T>();
 
-        testing_orgtr_ungtr<FORTRAN, T>(arg);
+        testing_orgtr_ungtr<API, T>(arg);
     }
 };
 
-class ORGTR : public ORGTR_UNGTR<false>
+class ORGTR : public ORGTR_UNGTR<API_NORMAL>
 {
 };
 
-class UNGTR : public ORGTR_UNGTR<false>
+class UNGTR : public ORGTR_UNGTR<API_NORMAL>
 {
 };
 
-class ORGTR_FORTRAN : public ORGTR_UNGTR<true>
+class ORGTR_FORTRAN : public ORGTR_UNGTR<API_FORTRAN>
 {
 };
 
-class UNGTR_FORTRAN : public ORGTR_UNGTR<true>
+class UNGTR_FORTRAN : public ORGTR_UNGTR<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/ormqr_unmqr_gtest.cpp
+++ b/clients/gtest/ormqr_unmqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -108,7 +108,7 @@ Arguments ormqr_setup_arguments(ormqr_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class ORMQR_UNMQR : public ::TestWithParam<ormqr_tuple>
 {
 protected:
@@ -123,25 +123,25 @@ protected:
 
         if(arg.peek<rocblas_int>("m") == -1 && arg.peek<char>("side") == 'L'
            && arg.peek<char>("trans") == 'T')
-            testing_ormqr_unmqr_bad_arg<FORTRAN, T>();
+            testing_ormqr_unmqr_bad_arg<API, T>();
 
-        testing_ormqr_unmqr<FORTRAN, T>(arg);
+        testing_ormqr_unmqr<API, T>(arg);
     }
 };
 
-class ORMQR : public ORMQR_UNMQR<false>
+class ORMQR : public ORMQR_UNMQR<API_NORMAL>
 {
 };
 
-class UNMQR : public ORMQR_UNMQR<false>
+class UNMQR : public ORMQR_UNMQR<API_NORMAL>
 {
 };
 
-class ORMQR_FORTRAN : public ORMQR_UNMQR<true>
+class ORMQR_FORTRAN : public ORMQR_UNMQR<API_FORTRAN>
 {
 };
 
-class UNMQR_FORTRAN : public ORMQR_UNMQR<true>
+class UNMQR_FORTRAN : public ORMQR_UNMQR<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/ormtr_unmtr_gtest.cpp
+++ b/clients/gtest/ormtr_unmtr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -120,7 +120,7 @@ Arguments ormtr_setup_arguments(ormtr_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class ORMTR_UNMTR : public ::TestWithParam<ormtr_tuple>
 {
 protected:
@@ -136,25 +136,25 @@ protected:
         if(arg.peek<rocblas_int>("m") == -1 && arg.peek<rocblas_int>("n") == 1
            && arg.peek<char>("side") == 'L' && arg.peek<char>("trans") == 'T'
            && arg.peek<char>("uplo") == 'U')
-            testing_ormtr_unmtr_bad_arg<FORTRAN, T>();
+            testing_ormtr_unmtr_bad_arg<API, T>();
 
-        testing_ormtr_unmtr<FORTRAN, T>(arg);
+        testing_ormtr_unmtr<API, T>(arg);
     }
 };
 
-class ORMTR : public ORMTR_UNMTR<false>
+class ORMTR : public ORMTR_UNMTR<API_NORMAL>
 {
 };
 
-class UNMTR : public ORMTR_UNMTR<false>
+class UNMTR : public ORMTR_UNMTR<API_NORMAL>
 {
 };
 
-class ORMTR_FORTRAN : public ORMTR_UNMTR<true>
+class ORMTR_FORTRAN : public ORMTR_UNMTR<API_FORTRAN>
 {
 };
 
-class UNMTR_FORTRAN : public ORMTR_UNMTR<true>
+class UNMTR_FORTRAN : public ORMTR_UNMTR<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/potri_gtest.cpp
+++ b/clients/gtest/potri_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -74,7 +74,7 @@ Arguments potri_setup_arguments(potri_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class POTRI_BASE : public ::TestWithParam<potri_tuple>
 {
 protected:
@@ -88,18 +88,18 @@ protected:
         Arguments arg = potri_setup_arguments(GetParam());
 
         if(arg.peek<char>("uplo") == 'L' && arg.peek<rocblas_int>("n") == -1)
-            testing_potri_bad_arg<FORTRAN, BATCHED, STRIDED, T>();
+            testing_potri_bad_arg<API, BATCHED, STRIDED, T>();
 
         arg.batch_count = 1;
-        testing_potri<FORTRAN, BATCHED, STRIDED, T>(arg);
+        testing_potri<API, BATCHED, STRIDED, T>(arg);
     }
 };
 
-class POTRI : public POTRI_BASE<false>
+class POTRI : public POTRI_BASE<API_NORMAL>
 {
 };
 
-class POTRI_FORTRAN : public POTRI_BASE<true>
+class POTRI_FORTRAN : public POTRI_BASE<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/syevd_heevd_gtest.cpp
+++ b/clients/gtest/syevd_heevd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -75,7 +75,7 @@ Arguments syevd_heevd_setup_arguments(syevd_heevd_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class SYEVD_HEEVD : public ::TestWithParam<syevd_heevd_tuple>
 {
 protected:
@@ -90,26 +90,26 @@ protected:
 
         if(arg.peek<rocblas_int>("n") == -1 && arg.peek<char>("jobz") == 'N'
            && arg.peek<char>("uplo") == 'L')
-            testing_syevd_heevd_bad_arg<FORTRAN, BATCHED, STRIDED, T>();
+            testing_syevd_heevd_bad_arg<API, BATCHED, STRIDED, T>();
 
         arg.batch_count = 1;
-        testing_syevd_heevd<FORTRAN, BATCHED, STRIDED, T>(arg);
+        testing_syevd_heevd<API, BATCHED, STRIDED, T>(arg);
     }
 };
 
-class SYEVD : public SYEVD_HEEVD<false>
+class SYEVD : public SYEVD_HEEVD<API_NORMAL>
 {
 };
 
-class HEEVD : public SYEVD_HEEVD<false>
+class HEEVD : public SYEVD_HEEVD<API_NORMAL>
 {
 };
 
-class SYEVD_FORTRAN : public SYEVD_HEEVD<true>
+class SYEVD_FORTRAN : public SYEVD_HEEVD<API_FORTRAN>
 {
 };
 
-class HEEVD_FORTRAN : public SYEVD_HEEVD<true>
+class HEEVD_FORTRAN : public SYEVD_HEEVD<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/sygvd_hegvd_gtest.cpp
+++ b/clients/gtest/sygvd_hegvd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -84,7 +84,7 @@ Arguments sygvd_setup_arguments(sygvd_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class SYGVD_HEGVD : public ::TestWithParam<sygvd_tuple>
 {
 protected:
@@ -99,26 +99,26 @@ protected:
 
         if(arg.peek<char>("itype") == '1' && arg.peek<char>("jobz") == 'N'
            && arg.peek<char>("uplo") == 'U' && arg.peek<rocblas_int>("n") == -1)
-            testing_sygvd_hegvd_bad_arg<FORTRAN, BATCHED, STRIDED, T>();
+            testing_sygvd_hegvd_bad_arg<API, BATCHED, STRIDED, T>();
 
         arg.batch_count = 1;
-        testing_sygvd_hegvd<FORTRAN, BATCHED, STRIDED, T>(arg);
+        testing_sygvd_hegvd<API, BATCHED, STRIDED, T>(arg);
     }
 };
 
-class SYGVD : public SYGVD_HEGVD<false>
+class SYGVD : public SYGVD_HEGVD<API_NORMAL>
 {
 };
 
-class HEGVD : public SYGVD_HEGVD<false>
+class HEGVD : public SYGVD_HEGVD<API_NORMAL>
 {
 };
 
-class SYGVD_FORTRAN : public SYGVD_HEGVD<true>
+class SYGVD_FORTRAN : public SYGVD_HEGVD<API_FORTRAN>
 {
 };
 
-class HEGVD_FORTRAN : public SYGVD_HEGVD<true>
+class HEGVD_FORTRAN : public SYGVD_HEGVD<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/sytrd_hetrd_gtest.cpp
+++ b/clients/gtest/sytrd_hetrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -75,7 +75,7 @@ Arguments sytrd_setup_arguments(sytrd_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class SYTRD_HETRD : public ::TestWithParam<sytrd_tuple>
 {
 protected:
@@ -89,26 +89,26 @@ protected:
         Arguments arg = sytrd_setup_arguments(GetParam());
 
         if(arg.peek<char>("uplo") == 'U' && arg.peek<rocblas_int>("n") == -1)
-            testing_sytrd_hetrd_bad_arg<FORTRAN, BATCHED, STRIDED, T>();
+            testing_sytrd_hetrd_bad_arg<API, BATCHED, STRIDED, T>();
 
         arg.batch_count = 1;
-        testing_sytrd_hetrd<FORTRAN, BATCHED, STRIDED, T>(arg);
+        testing_sytrd_hetrd<API, BATCHED, STRIDED, T>(arg);
     }
 };
 
-class SYTRD : public SYTRD_HETRD<false>
+class SYTRD : public SYTRD_HETRD<API_NORMAL>
 {
 };
 
-class HETRD : public SYTRD_HETRD<false>
+class HETRD : public SYTRD_HETRD<API_NORMAL>
 {
 };
 
-class SYTRD_FORTRAN : public SYTRD_HETRD<true>
+class SYTRD_FORTRAN : public SYTRD_HETRD<API_FORTRAN>
 {
 };
 
-class HETRD_FORTRAN : public SYTRD_HETRD<true>
+class HETRD_FORTRAN : public SYTRD_HETRD<API_FORTRAN>
 {
 };
 

--- a/clients/gtest/sytrf_gtest.cpp
+++ b/clients/gtest/sytrf_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -78,7 +78,7 @@ Arguments sytrf_setup_arguments(sytrf_tuple tup)
     return arg;
 }
 
-template <bool FORTRAN>
+template <testAPI_t API>
 class SYTRF_BASE : public ::TestWithParam<sytrf_tuple>
 {
 protected:
@@ -92,18 +92,18 @@ protected:
         Arguments arg = sytrf_setup_arguments(GetParam());
 
         if(arg.peek<char>("uplo") == 'L' && arg.peek<rocblas_int>("n") == -1)
-            testing_sytrf_bad_arg<FORTRAN, BATCHED, STRIDED, T>();
+            testing_sytrf_bad_arg<API, BATCHED, STRIDED, T>();
 
         arg.batch_count = 1;
-        testing_sytrf<FORTRAN, BATCHED, STRIDED, T>(arg);
+        testing_sytrf<API, BATCHED, STRIDED, T>(arg);
     }
 };
 
-class SYTRF : public SYTRF_BASE<false>
+class SYTRF : public SYTRF_BASE<API_NORMAL>
 {
 };
 
-class SYTRF_FORTRAN : public SYTRF_BASE<true>
+class SYTRF_FORTRAN : public SYTRF_BASE<API_FORTRAN>
 {
 };
 

--- a/clients/include/hipsolver.hpp
+++ b/clients/include/hipsolver.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -89,7 +89,7 @@ inline testMarshal_t api2marshal(testAPI_t API, bool ALT)
 
 /******************** ORGBR/UNGBR ********************/
 // normal and strided_batched
-inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverSideMode_t side,
                                                           int                 m,
@@ -100,13 +100,18 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                FO
                                                           float*              tau,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSorgbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSorgbr_bufferSizeFortran(handle, side, m, n, k, A, lda, tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverSideMode_t side,
                                                           int                 m,
@@ -117,13 +122,18 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                FO
                                                           double*             tau,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDorgbr_bufferSize(handle, side, m, n, k, A, lda, tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDorgbr_bufferSizeFortran(handle, side, m, n, k, A, lda, tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverSideMode_t side,
                                                           int                 m,
@@ -134,15 +144,20 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                FO
                                                           hipsolverComplex*   tau,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCungbr_bufferSize(
             handle, side, m, n, k, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCungbr_bufferSizeFortran(
             handle, side, m, n, k, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(testAPI_t               API,
                                                           hipsolverHandle_t       handle,
                                                           hipsolverSideMode_t     side,
                                                           int                     m,
@@ -153,15 +168,20 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr_bufferSize(bool                  
                                                           hipsolverDoubleComplex* tau,
                                                           int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZungbr_bufferSize(
             handle, side, m, n, k, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZungbr_bufferSizeFortran(
             handle, side, m, n, k, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgbr_ungbr(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverSideMode_t side,
                                                int                 m,
@@ -174,13 +194,18 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
                                                int                 lwork,
                                                int*                info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSorgbr(handle, side, m, n, k, A, lda, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSorgbrFortran(handle, side, m, n, k, A, lda, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgbr_ungbr(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverSideMode_t side,
                                                int                 m,
@@ -193,13 +218,18 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
                                                int                 lwork,
                                                int*                info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDorgbr(handle, side, m, n, k, A, lda, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDorgbrFortran(handle, side, m, n, k, A, lda, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgbr_ungbr(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverSideMode_t side,
                                                int                 m,
@@ -212,7 +242,9 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
                                                int                 lwork,
                                                int*                info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCungbr(handle,
                                side,
                                m,
@@ -224,7 +256,7 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverCungbrFortran(handle,
                                       side,
                                       m,
@@ -236,9 +268,12 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_orgbr_ungbr(testAPI_t               API,
                                                hipsolverHandle_t       handle,
                                                hipsolverSideMode_t     side,
                                                int                     m,
@@ -251,7 +286,9 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                    FORTRAN,
                                                int                     lwork,
                                                int*                    info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZungbr(handle,
                                side,
                                m,
@@ -263,7 +300,7 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZungbrFortran(handle,
                                       side,
                                       m,
@@ -275,12 +312,15 @@ inline hipsolverStatus_t hipsolver_orgbr_ungbr(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
 /******************** ORGQR/UNGQR ********************/
 // normal and strided_batched
-inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(testAPI_t         API,
                                                           hipsolverHandle_t handle,
                                                           int               m,
                                                           int               n,
@@ -290,13 +330,18 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool              FORT
                                                           float*            tau,
                                                           int*              lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSorgqr_bufferSize(handle, m, n, k, A, lda, tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSorgqr_bufferSizeFortran(handle, m, n, k, A, lda, tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(testAPI_t         API,
                                                           hipsolverHandle_t handle,
                                                           int               m,
                                                           int               n,
@@ -306,13 +351,18 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool              FORT
                                                           double*           tau,
                                                           int*              lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDorgqr_bufferSize(handle, m, n, k, A, lda, tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDorgqr_bufferSizeFortran(handle, m, n, k, A, lda, tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(testAPI_t         API,
                                                           hipsolverHandle_t handle,
                                                           int               m,
                                                           int               n,
@@ -322,15 +372,20 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool              FORT
                                                           hipsolverComplex* tau,
                                                           int*              lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCungqr_bufferSize(
             handle, m, n, k, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCungqr_bufferSizeFortran(
             handle, m, n, k, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(testAPI_t               API,
                                                           hipsolverHandle_t       handle,
                                                           int                     m,
                                                           int                     n,
@@ -340,15 +395,20 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr_bufferSize(bool                  
                                                           hipsolverDoubleComplex* tau,
                                                           int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZungqr_bufferSize(
             handle, m, n, k, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZungqr_bufferSizeFortran(
             handle, m, n, k, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_orgqr_ungqr(testAPI_t         API,
                                                hipsolverHandle_t handle,
                                                int               m,
                                                int               n,
@@ -360,13 +420,18 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
                                                int               lwork,
                                                int*              info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSorgqr(handle, m, n, k, A, lda, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSorgqrFortran(handle, m, n, k, A, lda, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_orgqr_ungqr(testAPI_t         API,
                                                hipsolverHandle_t handle,
                                                int               m,
                                                int               n,
@@ -378,13 +443,18 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
                                                int               lwork,
                                                int*              info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDorgqr(handle, m, n, k, A, lda, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDorgqrFortran(handle, m, n, k, A, lda, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_orgqr_ungqr(testAPI_t         API,
                                                hipsolverHandle_t handle,
                                                int               m,
                                                int               n,
@@ -396,7 +466,9 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
                                                int               lwork,
                                                int*              info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCungqr(handle,
                                m,
                                n,
@@ -407,7 +479,7 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverCungqrFortran(handle,
                                       m,
                                       n,
@@ -418,9 +490,12 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool              FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_orgqr_ungqr(testAPI_t               API,
                                                hipsolverHandle_t       handle,
                                                int                     m,
                                                int                     n,
@@ -432,7 +507,9 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool                    FORTRAN,
                                                int                     lwork,
                                                int*                    info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZungqr(handle,
                                m,
                                n,
@@ -443,7 +520,7 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZungqrFortran(handle,
                                       m,
                                       n,
@@ -454,12 +531,15 @@ inline hipsolverStatus_t hipsolver_orgqr_ungqr(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
 /******************** ORGTR/UNGTR ********************/
 // normal and strided_batched
-inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
@@ -468,13 +548,18 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                FO
                                                           float*              tau,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSorgtr_bufferSize(handle, uplo, n, A, lda, tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSorgtr_bufferSizeFortran(handle, uplo, n, A, lda, tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
@@ -483,13 +568,18 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                FO
                                                           double*             tau,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDorgtr_bufferSize(handle, uplo, n, A, lda, tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDorgtr_bufferSizeFortran(handle, uplo, n, A, lda, tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
@@ -498,15 +588,20 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                FO
                                                           hipsolverComplex*   tau,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCungtr_bufferSize(
             handle, uplo, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCungtr_bufferSizeFortran(
             handle, uplo, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(testAPI_t               API,
                                                           hipsolverHandle_t       handle,
                                                           hipsolverFillMode_t     uplo,
                                                           int                     n,
@@ -515,15 +610,20 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr_bufferSize(bool                  
                                                           hipsolverDoubleComplex* tau,
                                                           int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZungtr_bufferSize(
             handle, uplo, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZungtr_bufferSizeFortran(
             handle, uplo, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgtr_ungtr(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverFillMode_t uplo,
                                                int                 n,
@@ -534,13 +634,18 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
                                                int                 lwork,
                                                int*                info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSorgtr(handle, uplo, n, A, lda, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSorgtrFortran(handle, uplo, n, A, lda, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgtr_ungtr(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverFillMode_t uplo,
                                                int                 n,
@@ -551,13 +656,18 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
                                                int                 lwork,
                                                int*                info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDorgtr(handle, uplo, n, A, lda, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDorgtrFortran(handle, uplo, n, A, lda, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_orgtr_ungtr(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverFillMode_t uplo,
                                                int                 n,
@@ -568,7 +678,9 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
                                                int                 lwork,
                                                int*                info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCungtr(handle,
                                uplo,
                                n,
@@ -578,7 +690,7 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverCungtrFortran(handle,
                                       uplo,
                                       n,
@@ -588,9 +700,12 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_orgtr_ungtr(testAPI_t               API,
                                                hipsolverHandle_t       handle,
                                                hipsolverFillMode_t     uplo,
                                                int                     n,
@@ -601,7 +716,9 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                    FORTRAN,
                                                int                     lwork,
                                                int*                    info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZungtr(handle,
                                uplo,
                                n,
@@ -611,7 +728,7 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZungtrFortran(handle,
                                       uplo,
                                       n,
@@ -621,12 +738,15 @@ inline hipsolverStatus_t hipsolver_orgtr_ungtr(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
 /******************** ORMQR/UNMQR ********************/
 // normal and strided_batched
-inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(testAPI_t            API,
                                                           hipsolverHandle_t    handle,
                                                           hipsolverSideMode_t  side,
                                                           hipsolverOperation_t trans,
@@ -640,14 +760,19 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                 F
                                                           int                  ldc,
                                                           int*                 lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSormqr_bufferSizeFortran(
             handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(testAPI_t            API,
                                                           hipsolverHandle_t    handle,
                                                           hipsolverSideMode_t  side,
                                                           hipsolverOperation_t trans,
@@ -661,14 +786,19 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                 F
                                                           int                  ldc,
                                                           int*                 lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDormqr_bufferSizeFortran(
             handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(testAPI_t            API,
                                                           hipsolverHandle_t    handle,
                                                           hipsolverSideMode_t  side,
                                                           hipsolverOperation_t trans,
@@ -682,7 +812,9 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                 F
                                                           int                  ldc,
                                                           int*                 lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCunmqr_bufferSize(handle,
                                           side,
                                           trans,
@@ -695,7 +827,7 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                 F
                                           (hipFloatComplex*)C,
                                           ldc,
                                           lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCunmqr_bufferSizeFortran(handle,
                                                  side,
                                                  trans,
@@ -708,9 +840,12 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                 F
                                                  (hipFloatComplex*)C,
                                                  ldc,
                                                  lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(testAPI_t               API,
                                                           hipsolverHandle_t       handle,
                                                           hipsolverSideMode_t     side,
                                                           hipsolverOperation_t    trans,
@@ -724,7 +859,9 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                  
                                                           int                     ldc,
                                                           int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZunmqr_bufferSize(handle,
                                           side,
                                           trans,
@@ -737,7 +874,7 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                  
                                           (hipDoubleComplex*)C,
                                           ldc,
                                           lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZunmqr_bufferSizeFortran(handle,
                                                  side,
                                                  trans,
@@ -750,9 +887,12 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr_bufferSize(bool                  
                                                  (hipDoubleComplex*)C,
                                                  ldc,
                                                  lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormqr_unmqr(testAPI_t            API,
                                                hipsolverHandle_t    handle,
                                                hipsolverSideMode_t  side,
                                                hipsolverOperation_t trans,
@@ -768,15 +908,20 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
                                                int                  lwork,
                                                int*                 info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSormqr(
             handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSormqrFortran(
             handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormqr_unmqr(testAPI_t            API,
                                                hipsolverHandle_t    handle,
                                                hipsolverSideMode_t  side,
                                                hipsolverOperation_t trans,
@@ -792,15 +937,20 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
                                                int                  lwork,
                                                int*                 info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDormqr(
             handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDormqrFortran(
             handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormqr_unmqr(testAPI_t            API,
                                                hipsolverHandle_t    handle,
                                                hipsolverSideMode_t  side,
                                                hipsolverOperation_t trans,
@@ -816,7 +966,9 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
                                                int                  lwork,
                                                int*                 info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCunmqr(handle,
                                side,
                                trans,
@@ -831,7 +983,7 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverCunmqrFortran(handle,
                                       side,
                                       trans,
@@ -846,9 +998,12 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                 FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_ormqr_unmqr(testAPI_t               API,
                                                hipsolverHandle_t       handle,
                                                hipsolverSideMode_t     side,
                                                hipsolverOperation_t    trans,
@@ -864,7 +1019,9 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                    FORTRAN,
                                                int                     lwork,
                                                int*                    info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZunmqr(handle,
                                side,
                                trans,
@@ -879,7 +1036,7 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZunmqrFortran(handle,
                                       side,
                                       trans,
@@ -894,12 +1051,15 @@ inline hipsolverStatus_t hipsolver_ormqr_unmqr(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
 /******************** ORMTR/UNMTR ********************/
 // normal and strided_batched
-inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(testAPI_t            API,
                                                           hipsolverHandle_t    handle,
                                                           hipsolverSideMode_t  side,
                                                           hipsolverFillMode_t  uplo,
@@ -913,15 +1073,20 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                 F
                                                           int                  ldc,
                                                           int*                 lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSormtr_bufferSize(
             handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSormtr_bufferSizeFortran(
             handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(testAPI_t            API,
                                                           hipsolverHandle_t    handle,
                                                           hipsolverSideMode_t  side,
                                                           hipsolverFillMode_t  uplo,
@@ -935,15 +1100,20 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                 F
                                                           int                  ldc,
                                                           int*                 lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDormtr_bufferSize(
             handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDormtr_bufferSizeFortran(
             handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(testAPI_t            API,
                                                           hipsolverHandle_t    handle,
                                                           hipsolverSideMode_t  side,
                                                           hipsolverFillMode_t  uplo,
@@ -957,7 +1127,9 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                 F
                                                           int                  ldc,
                                                           int*                 lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCunmtr_bufferSize(handle,
                                           side,
                                           uplo,
@@ -970,7 +1142,7 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                 F
                                           (hipFloatComplex*)C,
                                           ldc,
                                           lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCunmtr_bufferSizeFortran(handle,
                                                  side,
                                                  uplo,
@@ -983,9 +1155,12 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                 F
                                                  (hipFloatComplex*)C,
                                                  ldc,
                                                  lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(testAPI_t               API,
                                                           hipsolverHandle_t       handle,
                                                           hipsolverSideMode_t     side,
                                                           hipsolverFillMode_t     uplo,
@@ -999,7 +1174,9 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                  
                                                           int                     ldc,
                                                           int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZunmtr_bufferSize(handle,
                                           side,
                                           uplo,
@@ -1012,7 +1189,7 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                  
                                           (hipDoubleComplex*)C,
                                           ldc,
                                           lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZunmtr_bufferSizeFortran(handle,
                                                  side,
                                                  uplo,
@@ -1025,9 +1202,12 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr_bufferSize(bool                  
                                                  (hipDoubleComplex*)C,
                                                  ldc,
                                                  lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormtr_unmtr(testAPI_t            API,
                                                hipsolverHandle_t    handle,
                                                hipsolverSideMode_t  side,
                                                hipsolverFillMode_t  uplo,
@@ -1043,15 +1223,20 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
                                                int                  lwork,
                                                int*                 info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSormtr(
             handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSormtrFortran(
             handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormtr_unmtr(testAPI_t            API,
                                                hipsolverHandle_t    handle,
                                                hipsolverSideMode_t  side,
                                                hipsolverFillMode_t  uplo,
@@ -1067,15 +1252,20 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
                                                int                  lwork,
                                                int*                 info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDormtr(
             handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDormtrFortran(
             handle, side, uplo, trans, m, n, A, lda, tau, C, ldc, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
+inline hipsolverStatus_t hipsolver_ormtr_unmtr(testAPI_t            API,
                                                hipsolverHandle_t    handle,
                                                hipsolverSideMode_t  side,
                                                hipsolverFillMode_t  uplo,
@@ -1091,7 +1281,9 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
                                                int                  lwork,
                                                int*                 info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCunmtr(handle,
                                side,
                                uplo,
@@ -1106,7 +1298,7 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverCunmtrFortran(handle,
                                       side,
                                       uplo,
@@ -1121,9 +1313,12 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                 FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_ormtr_unmtr(testAPI_t               API,
                                                hipsolverHandle_t       handle,
                                                hipsolverSideMode_t     side,
                                                hipsolverFillMode_t     uplo,
@@ -1139,7 +1334,9 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                    FORTRAN,
                                                int                     lwork,
                                                int*                    info)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZunmtr(handle,
                                side,
                                uplo,
@@ -1154,7 +1351,7 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZunmtrFortran(handle,
                                       side,
                                       uplo,
@@ -1169,39 +1366,57 @@ inline hipsolverStatus_t hipsolver_ormtr_unmtr(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
 /******************** GEBRD ********************/
 // normal and strided_batched
 inline hipsolverStatus_t hipsolver_gebrd_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSgebrd_bufferSize(handle, m, n, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSgebrd_bufferSizeFortran(handle, m, n, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
 inline hipsolverStatus_t hipsolver_gebrd_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDgebrd_bufferSize(handle, m, n, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDgebrd_bufferSizeFortran(handle, m, n, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
 inline hipsolverStatus_t hipsolver_gebrd_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCgebrd_bufferSize(handle, m, n, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCgebrd_bufferSizeFortran(handle, m, n, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_gebrd_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_gebrd_bufferSize(testAPI_t               API,
                                                     hipsolverHandle_t       handle,
                                                     int                     m,
                                                     int                     n,
@@ -1209,13 +1424,18 @@ inline hipsolverStatus_t hipsolver_gebrd_bufferSize(bool                    FORT
                                                     int                     lda,
                                                     int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZgebrd_bufferSize(handle, m, n, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZgebrd_bufferSizeFortran(handle, m, n, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_gebrd(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_gebrd(testAPI_t         API,
                                          hipsolverHandle_t handle,
                                          int               m,
                                          int               n,
@@ -1235,13 +1455,18 @@ inline hipsolverStatus_t hipsolver_gebrd(bool              FORTRAN,
                                          int*              info,
                                          int               bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSgebrdFortran(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_gebrd(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_gebrd(testAPI_t         API,
                                          hipsolverHandle_t handle,
                                          int               m,
                                          int               n,
@@ -1261,13 +1486,18 @@ inline hipsolverStatus_t hipsolver_gebrd(bool              FORTRAN,
                                          int*              info,
                                          int               bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDgebrdFortran(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_gebrd(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_gebrd(testAPI_t         API,
                                          hipsolverHandle_t handle,
                                          int               m,
                                          int               n,
@@ -1287,7 +1517,9 @@ inline hipsolverStatus_t hipsolver_gebrd(bool              FORTRAN,
                                          int*              info,
                                          int               bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCgebrd(handle,
                                m,
                                n,
@@ -1300,7 +1532,7 @@ inline hipsolverStatus_t hipsolver_gebrd(bool              FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverCgebrdFortran(handle,
                                       m,
                                       n,
@@ -1313,9 +1545,12 @@ inline hipsolverStatus_t hipsolver_gebrd(bool              FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_gebrd(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_gebrd(testAPI_t               API,
                                          hipsolverHandle_t       handle,
                                          int                     m,
                                          int                     n,
@@ -1335,7 +1570,9 @@ inline hipsolverStatus_t hipsolver_gebrd(bool                    FORTRAN,
                                          int*                    info,
                                          int                     bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZgebrd(handle,
                                m,
                                n,
@@ -1348,7 +1585,7 @@ inline hipsolverStatus_t hipsolver_gebrd(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZgebrdFortran(handle,
                                       m,
                                       n,
@@ -1361,6 +1598,9 @@ inline hipsolverStatus_t hipsolver_gebrd(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
@@ -1798,33 +2038,48 @@ inline hipsolverStatus_t hipsolver_gels(testAPI_t               API,
 /******************** GEQRF ********************/
 // normal and strided_batched
 inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int m, int n, float* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSgeqrf_bufferSize(handle, m, n, A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSgeqrf_bufferSizeFortran(handle, m, n, A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
 inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int m, int n, double* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDgeqrf_bufferSize(handle, m, n, A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDgeqrf_bufferSizeFortran(handle, m, n, A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
 inline hipsolverStatus_t hipsolver_geqrf_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int m, int n, hipsolverComplex* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCgeqrf_bufferSize(handle, m, n, (hipFloatComplex*)A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCgeqrf_bufferSizeFortran(handle, m, n, (hipFloatComplex*)A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_geqrf_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_geqrf_bufferSize(testAPI_t               API,
                                                     hipsolverHandle_t       handle,
                                                     int                     m,
                                                     int                     n,
@@ -1832,13 +2087,18 @@ inline hipsolverStatus_t hipsolver_geqrf_bufferSize(bool                    FORT
                                                     int                     lda,
                                                     int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZgeqrf_bufferSize(handle, m, n, (hipDoubleComplex*)A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZgeqrf_bufferSizeFortran(handle, m, n, (hipDoubleComplex*)A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_geqrf(testAPI_t         API,
                                          hipsolverHandle_t handle,
                                          int               m,
                                          int               n,
@@ -1852,13 +2112,18 @@ inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
                                          int*              info,
                                          int               bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSgeqrf(handle, m, n, A, lda, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSgeqrfFortran(handle, m, n, A, lda, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_geqrf(testAPI_t         API,
                                          hipsolverHandle_t handle,
                                          int               m,
                                          int               n,
@@ -1872,13 +2137,18 @@ inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
                                          int*              info,
                                          int               bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDgeqrf(handle, m, n, A, lda, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDgeqrfFortran(handle, m, n, A, lda, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
+inline hipsolverStatus_t hipsolver_geqrf(testAPI_t         API,
                                          hipsolverHandle_t handle,
                                          int               m,
                                          int               n,
@@ -1892,7 +2162,9 @@ inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
                                          int*              info,
                                          int               bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCgeqrf(handle,
                                m,
                                n,
@@ -1902,7 +2174,7 @@ inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverCgeqrfFortran(handle,
                                       m,
                                       n,
@@ -1912,9 +2184,12 @@ inline hipsolverStatus_t hipsolver_geqrf(bool              FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_geqrf(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_geqrf(testAPI_t               API,
                                          hipsolverHandle_t       handle,
                                          int                     m,
                                          int                     n,
@@ -1928,7 +2203,9 @@ inline hipsolverStatus_t hipsolver_geqrf(bool                    FORTRAN,
                                          int*                    info,
                                          int                     bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZgeqrf(handle,
                                m,
                                n,
@@ -1938,7 +2215,7 @@ inline hipsolverStatus_t hipsolver_geqrf(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZgeqrfFortran(handle,
                                       m,
                                       n,
@@ -1948,6 +2225,9 @@ inline hipsolverStatus_t hipsolver_geqrf(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
@@ -4744,7 +5024,7 @@ inline hipsolverStatus_t hipsolver_potrf(testAPI_t               API,
 
 /******************** POTRI ********************/
 // normal and strided_batched
-inline hipsolverStatus_t hipsolver_potri_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_potri_bufferSize(testAPI_t           API,
                                                     hipsolverHandle_t   handle,
                                                     hipsolverFillMode_t uplo,
                                                     int                 n,
@@ -4752,13 +5032,18 @@ inline hipsolverStatus_t hipsolver_potri_bufferSize(bool                FORTRAN,
                                                     int                 lda,
                                                     int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSpotri_bufferSize(handle, uplo, n, A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSpotri_bufferSizeFortran(handle, uplo, n, A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_potri_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_potri_bufferSize(testAPI_t           API,
                                                     hipsolverHandle_t   handle,
                                                     hipsolverFillMode_t uplo,
                                                     int                 n,
@@ -4766,13 +5051,18 @@ inline hipsolverStatus_t hipsolver_potri_bufferSize(bool                FORTRAN,
                                                     int                 lda,
                                                     int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDpotri_bufferSize(handle, uplo, n, A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDpotri_bufferSizeFortran(handle, uplo, n, A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_potri_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_potri_bufferSize(testAPI_t           API,
                                                     hipsolverHandle_t   handle,
                                                     hipsolverFillMode_t uplo,
                                                     int                 n,
@@ -4780,13 +5070,18 @@ inline hipsolverStatus_t hipsolver_potri_bufferSize(bool                FORTRAN,
                                                     int                 lda,
                                                     int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCpotri_bufferSize(handle, uplo, n, (hipFloatComplex*)A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCpotri_bufferSizeFortran(handle, uplo, n, (hipFloatComplex*)A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_potri_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_potri_bufferSize(testAPI_t               API,
                                                     hipsolverHandle_t       handle,
                                                     hipsolverFillMode_t     uplo,
                                                     int                     n,
@@ -4794,13 +5089,18 @@ inline hipsolverStatus_t hipsolver_potri_bufferSize(bool                    FORT
                                                     int                     lda,
                                                     int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZpotri_bufferSize(handle, uplo, n, (hipDoubleComplex*)A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZpotri_bufferSizeFortran(handle, uplo, n, (hipDoubleComplex*)A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_potri(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_potri(testAPI_t           API,
                                          hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
@@ -4812,13 +5112,18 @@ inline hipsolverStatus_t hipsolver_potri(bool                FORTRAN,
                                          int*                info,
                                          int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSpotri(handle, uplo, n, A, lda, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSpotriFortran(handle, uplo, n, A, lda, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_potri(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_potri(testAPI_t           API,
                                          hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
@@ -4830,13 +5135,18 @@ inline hipsolverStatus_t hipsolver_potri(bool                FORTRAN,
                                          int*                info,
                                          int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDpotri(handle, uplo, n, A, lda, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDpotriFortran(handle, uplo, n, A, lda, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_potri(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_potri(testAPI_t           API,
                                          hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
@@ -4848,15 +5158,20 @@ inline hipsolverStatus_t hipsolver_potri(bool                FORTRAN,
                                          int*                info,
                                          int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCpotri(
             handle, uplo, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverCpotriFortran(
             handle, uplo, n, (hipFloatComplex*)A, lda, (hipFloatComplex*)work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_potri(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_potri(testAPI_t               API,
                                          hipsolverHandle_t       handle,
                                          hipsolverFillMode_t     uplo,
                                          int                     n,
@@ -4868,12 +5183,17 @@ inline hipsolverStatus_t hipsolver_potri(bool                    FORTRAN,
                                          int*                    info,
                                          int                     bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZpotri(
             handle, uplo, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverZpotriFortran(
             handle, uplo, n, (hipDoubleComplex*)A, lda, (hipDoubleComplex*)work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
@@ -5431,7 +5751,7 @@ inline hipsolverStatus_t hipsolver_potrs(testAPI_t               API,
 
 /******************** SYEVD/HEEVD ********************/
 // normal and strided_batched
-inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverEigMode_t  jobz,
                                                           hipsolverFillMode_t uplo,
@@ -5441,13 +5761,18 @@ inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                FO
                                                           float*              W,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSsyevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSsyevd_bufferSizeFortran(handle, jobz, uplo, n, A, lda, W, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverEigMode_t  jobz,
                                                           hipsolverFillMode_t uplo,
@@ -5457,13 +5782,18 @@ inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                FO
                                                           double*             W,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDsyevd_bufferSize(handle, jobz, uplo, n, A, lda, W, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDsyevd_bufferSizeFortran(handle, jobz, uplo, n, A, lda, W, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverEigMode_t  jobz,
                                                           hipsolverFillMode_t uplo,
@@ -5473,15 +5803,20 @@ inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                FO
                                                           float*              W,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCheevd_bufferSize(
             handle, jobz, uplo, n, (hipFloatComplex*)A, lda, W, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCheevd_bufferSizeFortran(
             handle, jobz, uplo, n, (hipFloatComplex*)A, lda, W, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(testAPI_t               API,
                                                           hipsolverHandle_t       handle,
                                                           hipsolverEigMode_t      jobz,
                                                           hipsolverFillMode_t     uplo,
@@ -5491,15 +5826,20 @@ inline hipsolverStatus_t hipsolver_syevd_heevd_bufferSize(bool                  
                                                           double*                 W,
                                                           int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZheevd_bufferSize(
             handle, jobz, uplo, n, (hipDoubleComplex*)A, lda, W, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZheevd_bufferSizeFortran(
             handle, jobz, uplo, n, (hipDoubleComplex*)A, lda, W, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_syevd_heevd(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverEigMode_t  jobz,
                                                hipsolverFillMode_t uplo,
@@ -5514,13 +5854,18 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
                                                int*                info,
                                                int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSsyevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSsyevdFortran(handle, jobz, uplo, n, A, lda, W, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_syevd_heevd(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverEigMode_t  jobz,
                                                hipsolverFillMode_t uplo,
@@ -5535,13 +5880,18 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
                                                int*                info,
                                                int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDsyevd(handle, jobz, uplo, n, A, lda, W, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDsyevdFortran(handle, jobz, uplo, n, A, lda, W, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_syevd_heevd(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverEigMode_t  jobz,
                                                hipsolverFillMode_t uplo,
@@ -5556,7 +5906,9 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
                                                int*                info,
                                                int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCheevd(handle,
                                jobz,
                                uplo,
@@ -5567,7 +5919,7 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverCheevdFortran(handle,
                                       jobz,
                                       uplo,
@@ -5578,9 +5930,12 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_syevd_heevd(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_syevd_heevd(testAPI_t               API,
                                                hipsolverHandle_t       handle,
                                                hipsolverEigMode_t      jobz,
                                                hipsolverFillMode_t     uplo,
@@ -5595,7 +5950,9 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                    FORTRAN,
                                                int*                    info,
                                                int                     bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZheevd(handle,
                                jobz,
                                uplo,
@@ -5606,7 +5963,7 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZheevdFortran(handle,
                                       jobz,
                                       uplo,
@@ -5617,6 +5974,9 @@ inline hipsolverStatus_t hipsolver_syevd_heevd(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
@@ -6306,7 +6666,7 @@ inline hipsolverStatus_t hipsolver_syevj_heevj(testAPI_t               API,
 
 /******************** SYGVD/HEGVD ********************/
 // normal and strided_batched
-inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverEigType_t  itype,
                                                           hipsolverEigMode_t  jobz,
@@ -6319,14 +6679,19 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                FO
                                                           float*              W,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSsygvd_bufferSizeFortran(
             handle, itype, jobz, uplo, n, A, lda, B, ldb, W, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverEigType_t  itype,
                                                           hipsolverEigMode_t  jobz,
@@ -6339,14 +6704,19 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                FO
                                                           double*             W,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDsygvd_bufferSize(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDsygvd_bufferSizeFortran(
             handle, itype, jobz, uplo, n, A, lda, B, ldb, W, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverEigType_t  itype,
                                                           hipsolverEigMode_t  jobz,
@@ -6359,7 +6729,9 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                FO
                                                           float*              W,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverChegvd_bufferSize(handle,
                                           itype,
                                           jobz,
@@ -6371,7 +6743,7 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                FO
                                           ldb,
                                           W,
                                           lwork);
-    else
+    case API_FORTRAN:
         return hipsolverChegvd_bufferSizeFortran(handle,
                                                  itype,
                                                  jobz,
@@ -6383,9 +6755,12 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                FO
                                                  ldb,
                                                  W,
                                                  lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(testAPI_t               API,
                                                           hipsolverHandle_t       handle,
                                                           hipsolverEigType_t      itype,
                                                           hipsolverEigMode_t      jobz,
@@ -6398,7 +6773,9 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                  
                                                           double*                 W,
                                                           int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZhegvd_bufferSize(handle,
                                           itype,
                                           jobz,
@@ -6410,7 +6787,7 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                  
                                           ldb,
                                           W,
                                           lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZhegvd_bufferSizeFortran(handle,
                                                  itype,
                                                  jobz,
@@ -6422,9 +6799,12 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd_bufferSize(bool                  
                                                  ldb,
                                                  W,
                                                  lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sygvd_hegvd(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverEigType_t  itype,
                                                hipsolverEigMode_t  jobz,
@@ -6443,14 +6823,19 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
                                                int*                info,
                                                int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSsygvdFortran(
             handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sygvd_hegvd(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverEigType_t  itype,
                                                hipsolverEigMode_t  jobz,
@@ -6469,14 +6854,19 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
                                                int*                info,
                                                int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDsygvd(handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDsygvdFortran(
             handle, itype, jobz, uplo, n, A, lda, B, ldb, W, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sygvd_hegvd(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverEigType_t  itype,
                                                hipsolverEigMode_t  jobz,
@@ -6495,7 +6885,9 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
                                                int*                info,
                                                int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverChegvd(handle,
                                itype,
                                jobz,
@@ -6509,7 +6901,7 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverChegvdFortran(handle,
                                       itype,
                                       jobz,
@@ -6523,9 +6915,12 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_sygvd_hegvd(testAPI_t               API,
                                                hipsolverHandle_t       handle,
                                                hipsolverEigType_t      itype,
                                                hipsolverEigMode_t      jobz,
@@ -6544,7 +6939,9 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                    FORTRAN,
                                                int*                    info,
                                                int                     bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZhegvd(handle,
                                itype,
                                jobz,
@@ -6558,7 +6955,7 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZhegvdFortran(handle,
                                       itype,
                                       jobz,
@@ -6572,6 +6969,9 @@ inline hipsolverStatus_t hipsolver_sygvd_hegvd(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
@@ -7333,7 +7733,7 @@ inline hipsolverStatus_t hipsolver_sygvj_hegvj(testAPI_t               API,
 
 /******************** SYTRD/HETRD ********************/
 // normal and strided_batched
-inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
@@ -7344,13 +7744,18 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                FO
                                                           float*              tau,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSsytrd_bufferSize(handle, uplo, n, A, lda, D, E, tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSsytrd_bufferSizeFortran(handle, uplo, n, A, lda, D, E, tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
@@ -7361,13 +7766,18 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                FO
                                                           double*             tau,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDsytrd_bufferSize(handle, uplo, n, A, lda, D, E, tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDsytrd_bufferSizeFortran(handle, uplo, n, A, lda, D, E, tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(testAPI_t           API,
                                                           hipsolverHandle_t   handle,
                                                           hipsolverFillMode_t uplo,
                                                           int                 n,
@@ -7378,15 +7788,20 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                FO
                                                           hipsolverComplex*   tau,
                                                           int*                lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverChetrd_bufferSize(
             handle, uplo, n, (hipFloatComplex*)A, lda, D, E, (hipFloatComplex*)tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverChetrd_bufferSizeFortran(
             handle, uplo, n, (hipFloatComplex*)A, lda, D, E, (hipFloatComplex*)tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(testAPI_t               API,
                                                           hipsolverHandle_t       handle,
                                                           hipsolverFillMode_t     uplo,
                                                           int                     n,
@@ -7397,15 +7812,20 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd_bufferSize(bool                  
                                                           hipsolverDoubleComplex* tau,
                                                           int*                    lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZhetrd_bufferSize(
             handle, uplo, n, (hipDoubleComplex*)A, lda, D, E, (hipDoubleComplex*)tau, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZhetrd_bufferSizeFortran(
             handle, uplo, n, (hipDoubleComplex*)A, lda, D, E, (hipDoubleComplex*)tau, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrd_hetrd(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverFillMode_t uplo,
                                                int                 n,
@@ -7423,13 +7843,18 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
                                                int*                info,
                                                int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSsytrd(handle, uplo, n, A, lda, D, E, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSsytrdFortran(handle, uplo, n, A, lda, D, E, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrd_hetrd(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverFillMode_t uplo,
                                                int                 n,
@@ -7447,13 +7872,18 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
                                                int*                info,
                                                int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDsytrd(handle, uplo, n, A, lda, D, E, tau, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDsytrdFortran(handle, uplo, n, A, lda, D, E, tau, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrd_hetrd(testAPI_t           API,
                                                hipsolverHandle_t   handle,
                                                hipsolverFillMode_t uplo,
                                                int                 n,
@@ -7471,7 +7901,9 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
                                                int*                info,
                                                int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverChetrd(handle,
                                uplo,
                                n,
@@ -7483,7 +7915,7 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
                                (hipFloatComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverChetrdFortran(handle,
                                       uplo,
                                       n,
@@ -7495,9 +7927,12 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                FORTRAN,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrd_hetrd(testAPI_t               API,
                                                hipsolverHandle_t       handle,
                                                hipsolverFillMode_t     uplo,
                                                int                     n,
@@ -7515,7 +7950,9 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                    FORTRAN,
                                                int*                    info,
                                                int                     bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZhetrd(handle,
                                uplo,
                                n,
@@ -7527,7 +7964,7 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                    FORTRAN,
                                (hipDoubleComplex*)work,
                                lwork,
                                info);
-    else
+    case API_FORTRAN:
         return hipsolverZhetrdFortran(handle,
                                       uplo,
                                       n,
@@ -7539,48 +7976,71 @@ inline hipsolverStatus_t hipsolver_sytrd_hetrd(bool                    FORTRAN,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/
 
 /******************** SYTRF ********************/
 // normal and strided_batched
 inline hipsolverStatus_t hipsolver_sytrf_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int n, float* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int n, float* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSsytrf_bufferSize(handle, n, A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverSsytrf_bufferSizeFortran(handle, n, A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
 inline hipsolverStatus_t hipsolver_sytrf_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int n, double* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int n, double* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDsytrf_bufferSize(handle, n, A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverDsytrf_bufferSizeFortran(handle, n, A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
 inline hipsolverStatus_t hipsolver_sytrf_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int n, hipsolverComplex* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int n, hipsolverComplex* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCsytrf_bufferSize(handle, n, (hipFloatComplex*)A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverCsytrf_bufferSizeFortran(handle, n, (hipFloatComplex*)A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
 inline hipsolverStatus_t hipsolver_sytrf_bufferSize(
-    bool FORTRAN, hipsolverHandle_t handle, int n, hipsolverDoubleComplex* A, int lda, int* lwork)
+    testAPI_t API, hipsolverHandle_t handle, int n, hipsolverDoubleComplex* A, int lda, int* lwork)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZsytrf_bufferSize(handle, n, (hipDoubleComplex*)A, lda, lwork);
-    else
+    case API_FORTRAN:
         return hipsolverZsytrf_bufferSizeFortran(handle, n, (hipDoubleComplex*)A, lda, lwork);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrf(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrf(testAPI_t           API,
                                          hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
@@ -7594,13 +8054,18 @@ inline hipsolverStatus_t hipsolver_sytrf(bool                FORTRAN,
                                          int*                info,
                                          int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverSsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverSsytrfFortran(handle, uplo, n, A, lda, ipiv, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrf(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrf(testAPI_t           API,
                                          hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
@@ -7614,13 +8079,18 @@ inline hipsolverStatus_t hipsolver_sytrf(bool                FORTRAN,
                                          int*                info,
                                          int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverDsytrf(handle, uplo, n, A, lda, ipiv, work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverDsytrfFortran(handle, uplo, n, A, lda, ipiv, work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrf(bool                FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrf(testAPI_t           API,
                                          hipsolverHandle_t   handle,
                                          hipsolverFillMode_t uplo,
                                          int                 n,
@@ -7634,15 +8104,20 @@ inline hipsolverStatus_t hipsolver_sytrf(bool                FORTRAN,
                                          int*                info,
                                          int                 bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverCsytrf(
             handle, uplo, n, (hipFloatComplex*)A, lda, ipiv, (hipFloatComplex*)work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverCsytrfFortran(
             handle, uplo, n, (hipFloatComplex*)A, lda, ipiv, (hipFloatComplex*)work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 
-inline hipsolverStatus_t hipsolver_sytrf(bool                    FORTRAN,
+inline hipsolverStatus_t hipsolver_sytrf(testAPI_t               API,
                                          hipsolverHandle_t       handle,
                                          hipsolverFillMode_t     uplo,
                                          int                     n,
@@ -7656,11 +8131,16 @@ inline hipsolverStatus_t hipsolver_sytrf(bool                    FORTRAN,
                                          int*                    info,
                                          int                     bc)
 {
-    if(!FORTRAN)
+    switch(API)
+    {
+    case API_NORMAL:
         return hipsolverZsytrf(
             handle, uplo, n, (hipDoubleComplex*)A, lda, ipiv, (hipDoubleComplex*)work, lwork, info);
-    else
+    case API_FORTRAN:
         return hipsolverZsytrfFortran(
             handle, uplo, n, (hipDoubleComplex*)A, lda, ipiv, (hipDoubleComplex*)work, lwork, info);
+    default:
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+    }
 }
 /********************************************************/

--- a/clients/include/hipsolver_dispatcher.hpp
+++ b/clients/include/hipsolver_dispatcher.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2021-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -73,9 +73,9 @@ class hipsolver_dispatcher
     {
         // Map for functions that support all precisions
         static const func_map map = {
-            {"gebrd", testing_gebrd<false, false, false, T>},
+            {"gebrd", testing_gebrd<API_NORMAL, false, false, T>},
             {"gels", testing_gels<API_NORMAL, false, false, false, T>},
-            {"geqrf", testing_geqrf<false, false, false, T>},
+            {"geqrf", testing_geqrf<API_NORMAL, false, false, T>},
             {"gesv", testing_gesv<API_NORMAL, false, false, false, T>},
             {"gesvd", testing_gesvd<API_NORMAL, false, false, false, T>},
             {"gesvda_strided_batched", testing_gesvda<API_COMPAT, false, true, T>},
@@ -85,10 +85,10 @@ class hipsolver_dispatcher
             {"getrs", testing_getrs<API_NORMAL, false, false, T>},
             {"potrf", testing_potrf<API_NORMAL, false, false, T>},
             {"potrf_batched", testing_potrf<API_NORMAL, true, false, T>},
-            {"potri", testing_potri<false, false, false, T>},
+            {"potri", testing_potri<API_NORMAL, false, false, T>},
             {"potrs", testing_potrs<API_NORMAL, false, false, T>},
             {"potrs_batched", testing_potrs<API_NORMAL, true, false, T>},
-            {"sytrf", testing_sytrf<false, false, false, T>},
+            {"sytrf", testing_sytrf<API_NORMAL, false, false, T>},
         };
 
         // Grab function from the map and execute
@@ -107,19 +107,19 @@ class hipsolver_dispatcher
     {
         // Map for functions that support single and double precisions
         static const func_map map_real = {
-            {"orgbr", testing_orgbr_ungbr<false, T>},
-            {"orgqr", testing_orgqr_ungqr<false, T>},
-            {"orgtr", testing_orgtr_ungtr<false, T>},
-            {"ormqr", testing_ormqr_unmqr<false, T>},
-            {"ormtr", testing_ormtr_unmtr<false, T>},
-            {"syevd", testing_syevd_heevd<false, false, false, T>},
+            {"orgbr", testing_orgbr_ungbr<API_NORMAL, T>},
+            {"orgqr", testing_orgqr_ungqr<API_NORMAL, T>},
+            {"orgtr", testing_orgtr_ungtr<API_NORMAL, T>},
+            {"ormqr", testing_ormqr_unmqr<API_NORMAL, T>},
+            {"ormtr", testing_ormtr_unmtr<API_NORMAL, T>},
+            {"syevd", testing_syevd_heevd<API_NORMAL, false, false, T>},
             {"syevdx", testing_syevdx_heevdx<API_COMPAT, false, false, T>},
             {"syevj", testing_syevj_heevj<API_NORMAL, false, false, T>},
             {"syevj_batched", testing_syevj_heevj<API_NORMAL, false, true, T>},
-            {"sygvd", testing_sygvd_hegvd<false, false, false, T>},
+            {"sygvd", testing_sygvd_hegvd<API_NORMAL, false, false, T>},
             {"sygvdx", testing_sygvdx_hegvdx<API_COMPAT, false, false, T>},
             {"sygvj", testing_sygvj_hegvj<API_NORMAL, false, false, T>},
-            {"sytrd", testing_sytrd_hetrd<false, false, false, T>},
+            {"sytrd", testing_sytrd_hetrd<API_NORMAL, false, false, T>},
             {"csrlsvchol", testing_csrlsvchol<false, T>},
             {"csrlsvcholHost", testing_csrlsvchol<true, T>},
         };
@@ -140,19 +140,19 @@ class hipsolver_dispatcher
     {
         // Map for functions that support single complex and double complex precisions
         static const func_map map_complex = {
-            {"ungbr", testing_orgbr_ungbr<false, T>},
-            {"ungqr", testing_orgqr_ungqr<false, T>},
-            {"ungtr", testing_orgtr_ungtr<false, T>},
-            {"unmqr", testing_ormqr_unmqr<false, T>},
-            {"unmtr", testing_ormtr_unmtr<false, T>},
-            {"heevd", testing_syevd_heevd<false, false, false, T>},
+            {"ungbr", testing_orgbr_ungbr<API_NORMAL, T>},
+            {"ungqr", testing_orgqr_ungqr<API_NORMAL, T>},
+            {"ungtr", testing_orgtr_ungtr<API_NORMAL, T>},
+            {"unmqr", testing_ormqr_unmqr<API_NORMAL, T>},
+            {"unmtr", testing_ormtr_unmtr<API_NORMAL, T>},
+            {"heevd", testing_syevd_heevd<API_NORMAL, false, false, T>},
             {"heevdx", testing_syevdx_heevdx<API_COMPAT, false, false, T>},
             {"heevj", testing_syevj_heevj<API_NORMAL, false, false, T>},
             {"heevj_batched", testing_syevj_heevj<API_NORMAL, false, true, T>},
-            {"hegvd", testing_sygvd_hegvd<false, false, false, T>},
+            {"hegvd", testing_sygvd_hegvd<API_NORMAL, false, false, T>},
             {"hegvdx", testing_sygvdx_hegvdx<API_COMPAT, false, false, T>},
             {"hegvj", testing_sygvj_hegvj<API_NORMAL, false, false, T>},
-            {"hetrd", testing_sytrd_hetrd<false, false, false, T>},
+            {"hetrd", testing_sytrd_hetrd<API_NORMAL, false, false, T>},
         };
 
         // Grab function from the map and execute

--- a/clients/include/testing_gebrd.hpp
+++ b/clients/include/testing_gebrd.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, typename S, typename T, typename U, typename V>
+template <testAPI_t API, typename S, typename T, typename U, typename V>
 void gebrd_checkBadArgs(const hipsolverHandle_t handle,
                         const int               m,
                         const int               n,
@@ -46,7 +46,7 @@ void gebrd_checkBadArgs(const hipsolverHandle_t handle,
                         const int               bc)
 {
     // handle
-    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(API,
                                           nullptr,
                                           m,
                                           n,
@@ -72,7 +72,7 @@ void gebrd_checkBadArgs(const hipsolverHandle_t handle,
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
-    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(API,
                                           handle,
                                           m,
                                           n,
@@ -92,7 +92,7 @@ void gebrd_checkBadArgs(const hipsolverHandle_t handle,
                                           dInfo,
                                           bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(API,
                                           handle,
                                           m,
                                           n,
@@ -112,7 +112,7 @@ void gebrd_checkBadArgs(const hipsolverHandle_t handle,
                                           dInfo,
                                           bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(API,
                                           handle,
                                           m,
                                           n,
@@ -132,7 +132,7 @@ void gebrd_checkBadArgs(const hipsolverHandle_t handle,
                                           dInfo,
                                           bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(API,
                                           handle,
                                           m,
                                           n,
@@ -152,7 +152,7 @@ void gebrd_checkBadArgs(const hipsolverHandle_t handle,
                                           dInfo,
                                           bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(API,
                                           handle,
                                           m,
                                           n,
@@ -172,7 +172,7 @@ void gebrd_checkBadArgs(const hipsolverHandle_t handle,
                                           dInfo,
                                           bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(API,
                                           handle,
                                           m,
                                           n,
@@ -195,7 +195,7 @@ void gebrd_checkBadArgs(const hipsolverHandle_t handle,
 #endif
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_gebrd_bad_arg()
 {
     using S = decltype(std::real(T{}));
@@ -229,13 +229,13 @@ void testing_gebrd_bad_arg()
         // CHECK_HIP_ERROR(dInfo.memcheck());
 
         // int size_W;
-        // hipsolver_gebrd_bufferSize(FORTRAN, handle, m, n, dA.data(), lda, &size_W);
+        // hipsolver_gebrd_bufferSize(API, handle, m, n, dA.data(), lda, &size_W);
         // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check bad arguments
-        // gebrd_checkBadArgs<FORTRAN>(handle,
+        // gebrd_checkBadArgs<API>(handle,
         //                             m,
         //                             n,
         //                             dA.data(),
@@ -271,30 +271,30 @@ void testing_gebrd_bad_arg()
         CHECK_HIP_ERROR(dInfo.memcheck());
 
         int size_W;
-        hipsolver_gebrd_bufferSize(FORTRAN, handle, m, n, dA.data(), lda, &size_W);
+        hipsolver_gebrd_bufferSize(API, handle, m, n, dA.data(), lda, &size_W);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
         // check bad arguments
-        gebrd_checkBadArgs<FORTRAN>(handle,
-                                    m,
-                                    n,
-                                    dA.data(),
-                                    lda,
-                                    stA,
-                                    dD.data(),
-                                    stD,
-                                    dE.data(),
-                                    stE,
-                                    dTauq.data(),
-                                    stQ,
-                                    dTaup.data(),
-                                    stP,
-                                    dWork.data(),
-                                    size_W,
-                                    dInfo.data(),
-                                    bc);
+        gebrd_checkBadArgs<API>(handle,
+                                m,
+                                n,
+                                dA.data(),
+                                lda,
+                                stA,
+                                dD.data(),
+                                stD,
+                                dE.data(),
+                                stE,
+                                dTauq.data(),
+                                stQ,
+                                dTaup.data(),
+                                stP,
+                                dWork.data(),
+                                size_W,
+                                dInfo.data(),
+                                bc);
     }
 }
 
@@ -355,7 +355,7 @@ void gebrd_initData(const hipsolverHandle_t handle,
     }
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Sd,
           typename Td,
@@ -426,7 +426,7 @@ void gebrd_getError(const hipsolverHandle_t handle,
     if(!VERIFY_IMPLICIT_TEST)
     {
         // GPU lapack
-        CHECK_ROCBLAS_ERROR(hipsolver_gebrd(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_gebrd(API,
                                             handle,
                                             m,
                                             n,
@@ -592,7 +592,7 @@ void gebrd_getError(const hipsolverHandle_t handle,
     *max_err += err;
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Sd,
           typename Td,
@@ -709,7 +709,7 @@ void gebrd_getPerfData(const hipsolverHandle_t handle,
                                        hTauq,
                                        hTaup);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_gebrd(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_gebrd(API,
                                             handle,
                                             m,
                                             n,
@@ -759,7 +759,7 @@ void gebrd_getPerfData(const hipsolverHandle_t handle,
                                        hTaup);
 
         start = get_time_us_sync(stream);
-        hipsolver_gebrd(FORTRAN,
+        hipsolver_gebrd(API,
                         handle,
                         m,
                         n,
@@ -783,7 +783,7 @@ void gebrd_getPerfData(const hipsolverHandle_t handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_gebrd(Arguments& argus)
 {
     using S = decltype(std::real(T{}));
@@ -823,7 +823,7 @@ void testing_gebrd(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(API,
             //                                       handle,
             //                                       m,
             //                                       n,
@@ -846,7 +846,7 @@ void testing_gebrd(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(FORTRAN,
+            EXPECT_ROCBLAS_STATUS(hipsolver_gebrd(API,
                                                   handle,
                                                   m,
                                                   n,
@@ -876,7 +876,7 @@ void testing_gebrd(Arguments& argus)
 
     // memory size query is necessary
     int size_W;
-    hipsolver_gebrd_bufferSize(FORTRAN, handle, m, n, (T*)nullptr, lda, &size_W);
+    hipsolver_gebrd_bufferSize(API, handle, m, n, (T*)nullptr, lda, &size_W);
 
     if(argus.mem_query)
     {
@@ -918,7 +918,7 @@ void testing_gebrd(Arguments& argus)
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
-        //     gebrd_getError<FORTRAN, T>(handle,
+        //     gebrd_getError<API, T>(handle,
         //                                m,
         //                                n,
         //                                dA,
@@ -948,7 +948,7 @@ void testing_gebrd(Arguments& argus)
 
         // // collect performance data
         // if(argus.timing)
-        //     gebrd_getPerfData<FORTRAN, T>(handle,
+        //     gebrd_getPerfData<API, T>(handle,
         //                                   m,
         //                                   n,
         //                                   dA,
@@ -1012,64 +1012,64 @@ void testing_gebrd(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check)
-            gebrd_getError<FORTRAN, T>(handle,
-                                       m,
-                                       n,
-                                       dA,
-                                       lda,
-                                       stA,
-                                       dD,
-                                       stD,
-                                       dE,
-                                       stE,
-                                       dTauq,
-                                       stQ,
-                                       dTaup,
-                                       stP,
-                                       dWork,
-                                       size_W,
-                                       dInfo,
-                                       bc,
-                                       hA,
-                                       hARes,
-                                       hD,
-                                       hE,
-                                       hTauq,
-                                       hTaup,
-                                       hInfo,
-                                       hInfoRes,
-                                       &max_error);
+            gebrd_getError<API, T>(handle,
+                                   m,
+                                   n,
+                                   dA,
+                                   lda,
+                                   stA,
+                                   dD,
+                                   stD,
+                                   dE,
+                                   stE,
+                                   dTauq,
+                                   stQ,
+                                   dTaup,
+                                   stP,
+                                   dWork,
+                                   size_W,
+                                   dInfo,
+                                   bc,
+                                   hA,
+                                   hARes,
+                                   hD,
+                                   hE,
+                                   hTauq,
+                                   hTaup,
+                                   hInfo,
+                                   hInfoRes,
+                                   &max_error);
 
         // collect performance data
         if(argus.timing)
-            gebrd_getPerfData<FORTRAN, T>(handle,
-                                          m,
-                                          n,
-                                          dA,
-                                          lda,
-                                          stA,
-                                          dD,
-                                          stD,
-                                          dE,
-                                          stE,
-                                          dTauq,
-                                          stQ,
-                                          dTaup,
-                                          stP,
-                                          dWork,
-                                          size_W,
-                                          dInfo,
-                                          bc,
-                                          hA,
-                                          hD,
-                                          hE,
-                                          hTauq,
-                                          hTaup,
-                                          hInfo,
-                                          &gpu_time_used,
-                                          &cpu_time_used,
-                                          hot_calls,
-                                          argus.perf);
+            gebrd_getPerfData<API, T>(handle,
+                                      m,
+                                      n,
+                                      dA,
+                                      lda,
+                                      stA,
+                                      dD,
+                                      stD,
+                                      dE,
+                                      stE,
+                                      dTauq,
+                                      stQ,
+                                      dTaup,
+                                      stP,
+                                      dWork,
+                                      size_W,
+                                      dInfo,
+                                      bc,
+                                      hA,
+                                      hD,
+                                      hE,
+                                      hTauq,
+                                      hTaup,
+                                      hInfo,
+                                      &gpu_time_used,
+                                      &cpu_time_used,
+                                      hot_calls,
+                                      argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_geqrf.hpp
+++ b/clients/include/testing_geqrf.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, typename T, typename U, typename V>
+template <testAPI_t API, typename T, typename U, typename V>
 void geqrf_checkBadArgs(const hipsolverHandle_t handle,
                         const int               m,
                         const int               n,
@@ -41,7 +41,7 @@ void geqrf_checkBadArgs(const hipsolverHandle_t handle,
 {
     // handle
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_geqrf(FORTRAN, nullptr, m, n, dA, lda, stA, dIpiv, stP, dWork, lwork, dInfo, bc),
+        hipsolver_geqrf(API, nullptr, m, n, dA, lda, stA, dIpiv, stP, dWork, lwork, dInfo, bc),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
@@ -51,20 +51,18 @@ void geqrf_checkBadArgs(const hipsolverHandle_t handle,
     // pointers
     EXPECT_ROCBLAS_STATUS(
         hipsolver_geqrf(
-            FORTRAN, handle, m, n, (T) nullptr, lda, stA, dIpiv, stP, dWork, lwork, dInfo, bc),
+            API, handle, m, n, (T) nullptr, lda, stA, dIpiv, stP, dWork, lwork, dInfo, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_geqrf(
-            FORTRAN, handle, m, n, dA, lda, stA, (U) nullptr, stP, dWork, lwork, dInfo, bc),
+        hipsolver_geqrf(API, handle, m, n, dA, lda, stA, (U) nullptr, stP, dWork, lwork, dInfo, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_geqrf(
-            FORTRAN, handle, m, n, dA, lda, stA, dIpiv, stP, dWork, lwork, (V) nullptr, bc),
+        hipsolver_geqrf(API, handle, m, n, dA, lda, stA, dIpiv, stP, dWork, lwork, (V) nullptr, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_geqrf_bad_arg()
 {
     // safe arguments
@@ -87,13 +85,13 @@ void testing_geqrf_bad_arg()
         // CHECK_HIP_ERROR(dInfo.memcheck());
 
         // int size_W;
-        // hipsolver_geqrf_bufferSize(FORTRAN, handle, m, n, dA.data(), lda, &size_W);
+        // hipsolver_geqrf_bufferSize(API, handle, m, n, dA.data(), lda, &size_W);
         // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check bad arguments
-        // geqrf_checkBadArgs<FORTRAN>(handle,
+        // geqrf_checkBadArgs<API>(handle,
         //                             m,
         //                             n,
         //                             dA.data(),
@@ -117,24 +115,24 @@ void testing_geqrf_bad_arg()
         CHECK_HIP_ERROR(dInfo.memcheck());
 
         int size_W;
-        hipsolver_geqrf_bufferSize(FORTRAN, handle, m, n, dA.data(), lda, &size_W);
+        hipsolver_geqrf_bufferSize(API, handle, m, n, dA.data(), lda, &size_W);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
         // check bad arguments
-        geqrf_checkBadArgs<FORTRAN>(handle,
-                                    m,
-                                    n,
-                                    dA.data(),
-                                    lda,
-                                    stA,
-                                    dIpiv.data(),
-                                    stP,
-                                    dWork.data(),
-                                    size_W,
-                                    dInfo.data(),
-                                    bc);
+        geqrf_checkBadArgs<API>(handle,
+                                m,
+                                n,
+                                dA.data(),
+                                lda,
+                                stA,
+                                dIpiv.data(),
+                                stP,
+                                dWork.data(),
+                                size_W,
+                                dInfo.data(),
+                                bc);
     }
 }
 
@@ -178,7 +176,7 @@ void geqrf_initData(const hipsolverHandle_t handle,
     }
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Td,
           typename Ud,
@@ -212,7 +210,7 @@ void geqrf_getError(const hipsolverHandle_t handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(hipsolver_geqrf(FORTRAN,
+    CHECK_ROCBLAS_ERROR(hipsolver_geqrf(API,
                                         handle,
                                         m,
                                         n,
@@ -255,7 +253,7 @@ void geqrf_getError(const hipsolverHandle_t handle,
     *max_err += err;
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Td,
           typename Ud,
@@ -303,7 +301,7 @@ void geqrf_getPerfData(const hipsolverHandle_t handle,
     {
         geqrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_geqrf(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_geqrf(API,
                                             handle,
                                             m,
                                             n,
@@ -328,7 +326,7 @@ void geqrf_getPerfData(const hipsolverHandle_t handle,
         geqrf_initData<false, true, T>(handle, m, n, dA, lda, stA, dIpiv, stP, bc, hA, hIpiv);
 
         start = get_time_us_sync(stream);
-        hipsolver_geqrf(FORTRAN,
+        hipsolver_geqrf(API,
                         handle,
                         m,
                         n,
@@ -346,7 +344,7 @@ void geqrf_getPerfData(const hipsolverHandle_t handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_geqrf(Arguments& argus)
 {
     // get arguments
@@ -378,7 +376,7 @@ void testing_geqrf(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_geqrf(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_geqrf(API,
             //                                       handle,
             //                                       m,
             //                                       n,
@@ -395,7 +393,7 @@ void testing_geqrf(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_geqrf(FORTRAN,
+            EXPECT_ROCBLAS_STATUS(hipsolver_geqrf(API,
                                                   handle,
                                                   m,
                                                   n,
@@ -419,7 +417,7 @@ void testing_geqrf(Arguments& argus)
 
     // memory size query is necessary
     int size_W;
-    hipsolver_geqrf_bufferSize(FORTRAN, handle, m, n, (T*)nullptr, lda, &size_W);
+    hipsolver_geqrf_bufferSize(API, handle, m, n, (T*)nullptr, lda, &size_W);
 
     if(argus.mem_query)
     {
@@ -449,7 +447,7 @@ void testing_geqrf(Arguments& argus)
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
-        //     geqrf_getError<FORTRAN, T>(handle,
+        //     geqrf_getError<API, T>(handle,
         //                                m,
         //                                n,
         //                                dA,
@@ -470,7 +468,7 @@ void testing_geqrf(Arguments& argus)
 
         // // collect performance data
         // if(argus.timing)
-        //     geqrf_getPerfData<FORTRAN, T>(handle,
+        //     geqrf_getPerfData<API, T>(handle,
         //                                   m,
         //                                   n,
         //                                   dA,
@@ -513,46 +511,46 @@ void testing_geqrf(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check)
-            geqrf_getError<FORTRAN, T>(handle,
-                                       m,
-                                       n,
-                                       dA,
-                                       lda,
-                                       stA,
-                                       dIpiv,
-                                       stP,
-                                       dWork,
-                                       size_W,
-                                       dInfo,
-                                       bc,
-                                       hA,
-                                       hARes,
-                                       hIpiv,
-                                       hInfo,
-                                       hInfoRes,
-                                       &max_error);
+            geqrf_getError<API, T>(handle,
+                                   m,
+                                   n,
+                                   dA,
+                                   lda,
+                                   stA,
+                                   dIpiv,
+                                   stP,
+                                   dWork,
+                                   size_W,
+                                   dInfo,
+                                   bc,
+                                   hA,
+                                   hARes,
+                                   hIpiv,
+                                   hInfo,
+                                   hInfoRes,
+                                   &max_error);
 
         // collect performance data
         if(argus.timing)
-            geqrf_getPerfData<FORTRAN, T>(handle,
-                                          m,
-                                          n,
-                                          dA,
-                                          lda,
-                                          stA,
-                                          dIpiv,
-                                          stP,
-                                          dWork,
-                                          size_W,
-                                          dInfo,
-                                          bc,
-                                          hA,
-                                          hIpiv,
-                                          hInfo,
-                                          &gpu_time_used,
-                                          &cpu_time_used,
-                                          hot_calls,
-                                          argus.perf);
+            geqrf_getPerfData<API, T>(handle,
+                                      m,
+                                      n,
+                                      dA,
+                                      lda,
+                                      stA,
+                                      dIpiv,
+                                      stP,
+                                      dWork,
+                                      size_W,
+                                      dInfo,
+                                      bc,
+                                      hA,
+                                      hIpiv,
+                                      hInfo,
+                                      &gpu_time_used,
+                                      &cpu_time_used,
+                                      hot_calls,
+                                      argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_orgbr_ungbr.hpp
+++ b/clients/include/testing_orgbr_ungbr.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, typename T, typename U>
+template <testAPI_t API, typename T, typename U>
 void orgbr_ungbr_checkBadArgs(const hipsolverHandle_t   handle,
                               const hipsolverSideMode_t side,
                               const int                 m,
@@ -40,33 +40,33 @@ void orgbr_ungbr_checkBadArgs(const hipsolverHandle_t   handle,
 {
     // handle
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_orgbr_ungbr(FORTRAN, nullptr, side, m, n, k, dA, lda, dIpiv, dWork, lwork, dInfo),
+        hipsolver_orgbr_ungbr(API, nullptr, side, m, n, k, dA, lda, dIpiv, dWork, lwork, dInfo),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
     EXPECT_ROCBLAS_STATUS(
         hipsolver_orgbr_ungbr(
-            FORTRAN, handle, hipsolverSideMode_t(-1), m, n, k, dA, lda, dIpiv, dWork, lwork, dInfo),
+            API, handle, hipsolverSideMode_t(-1), m, n, k, dA, lda, dIpiv, dWork, lwork, dInfo),
         HIPSOLVER_STATUS_INVALID_ENUM);
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(
         hipsolver_orgbr_ungbr(
-            FORTRAN, handle, side, m, n, k, (T) nullptr, lda, dIpiv, dWork, lwork, dInfo),
+            API, handle, side, m, n, k, (T) nullptr, lda, dIpiv, dWork, lwork, dInfo),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
         hipsolver_orgbr_ungbr(
-            FORTRAN, handle, side, m, n, k, dA, lda, (T) nullptr, dWork, lwork, dInfo),
+            API, handle, side, m, n, k, dA, lda, (T) nullptr, dWork, lwork, dInfo),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
         hipsolver_orgbr_ungbr(
-            FORTRAN, handle, side, m, n, k, dA, lda, dIpiv, dWork, lwork, (U) nullptr),
+            API, handle, side, m, n, k, dA, lda, dIpiv, dWork, lwork, (U) nullptr),
         HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
 
-template <bool FORTRAN, typename T>
+template <testAPI_t API, typename T>
 void testing_orgbr_ungbr_bad_arg()
 {
     // safe arguments
@@ -87,13 +87,13 @@ void testing_orgbr_ungbr_bad_arg()
 
     int size_W;
     hipsolver_orgbr_ungbr_bufferSize(
-        FORTRAN, handle, side, m, n, k, dA.data(), lda, dIpiv.data(), &size_W);
+        API, handle, side, m, n, k, dA.data(), lda, dIpiv.data(), &size_W);
     device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
     if(size_W)
         CHECK_HIP_ERROR(dWork.memcheck());
 
     // check bad arguments
-    orgbr_ungbr_checkBadArgs<FORTRAN>(
+    orgbr_ungbr_checkBadArgs<API>(
         handle, side, m, n, k, dA.data(), lda, dIpiv.data(), dWork.data(), size_W, dInfo.data());
 }
 
@@ -166,7 +166,7 @@ void orgbr_ungbr_initData(const hipsolverHandle_t   handle,
     }
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>
+template <testAPI_t API, typename T, typename Td, typename Ud, typename Th, typename Uh>
 void orgbr_ungbr_getError(const hipsolverHandle_t   handle,
                           const hipsolverSideMode_t side,
                           const int                 m,
@@ -194,7 +194,7 @@ void orgbr_ungbr_getError(const hipsolverHandle_t   handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(hipsolver_orgbr_ungbr(FORTRAN,
+    CHECK_ROCBLAS_ERROR(hipsolver_orgbr_ungbr(API,
                                               handle,
                                               side,
                                               m,
@@ -224,7 +224,7 @@ void orgbr_ungbr_getError(const hipsolverHandle_t   handle,
         *max_err += 1;
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>
+template <testAPI_t API, typename T, typename Td, typename Ud, typename Th, typename Uh>
 void orgbr_ungbr_getPerfData(const hipsolverHandle_t   handle,
                              const hipsolverSideMode_t side,
                              const int                 m,
@@ -267,7 +267,7 @@ void orgbr_ungbr_getPerfData(const hipsolverHandle_t   handle,
         orgbr_ungbr_initData<false, true, T>(
             handle, side, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_orgbr_ungbr(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_orgbr_ungbr(API,
                                                   handle,
                                                   side,
                                                   m,
@@ -292,7 +292,7 @@ void orgbr_ungbr_getPerfData(const hipsolverHandle_t   handle,
             handle, side, m, n, k, dA, lda, dIpiv, hA, hIpiv, hW, size_W);
 
         start = get_time_us_sync(stream);
-        hipsolver_orgbr_ungbr(FORTRAN,
+        hipsolver_orgbr_ungbr(API,
                               handle,
                               side,
                               m,
@@ -309,7 +309,7 @@ void orgbr_ungbr_getPerfData(const hipsolverHandle_t   handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, typename T>
+template <testAPI_t API, typename T>
 void testing_orgbr_ungbr(Arguments& argus)
 {
     // get arguments
@@ -352,7 +352,7 @@ void testing_orgbr_ungbr(Arguments& argus)
                          || (!row && (n > m || n < min(m, k))));
     if(invalid_size)
     {
-        EXPECT_ROCBLAS_STATUS(hipsolver_orgbr_ungbr(FORTRAN,
+        EXPECT_ROCBLAS_STATUS(hipsolver_orgbr_ungbr(API,
                                                     handle,
                                                     side,
                                                     m,
@@ -375,7 +375,7 @@ void testing_orgbr_ungbr(Arguments& argus)
     // memory size query is necessary
     int size_W;
     hipsolver_orgbr_ungbr_bufferSize(
-        FORTRAN, handle, side, m, n, k, (T*)nullptr, lda, (T*)nullptr, &size_W);
+        API, handle, side, m, n, k, (T*)nullptr, lda, (T*)nullptr, &size_W);
 
     if(argus.mem_query)
     {
@@ -403,44 +403,44 @@ void testing_orgbr_ungbr(Arguments& argus)
 
     // check computations
     if(argus.unit_check || argus.norm_check)
-        orgbr_ungbr_getError<FORTRAN, T>(handle,
-                                         side,
-                                         m,
-                                         n,
-                                         k,
-                                         dA,
-                                         lda,
-                                         dIpiv,
-                                         dWork,
-                                         size_W,
-                                         dInfo,
-                                         hA,
-                                         hARes,
-                                         hIpiv,
-                                         hInfo,
-                                         hInfoRes,
-                                         &max_error);
+        orgbr_ungbr_getError<API, T>(handle,
+                                     side,
+                                     m,
+                                     n,
+                                     k,
+                                     dA,
+                                     lda,
+                                     dIpiv,
+                                     dWork,
+                                     size_W,
+                                     dInfo,
+                                     hA,
+                                     hARes,
+                                     hIpiv,
+                                     hInfo,
+                                     hInfoRes,
+                                     &max_error);
 
     // collect performance data
     if(argus.timing)
-        orgbr_ungbr_getPerfData<FORTRAN, T>(handle,
-                                            side,
-                                            m,
-                                            n,
-                                            k,
-                                            dA,
-                                            lda,
-                                            dIpiv,
-                                            dWork,
-                                            size_W,
-                                            dInfo,
-                                            hA,
-                                            hIpiv,
-                                            hInfo,
-                                            &gpu_time_used,
-                                            &cpu_time_used,
-                                            hot_calls,
-                                            argus.perf);
+        orgbr_ungbr_getPerfData<API, T>(handle,
+                                        side,
+                                        m,
+                                        n,
+                                        k,
+                                        dA,
+                                        lda,
+                                        dIpiv,
+                                        dWork,
+                                        size_W,
+                                        dInfo,
+                                        hA,
+                                        hIpiv,
+                                        hInfo,
+                                        &gpu_time_used,
+                                        &cpu_time_used,
+                                        hot_calls,
+                                        argus.perf);
 
     // validate results for rocsolver-test
     // using s * machine_precision as tolerance

--- a/clients/include/testing_ormqr_unmqr.hpp
+++ b/clients/include/testing_ormqr_unmqr.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, bool COMPLEX, typename T, typename U>
+template <testAPI_t API, bool COMPLEX, typename T, typename U>
 void ormqr_unmqr_checkBadArgs(const hipsolverHandle_t    handle,
                               const hipsolverSideMode_t  side,
                               const hipsolverOperation_t trans,
@@ -44,11 +44,11 @@ void ormqr_unmqr_checkBadArgs(const hipsolverHandle_t    handle,
     // handle
     EXPECT_ROCBLAS_STATUS(
         hipsolver_ormqr_unmqr(
-            FORTRAN, nullptr, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, dWork, lwork, dInfo),
+            API, nullptr, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, dWork, lwork, dInfo),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(API,
                                                 handle,
                                                 hipsolverSideMode_t(-1),
                                                 trans,
@@ -64,7 +64,7 @@ void ormqr_unmqr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 lwork,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_ENUM);
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(API,
                                                 handle,
                                                 side,
                                                 hipsolverOperation_t(-1),
@@ -81,7 +81,7 @@ void ormqr_unmqr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_ENUM);
     if(COMPLEX)
-        EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
+        EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(API,
                                                     handle,
                                                     side,
                                                     HIPSOLVER_OP_T,
@@ -98,7 +98,7 @@ void ormqr_unmqr_checkBadArgs(const hipsolverHandle_t    handle,
                                                     dInfo),
                               HIPSOLVER_STATUS_INVALID_VALUE);
     else
-        EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
+        EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(API,
                                                     handle,
                                                     side,
                                                     HIPSOLVER_OP_C,
@@ -117,7 +117,7 @@ void ormqr_unmqr_checkBadArgs(const hipsolverHandle_t    handle,
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(API,
                                                 handle,
                                                 side,
                                                 trans,
@@ -133,23 +133,11 @@ void ormqr_unmqr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 lwork,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
-                                                handle,
-                                                side,
-                                                trans,
-                                                m,
-                                                n,
-                                                k,
-                                                dA,
-                                                lda,
-                                                (T) nullptr,
-                                                dC,
-                                                ldc,
-                                                dWork,
-                                                lwork,
-                                                dInfo),
-                          HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_ormqr_unmqr(
+            API, handle, side, trans, m, n, k, dA, lda, (T) nullptr, dC, ldc, dWork, lwork, dInfo),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(API,
                                                 handle,
                                                 side,
                                                 trans,
@@ -165,26 +153,14 @@ void ormqr_unmqr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 lwork,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
-                                                handle,
-                                                side,
-                                                trans,
-                                                m,
-                                                n,
-                                                k,
-                                                dA,
-                                                lda,
-                                                dIpiv,
-                                                dC,
-                                                ldc,
-                                                dWork,
-                                                lwork,
-                                                (U) nullptr),
-                          HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_ormqr_unmqr(
+            API, handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, dWork, lwork, (U) nullptr),
+        HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
 
-template <bool FORTRAN, typename T, bool COMPLEX = is_complex<T>>
+template <testAPI_t API, typename T, bool COMPLEX = is_complex<T>>
 void testing_ormqr_unmqr_bad_arg()
 {
     // safe arguments
@@ -208,38 +184,27 @@ void testing_ormqr_unmqr_bad_arg()
     CHECK_HIP_ERROR(dInfo.memcheck());
 
     int size_W;
-    hipsolver_ormqr_unmqr_bufferSize(FORTRAN,
-                                     handle,
-                                     side,
-                                     trans,
-                                     m,
-                                     n,
-                                     k,
-                                     dA.data(),
-                                     lda,
-                                     dIpiv.data(),
-                                     dC.data(),
-                                     ldc,
-                                     &size_W);
+    hipsolver_ormqr_unmqr_bufferSize(
+        API, handle, side, trans, m, n, k, dA.data(), lda, dIpiv.data(), dC.data(), ldc, &size_W);
     device_strided_batch_vector<T> dWork(size_W, 1, size_W, 1);
     if(size_W)
         CHECK_HIP_ERROR(dWork.memcheck());
 
     // check bad arguments
-    ormqr_unmqr_checkBadArgs<FORTRAN, COMPLEX>(handle,
-                                               side,
-                                               trans,
-                                               m,
-                                               n,
-                                               k,
-                                               dA.data(),
-                                               lda,
-                                               dIpiv.data(),
-                                               dC.data(),
-                                               ldc,
-                                               dWork.data(),
-                                               size_W,
-                                               dInfo.data());
+    ormqr_unmqr_checkBadArgs<API, COMPLEX>(handle,
+                                           side,
+                                           trans,
+                                           m,
+                                           n,
+                                           k,
+                                           dA.data(),
+                                           lda,
+                                           dIpiv.data(),
+                                           dC.data(),
+                                           ldc,
+                                           dWork.data(),
+                                           size_W,
+                                           dInfo.data());
 }
 
 template <bool CPU, bool GPU, typename T, typename Td, typename Th>
@@ -294,7 +259,7 @@ void ormqr_unmqr_initData(const hipsolverHandle_t    handle,
     }
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>
+template <testAPI_t API, typename T, typename Td, typename Ud, typename Th, typename Uh>
 void ormqr_unmqr_getError(const hipsolverHandle_t    handle,
                           const hipsolverSideMode_t  side,
                           const hipsolverOperation_t trans,
@@ -326,7 +291,7 @@ void ormqr_unmqr_getError(const hipsolverHandle_t    handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(hipsolver_ormqr_unmqr(FORTRAN,
+    CHECK_ROCBLAS_ERROR(hipsolver_ormqr_unmqr(API,
                                               handle,
                                               side,
                                               trans,
@@ -360,7 +325,7 @@ void ormqr_unmqr_getError(const hipsolverHandle_t    handle,
         *max_err += 1;
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>
+template <testAPI_t API, typename T, typename Td, typename Ud, typename Th, typename Uh>
 void ormqr_unmqr_getPerfData(const hipsolverHandle_t    handle,
                              const hipsolverSideMode_t  side,
                              const hipsolverOperation_t trans,
@@ -408,7 +373,7 @@ void ormqr_unmqr_getPerfData(const hipsolverHandle_t    handle,
         ormqr_unmqr_initData<false, true, T>(
             handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, hA, hIpiv, hC, hW, size_W);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_ormqr_unmqr(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_ormqr_unmqr(API,
                                                   handle,
                                                   side,
                                                   trans,
@@ -436,7 +401,7 @@ void ormqr_unmqr_getPerfData(const hipsolverHandle_t    handle,
             handle, side, trans, m, n, k, dA, lda, dIpiv, dC, ldc, hA, hIpiv, hC, hW, size_W);
 
         start = get_time_us_sync(stream);
-        hipsolver_ormqr_unmqr(FORTRAN,
+        hipsolver_ormqr_unmqr(API,
                               handle,
                               side,
                               trans,
@@ -456,7 +421,7 @@ void ormqr_unmqr_getPerfData(const hipsolverHandle_t    handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, typename T, bool COMPLEX = is_complex<T>>
+template <testAPI_t API, typename T, bool COMPLEX = is_complex<T>>
 void testing_ormqr_unmqr(Arguments& argus)
 {
     // get arguments
@@ -488,7 +453,7 @@ void testing_ormqr_unmqr(Arguments& argus)
         = ((COMPLEX && trans == HIPSOLVER_OP_T) || (!COMPLEX && trans == HIPSOLVER_OP_C));
     if(invalid_value)
     {
-        EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
+        EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(API,
                                                     handle,
                                                     side,
                                                     trans,
@@ -525,7 +490,7 @@ void testing_ormqr_unmqr(Arguments& argus)
                          || (!left && (lda < n || k > n)));
     if(invalid_size)
     {
-        EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(FORTRAN,
+        EXPECT_ROCBLAS_STATUS(hipsolver_ormqr_unmqr(API,
                                                     handle,
                                                     side,
                                                     trans,
@@ -550,7 +515,7 @@ void testing_ormqr_unmqr(Arguments& argus)
 
     // memory size query is necessary
     int size_W;
-    hipsolver_ormqr_unmqr_bufferSize(FORTRAN,
+    hipsolver_ormqr_unmqr_bufferSize(API,
                                      handle,
                                      side,
                                      trans,
@@ -594,52 +559,52 @@ void testing_ormqr_unmqr(Arguments& argus)
 
     // check computations
     if(argus.unit_check || argus.norm_check)
-        ormqr_unmqr_getError<FORTRAN, T>(handle,
-                                         side,
-                                         trans,
-                                         m,
-                                         n,
-                                         k,
-                                         dA,
-                                         lda,
-                                         dIpiv,
-                                         dC,
-                                         ldc,
-                                         dWork,
-                                         size_W,
-                                         dInfo,
-                                         hA,
-                                         hIpiv,
-                                         hC,
-                                         hCRes,
-                                         hInfo,
-                                         hInfoRes,
-                                         &max_error);
+        ormqr_unmqr_getError<API, T>(handle,
+                                     side,
+                                     trans,
+                                     m,
+                                     n,
+                                     k,
+                                     dA,
+                                     lda,
+                                     dIpiv,
+                                     dC,
+                                     ldc,
+                                     dWork,
+                                     size_W,
+                                     dInfo,
+                                     hA,
+                                     hIpiv,
+                                     hC,
+                                     hCRes,
+                                     hInfo,
+                                     hInfoRes,
+                                     &max_error);
 
     // collect performance data
     if(argus.timing)
-        ormqr_unmqr_getPerfData<FORTRAN, T>(handle,
-                                            side,
-                                            trans,
-                                            m,
-                                            n,
-                                            k,
-                                            dA,
-                                            lda,
-                                            dIpiv,
-                                            dC,
-                                            ldc,
-                                            dWork,
-                                            size_W,
-                                            dInfo,
-                                            hA,
-                                            hIpiv,
-                                            hC,
-                                            hInfo,
-                                            &gpu_time_used,
-                                            &cpu_time_used,
-                                            hot_calls,
-                                            argus.perf);
+        ormqr_unmqr_getPerfData<API, T>(handle,
+                                        side,
+                                        trans,
+                                        m,
+                                        n,
+                                        k,
+                                        dA,
+                                        lda,
+                                        dIpiv,
+                                        dC,
+                                        ldc,
+                                        dWork,
+                                        size_W,
+                                        dInfo,
+                                        hA,
+                                        hIpiv,
+                                        hC,
+                                        hInfo,
+                                        &gpu_time_used,
+                                        &cpu_time_used,
+                                        hot_calls,
+                                        argus.perf);
 
     // validate results for rocsolver-test
     // using s * machine_precision as tolerance

--- a/clients/include/testing_ormtr_unmtr.hpp
+++ b/clients/include/testing_ormtr_unmtr.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, bool COMPLEX, typename T, typename U>
+template <testAPI_t API, bool COMPLEX, typename T, typename U>
 void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
                               const hipsolverSideMode_t  side,
                               const hipsolverFillMode_t  uplo,
@@ -42,25 +42,13 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
                               U                          dInfo)
 {
     // handle
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
-                                                nullptr,
-                                                side,
-                                                uplo,
-                                                trans,
-                                                m,
-                                                n,
-                                                dA,
-                                                lda,
-                                                dIpiv,
-                                                dC,
-                                                ldc,
-                                                dWork,
-                                                lwork,
-                                                dInfo),
-                          HIPSOLVER_STATUS_NOT_INITIALIZED);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_ormtr_unmtr(
+            API, nullptr, side, uplo, trans, m, n, dA, lda, dIpiv, dC, ldc, dWork, lwork, dInfo),
+        HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                 handle,
                                                 hipsolverSideMode_t(-1),
                                                 uplo,
@@ -76,7 +64,7 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 lwork,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_ENUM);
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                 handle,
                                                 side,
                                                 hipsolverFillMode_t(-1),
@@ -92,7 +80,7 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 lwork,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_ENUM);
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                 handle,
                                                 side,
                                                 uplo,
@@ -109,7 +97,7 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_ENUM);
     if(COMPLEX)
-        EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+        EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                     handle,
                                                     side,
                                                     uplo,
@@ -126,7 +114,7 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
                                                     dInfo),
                               HIPSOLVER_STATUS_INVALID_VALUE);
     else
-        EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+        EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                     handle,
                                                     side,
                                                     uplo,
@@ -145,7 +133,7 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                 handle,
                                                 side,
                                                 uplo,
@@ -161,7 +149,7 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 lwork,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                 handle,
                                                 side,
                                                 uplo,
@@ -177,7 +165,7 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 lwork,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                 handle,
                                                 side,
                                                 uplo,
@@ -193,7 +181,7 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
                                                 lwork,
                                                 dInfo),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                 handle,
                                                 side,
                                                 uplo,
@@ -212,7 +200,7 @@ void ormtr_unmtr_checkBadArgs(const hipsolverHandle_t    handle,
 #endif
 }
 
-template <bool FORTRAN, typename T, bool COMPLEX = is_complex<T>>
+template <testAPI_t API, typename T, bool COMPLEX = is_complex<T>>
 void testing_ormtr_unmtr_bad_arg()
 {
     // safe arguments
@@ -236,7 +224,7 @@ void testing_ormtr_unmtr_bad_arg()
     CHECK_HIP_ERROR(dInfo.memcheck());
 
     int size_W;
-    hipsolver_ormtr_unmtr_bufferSize(FORTRAN,
+    hipsolver_ormtr_unmtr_bufferSize(API,
                                      handle,
                                      side,
                                      uplo,
@@ -254,20 +242,20 @@ void testing_ormtr_unmtr_bad_arg()
         CHECK_HIP_ERROR(dWork.memcheck());
 
     // check bad arguments
-    ormtr_unmtr_checkBadArgs<FORTRAN, COMPLEX>(handle,
-                                               side,
-                                               uplo,
-                                               trans,
-                                               m,
-                                               n,
-                                               dA.data(),
-                                               lda,
-                                               dIpiv.data(),
-                                               dC.data(),
-                                               ldc,
-                                               dWork.data(),
-                                               size_W,
-                                               dInfo.data());
+    ormtr_unmtr_checkBadArgs<API, COMPLEX>(handle,
+                                           side,
+                                           uplo,
+                                           trans,
+                                           m,
+                                           n,
+                                           dA.data(),
+                                           lda,
+                                           dIpiv.data(),
+                                           dC.data(),
+                                           ldc,
+                                           dWork.data(),
+                                           size_W,
+                                           dInfo.data());
 }
 
 template <bool CPU, bool GPU, typename T, typename Td, typename Th>
@@ -324,7 +312,7 @@ void ormtr_unmtr_initData(const hipsolverHandle_t    handle,
     }
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>
+template <testAPI_t API, typename T, typename Td, typename Ud, typename Th, typename Uh>
 void ormtr_unmtr_getError(const hipsolverHandle_t    handle,
                           const hipsolverSideMode_t  side,
                           const hipsolverFillMode_t  uplo,
@@ -356,7 +344,7 @@ void ormtr_unmtr_getError(const hipsolverHandle_t    handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(hipsolver_ormtr_unmtr(FORTRAN,
+    CHECK_ROCBLAS_ERROR(hipsolver_ormtr_unmtr(API,
                                               handle,
                                               side,
                                               uplo,
@@ -390,7 +378,7 @@ void ormtr_unmtr_getError(const hipsolverHandle_t    handle,
         *max_err += 1;
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Th, typename Uh>
+template <testAPI_t API, typename T, typename Td, typename Ud, typename Th, typename Uh>
 void ormtr_unmtr_getPerfData(const hipsolverHandle_t    handle,
                              const hipsolverSideMode_t  side,
                              const hipsolverFillMode_t  uplo,
@@ -438,7 +426,7 @@ void ormtr_unmtr_getPerfData(const hipsolverHandle_t    handle,
         ormtr_unmtr_initData<false, true, T>(
             handle, side, uplo, trans, m, n, dA, lda, dIpiv, dC, ldc, hA, hIpiv, hC, hW, size_W);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_ormtr_unmtr(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_ormtr_unmtr(API,
                                                   handle,
                                                   side,
                                                   uplo,
@@ -466,7 +454,7 @@ void ormtr_unmtr_getPerfData(const hipsolverHandle_t    handle,
             handle, side, uplo, trans, m, n, dA, lda, dIpiv, dC, ldc, hA, hIpiv, hC, hW, size_W);
 
         start = get_time_us_sync(stream);
-        hipsolver_ormtr_unmtr(FORTRAN,
+        hipsolver_ormtr_unmtr(API,
                               handle,
                               side,
                               uplo,
@@ -486,7 +474,7 @@ void ormtr_unmtr_getPerfData(const hipsolverHandle_t    handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, typename T, bool COMPLEX = is_complex<T>>
+template <testAPI_t API, typename T, bool COMPLEX = is_complex<T>>
 void testing_ormtr_unmtr(Arguments& argus)
 {
     // get arguments
@@ -519,7 +507,7 @@ void testing_ormtr_unmtr(Arguments& argus)
         = ((COMPLEX && trans == HIPSOLVER_OP_T) || (!COMPLEX && trans == HIPSOLVER_OP_C));
     if(invalid_value)
     {
-        EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+        EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                     handle,
                                                     side,
                                                     uplo,
@@ -556,7 +544,7 @@ void testing_ormtr_unmtr(Arguments& argus)
     bool invalid_size = (m < 0 || n < 0 || ldc < m || lda < nq);
     if(invalid_size)
     {
-        EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(FORTRAN,
+        EXPECT_ROCBLAS_STATUS(hipsolver_ormtr_unmtr(API,
                                                     handle,
                                                     side,
                                                     uplo,
@@ -581,7 +569,7 @@ void testing_ormtr_unmtr(Arguments& argus)
 
     // memory size query is necessary
     int size_W;
-    hipsolver_ormtr_unmtr_bufferSize(FORTRAN,
+    hipsolver_ormtr_unmtr_bufferSize(API,
                                      handle,
                                      side,
                                      uplo,
@@ -625,52 +613,52 @@ void testing_ormtr_unmtr(Arguments& argus)
 
     // check computations
     if(argus.unit_check || argus.norm_check)
-        ormtr_unmtr_getError<FORTRAN, T>(handle,
-                                         side,
-                                         uplo,
-                                         trans,
-                                         m,
-                                         n,
-                                         dA,
-                                         lda,
-                                         dIpiv,
-                                         dC,
-                                         ldc,
-                                         dWork,
-                                         size_W,
-                                         dInfo,
-                                         hA,
-                                         hIpiv,
-                                         hC,
-                                         hCRes,
-                                         hInfo,
-                                         hInfoRes,
-                                         &max_error);
+        ormtr_unmtr_getError<API, T>(handle,
+                                     side,
+                                     uplo,
+                                     trans,
+                                     m,
+                                     n,
+                                     dA,
+                                     lda,
+                                     dIpiv,
+                                     dC,
+                                     ldc,
+                                     dWork,
+                                     size_W,
+                                     dInfo,
+                                     hA,
+                                     hIpiv,
+                                     hC,
+                                     hCRes,
+                                     hInfo,
+                                     hInfoRes,
+                                     &max_error);
 
     // collect performance data
     if(argus.timing)
-        ormtr_unmtr_getPerfData<FORTRAN, T>(handle,
-                                            side,
-                                            uplo,
-                                            trans,
-                                            m,
-                                            n,
-                                            dA,
-                                            lda,
-                                            dIpiv,
-                                            dC,
-                                            ldc,
-                                            dWork,
-                                            size_W,
-                                            dInfo,
-                                            hA,
-                                            hIpiv,
-                                            hC,
-                                            hInfo,
-                                            &gpu_time_used,
-                                            &cpu_time_used,
-                                            hot_calls,
-                                            argus.perf);
+        ormtr_unmtr_getPerfData<API, T>(handle,
+                                        side,
+                                        uplo,
+                                        trans,
+                                        m,
+                                        n,
+                                        dA,
+                                        lda,
+                                        dIpiv,
+                                        dC,
+                                        ldc,
+                                        dWork,
+                                        size_W,
+                                        dInfo,
+                                        hA,
+                                        hIpiv,
+                                        hC,
+                                        hInfo,
+                                        &gpu_time_used,
+                                        &cpu_time_used,
+                                        hot_calls,
+                                        argus.perf);
 
     // validate results for rocsolver-test
     // using s * machine_precision as tolerance

--- a/clients/include/testing_potri.hpp
+++ b/clients/include/testing_potri.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, typename T, typename U, typename V>
+template <testAPI_t API, typename T, typename U, typename V>
 void potri_checkBadArgs(const hipsolverHandle_t   handle,
                         const hipsolverFillMode_t uplo,
                         const int                 n,
@@ -39,27 +39,27 @@ void potri_checkBadArgs(const hipsolverHandle_t   handle,
 {
     // handle
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_potri(FORTRAN, nullptr, uplo, n, dA, lda, stA, dWork, lwork, dinfo, bc),
+        hipsolver_potri(API, nullptr, uplo, n, dA, lda, stA, dWork, lwork, dinfo, bc),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
     EXPECT_ROCBLAS_STATUS(
         hipsolver_potri(
-            FORTRAN, handle, hipsolverFillMode_t(-1), n, dA, lda, stA, dWork, lwork, dinfo, bc),
+            API, handle, hipsolverFillMode_t(-1), n, dA, lda, stA, dWork, lwork, dinfo, bc),
         HIPSOLVER_STATUS_INVALID_ENUM);
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_potri(FORTRAN, handle, uplo, n, (T) nullptr, lda, stA, dWork, lwork, dinfo, bc),
+        hipsolver_potri(API, handle, uplo, n, (T) nullptr, lda, stA, dWork, lwork, dinfo, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_potri(FORTRAN, handle, uplo, n, dA, lda, stA, dWork, lwork, (V) nullptr, bc),
+        hipsolver_potri(API, handle, uplo, n, dA, lda, stA, dWork, lwork, (V) nullptr, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_potri_bad_arg()
 {
     // safe arguments
@@ -79,13 +79,13 @@ void testing_potri_bad_arg()
         // CHECK_HIP_ERROR(dinfo.memcheck());
 
         // int size_W;
-        // hipsolver_potri_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W);
+        // hipsolver_potri_bufferSize(API, handle, uplo, n, dA.data(), lda, &size_W);
         // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check bad arguments
-        // potri_checkBadArgs<FORTRAN>(
+        // potri_checkBadArgs<API>(
         //     handle, uplo, n, dA.data(), lda, stA, dWork.data(), size_W, dinfo.data(), bc);
     }
     else
@@ -97,13 +97,13 @@ void testing_potri_bad_arg()
         CHECK_HIP_ERROR(dinfo.memcheck());
 
         int size_W;
-        hipsolver_potri_bufferSize(FORTRAN, handle, uplo, n, dA.data(), lda, &size_W);
+        hipsolver_potri_bufferSize(API, handle, uplo, n, dA.data(), lda, &size_W);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
         // check bad arguments
-        potri_checkBadArgs<FORTRAN>(
+        potri_checkBadArgs<API>(
             handle, uplo, n, dA.data(), lda, stA, dWork.data(), size_W, dinfo.data(), bc);
     }
 }
@@ -142,7 +142,13 @@ void potri_initData(const hipsolverHandle_t   handle,
     }
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Vd, typename Th, typename Uh>
+template <testAPI_t API,
+          typename T,
+          typename Td,
+          typename Ud,
+          typename Vd,
+          typename Th,
+          typename Uh>
 void potri_getError(const hipsolverHandle_t   handle,
                     const hipsolverFillMode_t uplo,
                     const int                 n,
@@ -165,7 +171,7 @@ void potri_getError(const hipsolverHandle_t   handle,
     // execute computations
     // GPU lapack
     CHECK_ROCBLAS_ERROR(hipsolver_potri(
-        FORTRAN, handle, uplo, n, dA.data(), lda, stA, dWork.data(), lwork, dInfo.data(), bc));
+        API, handle, uplo, n, dA.data(), lda, stA, dWork.data(), lwork, dInfo.data(), bc));
     CHECK_HIP_ERROR(hARes.transfer_from(dA));
     CHECK_HIP_ERROR(hInfoRes.transfer_from(dInfo));
 
@@ -201,7 +207,13 @@ void potri_getError(const hipsolverHandle_t   handle,
     }
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Vd, typename Th, typename Uh>
+template <testAPI_t API,
+          typename T,
+          typename Td,
+          typename Ud,
+          typename Vd,
+          typename Th,
+          typename Uh>
 void potri_getPerfData(const hipsolverHandle_t   handle,
                        const hipsolverFillMode_t uplo,
                        const int                 n,
@@ -238,7 +250,7 @@ void potri_getPerfData(const hipsolverHandle_t   handle,
         potri_initData<false, true, T>(handle, uplo, n, dA, lda, stA, dInfo, bc, hA, hInfo);
 
         CHECK_ROCBLAS_ERROR(hipsolver_potri(
-            FORTRAN, handle, uplo, n, dA.data(), lda, stA, dWork.data(), lwork, dInfo.data(), bc));
+            API, handle, uplo, n, dA.data(), lda, stA, dWork.data(), lwork, dInfo.data(), bc));
     }
 
     // gpu-lapack performance
@@ -252,13 +264,13 @@ void potri_getPerfData(const hipsolverHandle_t   handle,
 
         start = get_time_us_sync(stream);
         hipsolver_potri(
-            FORTRAN, handle, uplo, n, dA.data(), lda, stA, dWork.data(), lwork, dInfo.data(), bc);
+            API, handle, uplo, n, dA.data(), lda, stA, dWork.data(), lwork, dInfo.data(), bc);
         *gpu_time_used += get_time_us_sync(stream) - start;
     }
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_potri(Arguments& argus)
 {
     // get arguments
@@ -279,7 +291,7 @@ void testing_potri(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_potri(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_potri(API,
             //                                       handle,
             //                                       uplo,
             //                                       n,
@@ -294,18 +306,10 @@ void testing_potri(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_potri(FORTRAN,
-                                                  handle,
-                                                  uplo,
-                                                  n,
-                                                  (T*)nullptr,
-                                                  lda,
-                                                  stA,
-                                                  (T*)nullptr,
-                                                  0,
-                                                  (int*)nullptr,
-                                                  bc),
-                                  HIPSOLVER_STATUS_INVALID_VALUE);
+            EXPECT_ROCBLAS_STATUS(
+                hipsolver_potri(
+                    API, handle, uplo, n, (T*)nullptr, lda, stA, (T*)nullptr, 0, (int*)nullptr, bc),
+                HIPSOLVER_STATUS_INVALID_VALUE);
         }
 
         if(argus.timing)
@@ -326,7 +330,7 @@ void testing_potri(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_potri(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_potri(API,
             //                                       handle,
             //                                       uplo,
             //                                       n,
@@ -341,18 +345,10 @@ void testing_potri(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_potri(FORTRAN,
-                                                  handle,
-                                                  uplo,
-                                                  n,
-                                                  (T*)nullptr,
-                                                  lda,
-                                                  stA,
-                                                  (T*)nullptr,
-                                                  0,
-                                                  (int*)nullptr,
-                                                  bc),
-                                  HIPSOLVER_STATUS_INVALID_VALUE);
+            EXPECT_ROCBLAS_STATUS(
+                hipsolver_potri(
+                    API, handle, uplo, n, (T*)nullptr, lda, stA, (T*)nullptr, 0, (int*)nullptr, bc),
+                HIPSOLVER_STATUS_INVALID_VALUE);
         }
 
         if(argus.timing)
@@ -363,7 +359,7 @@ void testing_potri(Arguments& argus)
 
     // memory size query is necessary
     int size_W;
-    hipsolver_potri_bufferSize(FORTRAN, handle, uplo, n, (T*)nullptr, lda, &size_W);
+    hipsolver_potri_bufferSize(API, handle, uplo, n, (T*)nullptr, lda, &size_W);
 
     if(argus.mem_query)
     {
@@ -389,7 +385,7 @@ void testing_potri(Arguments& argus)
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
-        //     potri_getError<FORTRAN, T>(handle,
+        //     potri_getError<API, T>(handle,
         //                                uplo,
         //                                n,
         //                                dA,
@@ -407,7 +403,7 @@ void testing_potri(Arguments& argus)
 
         // // collect performance data
         // if(argus.timing)
-        //     potri_getPerfData<FORTRAN, T>(handle,
+        //     potri_getPerfData<API, T>(handle,
         //                                   uplo,
         //                                   n,
         //                                   dA,
@@ -443,40 +439,40 @@ void testing_potri(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check)
-            potri_getError<FORTRAN, T>(handle,
-                                       uplo,
-                                       n,
-                                       dA,
-                                       lda,
-                                       stA,
-                                       dWork,
-                                       size_W,
-                                       dInfo,
-                                       bc,
-                                       hA,
-                                       hARes,
-                                       hInfo,
-                                       hInfoRes,
-                                       &max_error);
+            potri_getError<API, T>(handle,
+                                   uplo,
+                                   n,
+                                   dA,
+                                   lda,
+                                   stA,
+                                   dWork,
+                                   size_W,
+                                   dInfo,
+                                   bc,
+                                   hA,
+                                   hARes,
+                                   hInfo,
+                                   hInfoRes,
+                                   &max_error);
 
         // collect performance data
         if(argus.timing)
-            potri_getPerfData<FORTRAN, T>(handle,
-                                          uplo,
-                                          n,
-                                          dA,
-                                          lda,
-                                          stA,
-                                          dWork,
-                                          size_W,
-                                          dInfo,
-                                          bc,
-                                          hA,
-                                          hInfo,
-                                          &gpu_time_used,
-                                          &cpu_time_used,
-                                          hot_calls,
-                                          argus.perf);
+            potri_getPerfData<API, T>(handle,
+                                      uplo,
+                                      n,
+                                      dA,
+                                      lda,
+                                      stA,
+                                      dWork,
+                                      size_W,
+                                      dInfo,
+                                      bc,
+                                      hA,
+                                      hInfo,
+                                      &gpu_time_used,
+                                      &cpu_time_used,
+                                      hot_calls,
+                                      argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_syevd_heevd.hpp
+++ b/clients/include/testing_syevd_heevd.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, typename T, typename S, typename U>
+template <testAPI_t API, typename T, typename S, typename U>
 void syevd_heevd_checkBadArgs(const hipsolverHandle_t   handle,
                               const hipsolverEigMode_t  evect,
                               const hipsolverFillMode_t uplo,
@@ -43,11 +43,11 @@ void syevd_heevd_checkBadArgs(const hipsolverHandle_t   handle,
     // handle
     EXPECT_ROCBLAS_STATUS(
         hipsolver_syevd_heevd(
-            FORTRAN, nullptr, evect, uplo, n, dA, lda, stA, dD, stD, dWork, lwork, dinfo, bc),
+            API, nullptr, evect, uplo, n, dA, lda, stA, dD, stD, dWork, lwork, dinfo, bc),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
-    EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(API,
                                                 handle,
                                                 hipsolverEigMode_t(-1),
                                                 uplo,
@@ -62,7 +62,7 @@ void syevd_heevd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dinfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
-    EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(API,
                                                 handle,
                                                 evect,
                                                 hipsolverFillMode_t(-1),
@@ -80,44 +80,22 @@ void syevd_heevd_checkBadArgs(const hipsolverHandle_t   handle,
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
-    EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(FORTRAN,
-                                                handle,
-                                                evect,
-                                                uplo,
-                                                n,
-                                                (T) nullptr,
-                                                lda,
-                                                stA,
-                                                dD,
-                                                stD,
-                                                dWork,
-                                                lwork,
-                                                dinfo,
-                                                bc),
-                          HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(FORTRAN,
-                                                handle,
-                                                evect,
-                                                uplo,
-                                                n,
-                                                dA,
-                                                lda,
-                                                stA,
-                                                (S) nullptr,
-                                                stD,
-                                                dWork,
-                                                lwork,
-                                                dinfo,
-                                                bc),
-                          HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
         hipsolver_syevd_heevd(
-            FORTRAN, handle, evect, uplo, n, dA, lda, stA, dD, stD, dWork, lwork, (U) nullptr, bc),
+            API, handle, evect, uplo, n, (T) nullptr, lda, stA, dD, stD, dWork, lwork, dinfo, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_syevd_heevd(
+            API, handle, evect, uplo, n, dA, lda, stA, (S) nullptr, stD, dWork, lwork, dinfo, bc),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_syevd_heevd(
+            API, handle, evect, uplo, n, dA, lda, stA, dD, stD, dWork, lwork, (U) nullptr, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_syevd_heevd_bad_arg()
 {
     using S = decltype(std::real(T{}));
@@ -144,13 +122,13 @@ void testing_syevd_heevd_bad_arg()
 
         // int size_W;
         // hipsolver_syevd_heevd_bufferSize(
-        //     FORTRAN, handle, evect, uplo, n, dA.data(), lda, dD.data(), &size_W);
+        //     API, handle, evect, uplo, n, dA.data(), lda, dD.data(), &size_W);
         // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check bad arguments
-        // syevd_heevd_checkBadArgs<FORTRAN>(handle,
+        // syevd_heevd_checkBadArgs<API>(handle,
         //                                   evect,
         //                                   uplo,
         //                                   n,
@@ -176,25 +154,25 @@ void testing_syevd_heevd_bad_arg()
 
         int size_W;
         hipsolver_syevd_heevd_bufferSize(
-            FORTRAN, handle, evect, uplo, n, dA.data(), lda, dD.data(), &size_W);
+            API, handle, evect, uplo, n, dA.data(), lda, dD.data(), &size_W);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
         // check bad arguments
-        syevd_heevd_checkBadArgs<FORTRAN>(handle,
-                                          evect,
-                                          uplo,
-                                          n,
-                                          dA.data(),
-                                          lda,
-                                          stA,
-                                          dD.data(),
-                                          stD,
-                                          dWork.data(),
-                                          size_W,
-                                          dinfo.data(),
-                                          bc);
+        syevd_heevd_checkBadArgs<API>(handle,
+                                      evect,
+                                      uplo,
+                                      n,
+                                      dA.data(),
+                                      lda,
+                                      stA,
+                                      dD.data(),
+                                      stD,
+                                      dWork.data(),
+                                      size_W,
+                                      dinfo.data(),
+                                      bc);
     }
 }
 
@@ -246,7 +224,7 @@ void syevd_heevd_initData(const hipsolverHandle_t  handle,
     }
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Sd,
           typename Td,
@@ -301,7 +279,7 @@ void syevd_heevd_getError(const hipsolverHandle_t   handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(hipsolver_syevd_heevd(FORTRAN,
+    CHECK_ROCBLAS_ERROR(hipsolver_syevd_heevd(API,
                                               handle,
                                               evect,
                                               uplo,
@@ -398,7 +376,7 @@ void syevd_heevd_getError(const hipsolverHandle_t   handle,
     }
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Sd,
           typename Td,
@@ -478,7 +456,7 @@ void syevd_heevd_getPerfData(const hipsolverHandle_t   handle,
     {
         syevd_heevd_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_syevd_heevd(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_syevd_heevd(API,
                                                   handle,
                                                   evect,
                                                   uplo,
@@ -504,7 +482,7 @@ void syevd_heevd_getPerfData(const hipsolverHandle_t   handle,
         syevd_heevd_initData<false, true, T>(handle, evect, n, dA, lda, bc, hA, A, 0);
 
         start = get_time_us_sync(stream);
-        hipsolver_syevd_heevd(FORTRAN,
+        hipsolver_syevd_heevd(API,
                               handle,
                               evect,
                               uplo,
@@ -523,7 +501,7 @@ void syevd_heevd_getPerfData(const hipsolverHandle_t   handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_syevd_heevd(Arguments& argus)
 {
     using S = decltype(std::real(T{}));
@@ -556,7 +534,7 @@ void testing_syevd_heevd(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(API,
             //                                             handle,
             //                                             evect,
             //                                             uplo,
@@ -574,7 +552,7 @@ void testing_syevd_heevd(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(FORTRAN,
+            EXPECT_ROCBLAS_STATUS(hipsolver_syevd_heevd(API,
                                                         handle,
                                                         evect,
                                                         uplo,
@@ -600,7 +578,7 @@ void testing_syevd_heevd(Arguments& argus)
     // memory size query is necessary
     int size_W;
     hipsolver_syevd_heevd_bufferSize(
-        FORTRAN, handle, evect, uplo, n, (T*)nullptr, lda, (S*)nullptr, &size_W);
+        API, handle, evect, uplo, n, (T*)nullptr, lda, (S*)nullptr, &size_W);
 
     if(argus.mem_query)
     {
@@ -636,7 +614,7 @@ void testing_syevd_heevd(Arguments& argus)
         // // check computations
         // if(argus.unit_check || argus.norm_check)
         // {
-        //     syevd_heevd_getError<FORTRAN, T>(handle,
+        //     syevd_heevd_getError<API, T>(handle,
         //                                      evect,
         //                                      uplo,
         //                                      n,
@@ -661,7 +639,7 @@ void testing_syevd_heevd(Arguments& argus)
         // // collect performance data
         // if(argus.timing)
         // {
-        //     syevd_heevd_getPerfData<FORTRAN, T>(handle,
+        //     syevd_heevd_getPerfData<API, T>(handle,
         //                                         evect,
         //                                         uplo,
         //                                         n,
@@ -696,51 +674,51 @@ void testing_syevd_heevd(Arguments& argus)
         // check computations
         if(argus.unit_check || argus.norm_check)
         {
-            syevd_heevd_getError<FORTRAN, T>(handle,
-                                             evect,
-                                             uplo,
-                                             n,
-                                             dA,
-                                             lda,
-                                             stA,
-                                             dD,
-                                             stD,
-                                             dWork,
-                                             size_W,
-                                             dinfo,
-                                             bc,
-                                             hA,
-                                             hAres,
-                                             hD,
-                                             hDres,
-                                             hinfo,
-                                             hinfoRes,
-                                             &max_error);
+            syevd_heevd_getError<API, T>(handle,
+                                         evect,
+                                         uplo,
+                                         n,
+                                         dA,
+                                         lda,
+                                         stA,
+                                         dD,
+                                         stD,
+                                         dWork,
+                                         size_W,
+                                         dinfo,
+                                         bc,
+                                         hA,
+                                         hAres,
+                                         hD,
+                                         hDres,
+                                         hinfo,
+                                         hinfoRes,
+                                         &max_error);
         }
 
         // collect performance data
         if(argus.timing)
         {
-            syevd_heevd_getPerfData<FORTRAN, T>(handle,
-                                                evect,
-                                                uplo,
-                                                n,
-                                                dA,
-                                                lda,
-                                                stA,
-                                                dD,
-                                                stD,
-                                                dWork,
-                                                size_W,
-                                                dinfo,
-                                                bc,
-                                                hA,
-                                                hD,
-                                                hinfo,
-                                                &gpu_time_used,
-                                                &cpu_time_used,
-                                                hot_calls,
-                                                argus.perf);
+            syevd_heevd_getPerfData<API, T>(handle,
+                                            evect,
+                                            uplo,
+                                            n,
+                                            dA,
+                                            lda,
+                                            stA,
+                                            dD,
+                                            stD,
+                                            dWork,
+                                            size_W,
+                                            dinfo,
+                                            bc,
+                                            hA,
+                                            hD,
+                                            hinfo,
+                                            &gpu_time_used,
+                                            &cpu_time_used,
+                                            hot_calls,
+                                            argus.perf);
         }
     }
 

--- a/clients/include/testing_sygvd_hegvd.hpp
+++ b/clients/include/testing_sygvd_hegvd.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, typename T, typename U>
+template <testAPI_t API, typename T, typename U>
 void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
                               const hipsolverEigType_t  itype,
                               const hipsolverEigMode_t  evect,
@@ -45,7 +45,7 @@ void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
                               const int                 bc)
 {
     // handle
-    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
                                                 nullptr,
                                                 itype,
                                                 evect,
@@ -66,7 +66,7 @@ void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
                           HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
-    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
                                                 handle,
                                                 hipsolverEigType_t(-1),
                                                 evect,
@@ -85,7 +85,7 @@ void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dInfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
-    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
                                                 handle,
                                                 itype,
                                                 hipsolverEigMode_t(-1),
@@ -104,7 +104,7 @@ void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dInfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_ENUM);
-    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
                                                 handle,
                                                 itype,
                                                 evect,
@@ -126,7 +126,7 @@ void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
-    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
                                                 handle,
                                                 itype,
                                                 evect,
@@ -145,7 +145,7 @@ void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dInfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
                                                 handle,
                                                 itype,
                                                 evect,
@@ -164,7 +164,7 @@ void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dInfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
                                                 handle,
                                                 itype,
                                                 evect,
@@ -183,7 +183,7 @@ void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dInfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
                                                 handle,
                                                 itype,
                                                 evect,
@@ -205,7 +205,7 @@ void sygvd_hegvd_checkBadArgs(const hipsolverHandle_t   handle,
 #endif
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_sygvd_hegvd_bad_arg()
 {
     using S = decltype(std::real(T{}));
@@ -236,7 +236,7 @@ void testing_sygvd_hegvd_bad_arg()
         // CHECK_HIP_ERROR(dInfo.memcheck());
 
         // int size_W;
-        // hipsolver_sygvd_hegvd_bufferSize(FORTRAN,
+        // hipsolver_sygvd_hegvd_bufferSize(API,
         //                                  handle,
         //                                  itype,
         //                                  evect,
@@ -253,7 +253,7 @@ void testing_sygvd_hegvd_bad_arg()
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check bad arguments
-        // sygvd_hegvd_checkBadArgs<FORTRAN>(handle,
+        // sygvd_hegvd_checkBadArgs<API>(handle,
         //                                   itype,
         //                                   evect,
         //                                   uplo,
@@ -284,40 +284,30 @@ void testing_sygvd_hegvd_bad_arg()
         CHECK_HIP_ERROR(dInfo.memcheck());
 
         int size_W;
-        hipsolver_sygvd_hegvd_bufferSize(FORTRAN,
-                                         handle,
-                                         itype,
-                                         evect,
-                                         uplo,
-                                         n,
-                                         dA.data(),
-                                         lda,
-                                         dB.data(),
-                                         ldb,
-                                         dD.data(),
-                                         &size_W);
+        hipsolver_sygvd_hegvd_bufferSize(
+            API, handle, itype, evect, uplo, n, dA.data(), lda, dB.data(), ldb, dD.data(), &size_W);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
         // check bad arguments
-        sygvd_hegvd_checkBadArgs<FORTRAN>(handle,
-                                          itype,
-                                          evect,
-                                          uplo,
-                                          n,
-                                          dA.data(),
-                                          lda,
-                                          stA,
-                                          dB.data(),
-                                          ldb,
-                                          stB,
-                                          dD.data(),
-                                          stD,
-                                          dWork.data(),
-                                          size_W,
-                                          dInfo.data(),
-                                          bc);
+        sygvd_hegvd_checkBadArgs<API>(handle,
+                                      itype,
+                                      evect,
+                                      uplo,
+                                      n,
+                                      dA.data(),
+                                      lda,
+                                      stA,
+                                      dB.data(),
+                                      ldb,
+                                      stB,
+                                      dD.data(),
+                                      stD,
+                                      dWork.data(),
+                                      size_W,
+                                      dInfo.data(),
+                                      bc);
     }
 }
 
@@ -394,7 +384,7 @@ void sygvd_hegvd_initData(const hipsolverHandle_t       handle,
     }
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Td,
           typename Ud,
@@ -457,7 +447,7 @@ void sygvd_hegvd_getError(const hipsolverHandle_t   handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(hipsolver_sygvd_hegvd(FORTRAN,
+    CHECK_ROCBLAS_ERROR(hipsolver_sygvd_hegvd(API,
                                               handle,
                                               itype,
                                               evect,
@@ -615,7 +605,7 @@ void sygvd_hegvd_getError(const hipsolverHandle_t   handle,
     }
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Td,
           typename Ud,
@@ -710,7 +700,7 @@ void sygvd_hegvd_getPerfData(const hipsolverHandle_t   handle,
         sygvd_hegvd_initData<false, true, T>(
             handle, itype, evect, n, dA, lda, stA, dB, ldb, stB, bc, hA, hB, A, B, false, singular);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_sygvd_hegvd(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_sygvd_hegvd(API,
                                                   handle,
                                                   itype,
                                                   evect,
@@ -741,7 +731,7 @@ void sygvd_hegvd_getPerfData(const hipsolverHandle_t   handle,
             handle, itype, evect, n, dA, lda, stA, dB, ldb, stB, bc, hA, hB, A, B, false, singular);
 
         start = get_time_us_sync(stream);
-        hipsolver_sygvd_hegvd(FORTRAN,
+        hipsolver_sygvd_hegvd(API,
                               handle,
                               itype,
                               evect,
@@ -764,7 +754,7 @@ void sygvd_hegvd_getPerfData(const hipsolverHandle_t   handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_sygvd_hegvd(Arguments& argus)
 {
     using S = decltype(std::real(T{}));
@@ -805,7 +795,7 @@ void testing_sygvd_hegvd(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
             //                                             handle,
             //                                             itype,
             //                                             evect,
@@ -827,7 +817,7 @@ void testing_sygvd_hegvd(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(FORTRAN,
+            EXPECT_ROCBLAS_STATUS(hipsolver_sygvd_hegvd(API,
                                                         handle,
                                                         itype,
                                                         evect,
@@ -856,7 +846,7 @@ void testing_sygvd_hegvd(Arguments& argus)
 
     // memory size query is necessary
     int size_W;
-    hipsolver_sygvd_hegvd_bufferSize(FORTRAN,
+    hipsolver_sygvd_hegvd_bufferSize(API,
                                      handle,
                                      itype,
                                      evect,
@@ -902,7 +892,7 @@ void testing_sygvd_hegvd(Arguments& argus)
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
-        //     sygvd_hegvd_getError<FORTRAN, T>(handle,
+        //     sygvd_hegvd_getError<API, T>(handle,
         //                                      itype,
         //                                      evect,
         //                                      uplo,
@@ -931,7 +921,7 @@ void testing_sygvd_hegvd(Arguments& argus)
 
         // // collect performance data
         // if(argus.timing)
-        //     sygvd_hegvd_getPerfData<FORTRAN, T>(handle,
+        //     sygvd_hegvd_getPerfData<API, T>(handle,
         //                                         itype,
         //                                         evect,
         //                                         uplo,
@@ -986,61 +976,61 @@ void testing_sygvd_hegvd(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check)
-            sygvd_hegvd_getError<FORTRAN, T>(handle,
-                                             itype,
-                                             evect,
-                                             uplo,
-                                             n,
-                                             dA,
-                                             lda,
-                                             stA,
-                                             dB,
-                                             ldb,
-                                             stB,
-                                             dD,
-                                             stD,
-                                             dWork,
-                                             size_W,
-                                             dInfo,
-                                             bc,
-                                             hA,
-                                             hARes,
-                                             hB,
-                                             hD,
-                                             hDRes,
-                                             hInfo,
-                                             hInfoRes,
-                                             &max_error,
-                                             argus.singular);
+            sygvd_hegvd_getError<API, T>(handle,
+                                         itype,
+                                         evect,
+                                         uplo,
+                                         n,
+                                         dA,
+                                         lda,
+                                         stA,
+                                         dB,
+                                         ldb,
+                                         stB,
+                                         dD,
+                                         stD,
+                                         dWork,
+                                         size_W,
+                                         dInfo,
+                                         bc,
+                                         hA,
+                                         hARes,
+                                         hB,
+                                         hD,
+                                         hDRes,
+                                         hInfo,
+                                         hInfoRes,
+                                         &max_error,
+                                         argus.singular);
 
         // collect performance data
         if(argus.timing)
-            sygvd_hegvd_getPerfData<FORTRAN, T>(handle,
-                                                itype,
-                                                evect,
-                                                uplo,
-                                                n,
-                                                dA,
-                                                lda,
-                                                stA,
-                                                dB,
-                                                ldb,
-                                                stB,
-                                                dD,
-                                                stD,
-                                                dWork,
-                                                size_W,
-                                                dInfo,
-                                                bc,
-                                                hA,
-                                                hB,
-                                                hD,
-                                                hInfo,
-                                                &gpu_time_used,
-                                                &cpu_time_used,
-                                                hot_calls,
-                                                argus.perf,
-                                                argus.singular);
+            sygvd_hegvd_getPerfData<API, T>(handle,
+                                            itype,
+                                            evect,
+                                            uplo,
+                                            n,
+                                            dA,
+                                            lda,
+                                            stA,
+                                            dB,
+                                            ldb,
+                                            stB,
+                                            dD,
+                                            stD,
+                                            dWork,
+                                            size_W,
+                                            dInfo,
+                                            bc,
+                                            hA,
+                                            hB,
+                                            hD,
+                                            hInfo,
+                                            &gpu_time_used,
+                                            &cpu_time_used,
+                                            hot_calls,
+                                            argus.perf,
+                                            argus.singular);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_sytrd_hetrd.hpp
+++ b/clients/include/testing_sytrd_hetrd.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, typename S, typename T, typename U, typename V>
+template <testAPI_t API, typename S, typename T, typename U, typename V>
 void sytrd_hetrd_checkBadArgs(const hipsolverHandle_t   handle,
                               const hipsolverFillMode_t uplo,
                               const int                 n,
@@ -44,7 +44,7 @@ void sytrd_hetrd_checkBadArgs(const hipsolverHandle_t   handle,
                               const int                 bc)
 {
     // handle
-    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
                                                 nullptr,
                                                 uplo,
                                                 n,
@@ -64,7 +64,7 @@ void sytrd_hetrd_checkBadArgs(const hipsolverHandle_t   handle,
                           HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
-    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
                                                 handle,
                                                 hipsolverFillMode_t(-1),
                                                 n,
@@ -85,7 +85,7 @@ void sytrd_hetrd_checkBadArgs(const hipsolverHandle_t   handle,
 
 #if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
     // pointers
-    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
                                                 handle,
                                                 uplo,
                                                 n,
@@ -103,7 +103,7 @@ void sytrd_hetrd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dInfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
                                                 handle,
                                                 uplo,
                                                 n,
@@ -121,7 +121,7 @@ void sytrd_hetrd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dInfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
                                                 handle,
                                                 uplo,
                                                 n,
@@ -139,7 +139,7 @@ void sytrd_hetrd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dInfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
                                                 handle,
                                                 uplo,
                                                 n,
@@ -157,7 +157,7 @@ void sytrd_hetrd_checkBadArgs(const hipsolverHandle_t   handle,
                                                 dInfo,
                                                 bc),
                           HIPSOLVER_STATUS_INVALID_VALUE);
-    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
                                                 handle,
                                                 uplo,
                                                 n,
@@ -178,7 +178,7 @@ void sytrd_hetrd_checkBadArgs(const hipsolverHandle_t   handle,
 #endif
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_sytrd_hetrd_bad_arg()
 {
     using S = decltype(std::real(T{}));
@@ -210,13 +210,13 @@ void testing_sytrd_hetrd_bad_arg()
 
         // int size_W;
         // hipsolver_sytrd_hetrd_bufferSize(
-        //     FORTRAN, handle, uplo, n, dA.data(), lda, dD.data(), dE.data(), dTau.data(), &size_W);
+        //     API, handle, uplo, n, dA.data(), lda, dD.data(), dE.data(), dTau.data(), &size_W);
         // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check bad arguments
-        // sytrd_hetrd_checkBadArgs<FORTRAN>(handle,
+        // sytrd_hetrd_checkBadArgs<API>(handle,
         //                                   uplo,
         //                                   n,
         //                                   dA.data(),
@@ -249,28 +249,28 @@ void testing_sytrd_hetrd_bad_arg()
 
         int size_W;
         hipsolver_sytrd_hetrd_bufferSize(
-            FORTRAN, handle, uplo, n, dA.data(), lda, dD.data(), dE.data(), dTau.data(), &size_W);
+            API, handle, uplo, n, dA.data(), lda, dD.data(), dE.data(), dTau.data(), &size_W);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
         // check bad arguments
-        sytrd_hetrd_checkBadArgs<FORTRAN>(handle,
-                                          uplo,
-                                          n,
-                                          dA.data(),
-                                          lda,
-                                          stA,
-                                          dD.data(),
-                                          stD,
-                                          dE.data(),
-                                          stE,
-                                          dTau.data(),
-                                          stP,
-                                          dWork.data(),
-                                          size_W,
-                                          dInfo.data(),
-                                          bc);
+        sytrd_hetrd_checkBadArgs<API>(handle,
+                                      uplo,
+                                      n,
+                                      dA.data(),
+                                      lda,
+                                      stA,
+                                      dD.data(),
+                                      stD,
+                                      dE.data(),
+                                      stE,
+                                      dTau.data(),
+                                      stP,
+                                      dWork.data(),
+                                      size_W,
+                                      dInfo.data(),
+                                      bc);
     }
 }
 
@@ -348,7 +348,7 @@ void sytrd_hetrd_initData(
     }
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Sd,
           typename Td,
@@ -393,7 +393,7 @@ void sytrd_hetrd_getError(const hipsolverHandle_t   handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(hipsolver_sytrd_hetrd(FORTRAN,
+    CHECK_ROCBLAS_ERROR(hipsolver_sytrd_hetrd(API,
                                               handle,
                                               uplo,
                                               n,
@@ -520,7 +520,7 @@ void sytrd_hetrd_getError(const hipsolverHandle_t   handle,
     *max_err += err;
 }
 
-template <bool FORTRAN,
+template <testAPI_t API,
           typename T,
           typename Sd,
           typename Td,
@@ -578,7 +578,7 @@ void sytrd_hetrd_getPerfData(const hipsolverHandle_t   handle,
     {
         sytrd_hetrd_initData<false, true, T>(handle, n, dA, lda, bc, hA);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_sytrd_hetrd(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_sytrd_hetrd(API,
                                                   handle,
                                                   uplo,
                                                   n,
@@ -607,7 +607,7 @@ void sytrd_hetrd_getPerfData(const hipsolverHandle_t   handle,
         sytrd_hetrd_initData<false, true, T>(handle, n, dA, lda, bc, hA);
 
         start = get_time_us_sync(stream);
-        hipsolver_sytrd_hetrd(FORTRAN,
+        hipsolver_sytrd_hetrd(API,
                               handle,
                               uplo,
                               n,
@@ -629,7 +629,7 @@ void sytrd_hetrd_getPerfData(const hipsolverHandle_t   handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_sytrd_hetrd(Arguments& argus)
 {
     using S = decltype(std::real(T{}));
@@ -655,7 +655,7 @@ void testing_sytrd_hetrd(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
             //                                             handle,
             //                                             uplo,
             //                                             n,
@@ -676,7 +676,7 @@ void testing_sytrd_hetrd(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+            EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
                                                         handle,
                                                         uplo,
                                                         n,
@@ -717,7 +717,7 @@ void testing_sytrd_hetrd(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
             //                                             handle,
             //                                             uplo,
             //                                             n,
@@ -738,7 +738,7 @@ void testing_sytrd_hetrd(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(FORTRAN,
+            EXPECT_ROCBLAS_STATUS(hipsolver_sytrd_hetrd(API,
                                                         handle,
                                                         uplo,
                                                         n,
@@ -767,7 +767,7 @@ void testing_sytrd_hetrd(Arguments& argus)
     // memory size query is necessary
     int size_W;
     hipsolver_sytrd_hetrd_bufferSize(
-        FORTRAN, handle, uplo, n, (T*)nullptr, lda, (S*)nullptr, (S*)nullptr, (T*)nullptr, &size_W);
+        API, handle, uplo, n, (T*)nullptr, lda, (S*)nullptr, (S*)nullptr, (T*)nullptr, &size_W);
 
     if(argus.mem_query)
     {
@@ -809,7 +809,7 @@ void testing_sytrd_hetrd(Arguments& argus)
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
-        //     sytrd_hetrd_getError<FORTRAN, T>(handle,
+        //     sytrd_hetrd_getError<API, T>(handle,
         //                                      uplo,
         //                                      n,
         //                                      dA,
@@ -836,7 +836,7 @@ void testing_sytrd_hetrd(Arguments& argus)
 
         // // collect performance data
         // if(argus.timing)
-        //     sytrd_hetrd_getPerfData<FORTRAN, T>(handle,
+        //     sytrd_hetrd_getPerfData<API, T>(handle,
         //                                         uplo,
         //                                         n,
         //                                         dA,
@@ -874,58 +874,58 @@ void testing_sytrd_hetrd(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check)
-            sytrd_hetrd_getError<FORTRAN, T>(handle,
-                                             uplo,
-                                             n,
-                                             dA,
-                                             lda,
-                                             stA,
-                                             dD,
-                                             stD,
-                                             dE,
-                                             stE,
-                                             dTau,
-                                             stP,
-                                             dWork,
-                                             size_W,
-                                             dInfo,
-                                             bc,
-                                             hA,
-                                             hARes,
-                                             hD,
-                                             hE,
-                                             hTau,
-                                             hInfo,
-                                             hInfoRes,
-                                             &max_error);
+            sytrd_hetrd_getError<API, T>(handle,
+                                         uplo,
+                                         n,
+                                         dA,
+                                         lda,
+                                         stA,
+                                         dD,
+                                         stD,
+                                         dE,
+                                         stE,
+                                         dTau,
+                                         stP,
+                                         dWork,
+                                         size_W,
+                                         dInfo,
+                                         bc,
+                                         hA,
+                                         hARes,
+                                         hD,
+                                         hE,
+                                         hTau,
+                                         hInfo,
+                                         hInfoRes,
+                                         &max_error);
 
         // collect performance data
         if(argus.timing)
-            sytrd_hetrd_getPerfData<FORTRAN, T>(handle,
-                                                uplo,
-                                                n,
-                                                dA,
-                                                lda,
-                                                stA,
-                                                dD,
-                                                stD,
-                                                dE,
-                                                stE,
-                                                dTau,
-                                                stP,
-                                                dWork,
-                                                size_W,
-                                                dInfo,
-                                                bc,
-                                                hA,
-                                                hD,
-                                                hE,
-                                                hTau,
-                                                hInfo,
-                                                &gpu_time_used,
-                                                &cpu_time_used,
-                                                hot_calls,
-                                                argus.perf);
+            sytrd_hetrd_getPerfData<API, T>(handle,
+                                            uplo,
+                                            n,
+                                            dA,
+                                            lda,
+                                            stA,
+                                            dD,
+                                            stD,
+                                            dE,
+                                            stE,
+                                            dTau,
+                                            stP,
+                                            dWork,
+                                            size_W,
+                                            dInfo,
+                                            bc,
+                                            hA,
+                                            hD,
+                                            hE,
+                                            hTau,
+                                            hInfo,
+                                            &gpu_time_used,
+                                            &cpu_time_used,
+                                            hot_calls,
+                                            argus.perf);
     }
 
     // validate results for rocsolver-test

--- a/clients/include/testing_sytrf.hpp
+++ b/clients/include/testing_sytrf.hpp
@@ -25,7 +25,7 @@
 
 #include "clientcommon.hpp"
 
-template <bool FORTRAN, typename T, typename U, typename V>
+template <testAPI_t API, typename T, typename U, typename V>
 void sytrf_checkBadArgs(const hipsolverHandle_t   handle,
                         const hipsolverFillMode_t uplo,
                         const int                 n,
@@ -41,12 +41,11 @@ void sytrf_checkBadArgs(const hipsolverHandle_t   handle,
 {
     // handle
     EXPECT_ROCBLAS_STATUS(
-        hipsolver_sytrf(
-            FORTRAN, nullptr, uplo, n, dA, lda, stA, dIpiv, stP, dWork, lwork, dinfo, bc),
+        hipsolver_sytrf(API, nullptr, uplo, n, dA, lda, stA, dIpiv, stP, dWork, lwork, dinfo, bc),
         HIPSOLVER_STATUS_NOT_INITIALIZED);
 
     // values
-    EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(FORTRAN,
+    EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(API,
                                           handle,
                                           hipsolverFillMode_t(-1),
                                           n,
@@ -65,20 +64,20 @@ void sytrf_checkBadArgs(const hipsolverHandle_t   handle,
     // pointers
     EXPECT_ROCBLAS_STATUS(
         hipsolver_sytrf(
-            FORTRAN, handle, uplo, n, (T) nullptr, lda, stA, dIpiv, stP, dWork, lwork, dinfo, bc),
+            API, handle, uplo, n, (T) nullptr, lda, stA, dIpiv, stP, dWork, lwork, dinfo, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
         hipsolver_sytrf(
-            FORTRAN, handle, uplo, n, dA, lda, stA, (U) nullptr, stP, dWork, lwork, dinfo, bc),
+            API, handle, uplo, n, dA, lda, stA, (U) nullptr, stP, dWork, lwork, dinfo, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
     EXPECT_ROCBLAS_STATUS(
         hipsolver_sytrf(
-            FORTRAN, handle, uplo, n, dA, lda, stA, dIpiv, stP, dWork, lwork, (U) nullptr, bc),
+            API, handle, uplo, n, dA, lda, stA, dIpiv, stP, dWork, lwork, (U) nullptr, bc),
         HIPSOLVER_STATUS_INVALID_VALUE);
 #endif
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_sytrf_bad_arg()
 {
     // safe arguments
@@ -101,13 +100,13 @@ void testing_sytrf_bad_arg()
         // CHECK_HIP_ERROR(dInfo.memcheck());
 
         // int size_W;
-        // hipsolver_sytrf_bufferSize(FORTRAN, handle, n, dA.data(), lda, &size_W);
+        // hipsolver_sytrf_bufferSize(API, handle, n, dA.data(), lda, &size_W);
         // device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         // if(size_W)
         //     CHECK_HIP_ERROR(dWork.memcheck());
 
         // // check bad arguments
-        // sytrf_checkBadArgs<FORTRAN>(handle,
+        // sytrf_checkBadArgs<API>(handle,
         //                             uplo,
         //                             n,
         //                             dA.data(),
@@ -131,24 +130,24 @@ void testing_sytrf_bad_arg()
         CHECK_HIP_ERROR(dInfo.memcheck());
 
         int size_W;
-        hipsolver_sytrf_bufferSize(FORTRAN, handle, n, dA.data(), lda, &size_W);
+        hipsolver_sytrf_bufferSize(API, handle, n, dA.data(), lda, &size_W);
         device_strided_batch_vector<T> dWork(size_W, 1, size_W, bc);
         if(size_W)
             CHECK_HIP_ERROR(dWork.memcheck());
 
         // check bad arguments
-        sytrf_checkBadArgs<FORTRAN>(handle,
-                                    uplo,
-                                    n,
-                                    dA.data(),
-                                    lda,
-                                    stA,
-                                    dIpiv.data(),
-                                    stP,
-                                    dWork.data(),
-                                    size_W,
-                                    dInfo.data(),
-                                    bc);
+        sytrf_checkBadArgs<API>(handle,
+                                uplo,
+                                n,
+                                dA.data(),
+                                lda,
+                                stA,
+                                dIpiv.data(),
+                                stP,
+                                dWork.data(),
+                                size_W,
+                                dInfo.data(),
+                                bc);
     }
 }
 
@@ -207,7 +206,13 @@ void sytrf_initData(const hipsolverHandle_t   handle,
     }
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Vd, typename Th, typename Uh>
+template <testAPI_t API,
+          typename T,
+          typename Td,
+          typename Ud,
+          typename Vd,
+          typename Th,
+          typename Uh>
 void sytrf_getError(const hipsolverHandle_t   handle,
                     const hipsolverFillMode_t uplo,
                     const int                 n,
@@ -237,7 +242,7 @@ void sytrf_getError(const hipsolverHandle_t   handle,
 
     // execute computations
     // GPU lapack
-    CHECK_ROCBLAS_ERROR(hipsolver_sytrf(FORTRAN,
+    CHECK_ROCBLAS_ERROR(hipsolver_sytrf(API,
                                         handle,
                                         uplo,
                                         n,
@@ -291,7 +296,13 @@ void sytrf_getError(const hipsolverHandle_t   handle,
     *max_err += err;
 }
 
-template <bool FORTRAN, typename T, typename Td, typename Ud, typename Vd, typename Th, typename Uh>
+template <testAPI_t API,
+          typename T,
+          typename Td,
+          typename Ud,
+          typename Vd,
+          typename Th,
+          typename Uh>
 void sytrf_getPerfData(const hipsolverHandle_t   handle,
                        const hipsolverFillMode_t uplo,
                        const int                 n,
@@ -336,7 +347,7 @@ void sytrf_getPerfData(const hipsolverHandle_t   handle,
         sytrf_initData<false, true, T>(
             handle, uplo, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA, hIpiv, hInfo);
 
-        CHECK_ROCBLAS_ERROR(hipsolver_sytrf(FORTRAN,
+        CHECK_ROCBLAS_ERROR(hipsolver_sytrf(API,
                                             handle,
                                             uplo,
                                             n,
@@ -362,7 +373,7 @@ void sytrf_getPerfData(const hipsolverHandle_t   handle,
             handle, uplo, n, dA, lda, stA, dIpiv, stP, dInfo, bc, hA, hIpiv, hInfo);
 
         start = get_time_us_sync(stream);
-        hipsolver_sytrf(FORTRAN,
+        hipsolver_sytrf(API,
                         handle,
                         uplo,
                         n,
@@ -380,7 +391,7 @@ void sytrf_getPerfData(const hipsolverHandle_t   handle,
     *gpu_time_used /= hot_calls;
 }
 
-template <bool FORTRAN, bool BATCHED, bool STRIDED, typename T>
+template <testAPI_t API, bool BATCHED, bool STRIDED, typename T>
 void testing_sytrf(Arguments& argus)
 {
     // get arguments
@@ -403,7 +414,7 @@ void testing_sytrf(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(API,
             //                                       handle,
             //                                       uplo,
             //                                       n,
@@ -420,7 +431,7 @@ void testing_sytrf(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(FORTRAN,
+            EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(API,
                                                   handle,
                                                   uplo,
                                                   n,
@@ -456,7 +467,7 @@ void testing_sytrf(Arguments& argus)
     {
         if(BATCHED)
         {
-            // EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(FORTRAN,
+            // EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(API,
             //                                       handle,
             //                                       uplo,
             //                                       n,
@@ -473,7 +484,7 @@ void testing_sytrf(Arguments& argus)
         }
         else
         {
-            EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(FORTRAN,
+            EXPECT_ROCBLAS_STATUS(hipsolver_sytrf(API,
                                                   handle,
                                                   uplo,
                                                   n,
@@ -497,7 +508,7 @@ void testing_sytrf(Arguments& argus)
 
     // memory size query is necessary
     int size_W;
-    hipsolver_sytrf_bufferSize(FORTRAN, handle, n, (T*)nullptr, lda, &size_W);
+    hipsolver_sytrf_bufferSize(API, handle, n, (T*)nullptr, lda, &size_W);
 
     if(argus.mem_query)
     {
@@ -528,7 +539,7 @@ void testing_sytrf(Arguments& argus)
 
         // // check computations
         // if(argus.unit_check || argus.norm_check)
-        //     sytrf_getError<FORTRAN, T>(handle,
+        //     sytrf_getError<API, T>(handle,
         //                                uplo,
         //                                n,
         //                                dA,
@@ -550,7 +561,7 @@ void testing_sytrf(Arguments& argus)
 
         // // collect performance data
         // if(argus.timing)
-        //     sytrf_getPerfData<FORTRAN, T>(handle,
+        //     sytrf_getPerfData<API, T>(handle,
         //                                   uplo,
         //                                   n,
         //                                   dA,
@@ -594,47 +605,47 @@ void testing_sytrf(Arguments& argus)
 
         // check computations
         if(argus.unit_check || argus.norm_check)
-            sytrf_getError<FORTRAN, T>(handle,
-                                       uplo,
-                                       n,
-                                       dA,
-                                       lda,
-                                       stA,
-                                       dIpiv,
-                                       stP,
-                                       dWork,
-                                       size_W,
-                                       dInfo,
-                                       bc,
-                                       hA,
-                                       hARes,
-                                       hIpiv,
-                                       hIpivRes,
-                                       hInfo,
-                                       hInfoRes,
-                                       &max_error);
+            sytrf_getError<API, T>(handle,
+                                   uplo,
+                                   n,
+                                   dA,
+                                   lda,
+                                   stA,
+                                   dIpiv,
+                                   stP,
+                                   dWork,
+                                   size_W,
+                                   dInfo,
+                                   bc,
+                                   hA,
+                                   hARes,
+                                   hIpiv,
+                                   hIpivRes,
+                                   hInfo,
+                                   hInfoRes,
+                                   &max_error);
 
         // collect performance data
         if(argus.timing)
-            sytrf_getPerfData<FORTRAN, T>(handle,
-                                          uplo,
-                                          n,
-                                          dA,
-                                          lda,
-                                          stA,
-                                          dIpiv,
-                                          stP,
-                                          dWork,
-                                          size_W,
-                                          dInfo,
-                                          bc,
-                                          hA,
-                                          hIpiv,
-                                          hInfo,
-                                          &gpu_time_used,
-                                          &cpu_time_used,
-                                          hot_calls,
-                                          argus.perf);
+            sytrf_getPerfData<API, T>(handle,
+                                      uplo,
+                                      n,
+                                      dA,
+                                      lda,
+                                      stA,
+                                      dIpiv,
+                                      stP,
+                                      dWork,
+                                      size_W,
+                                      dInfo,
+                                      bc,
+                                      hA,
+                                      hIpiv,
+                                      hInfo,
+                                      &gpu_time_used,
+                                      &cpu_time_used,
+                                      hot_calls,
+                                      argus.perf);
     }
 
     // validate results for rocsolver-test


### PR DESCRIPTION
When we added the first compatibility API, we added the `testAPI_t` enum to the client code in order to enumerate the different entry points for each function (i.e. regular API, compatibility API, and FORTRAN API). This was intended to replace the old behaviour of distinguishing between the regular API and FORTRAN API through the use of a boolean. However, the change was not applied to all functions as it was a tedious and not urgent change, and eventually I forgot about it.

With this PR, the change will now be applied to all functions, except the hipsolverSp and hipsolverRf functions.