### PR TITLE
Fix benchmark client built without sparse functionality

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -53,6 +53,10 @@ target_link_libraries( hipsolver-bench PRIVATE
   roc::hipsolver
 )
 if( BUILD_WITH_SPARSE )
+  set_source_files_properties(client.cpp
+    PROPERTIES
+      COMPILE_DEFINITIONS HAVE_HIPSPARSE
+  )
   target_link_libraries( hipsolver-bench PRIVATE roc::hipsparse )
 endif( )
 if( UNIX )

--- a/clients/include/hipsolver_dispatcher.hpp
+++ b/clients/include/hipsolver_dispatcher.hpp
@@ -27,7 +27,6 @@
 #include <map>
 #include <string>
 
-#include "testing_csrlsvchol.hpp"
 #include "testing_gebrd.hpp"
 #include "testing_gels.hpp"
 #include "testing_geqrf.hpp"
@@ -53,6 +52,10 @@
 #include "testing_sygvj_hegvj.hpp"
 #include "testing_sytrd_hetrd.hpp"
 #include "testing_sytrf.hpp"
+
+#ifdef HAVE_HIPSPARSE
+#include "testing_csrlsvchol.hpp"
+#endif
 
 struct str_less
 {
@@ -120,8 +123,11 @@ class hipsolver_dispatcher
             {"sygvdx", testing_sygvdx_hegvdx<API_COMPAT, false, false, T>},
             {"sygvj", testing_sygvj_hegvj<API_NORMAL, false, false, T>},
             {"sytrd", testing_sytrd_hetrd<API_NORMAL, false, false, T>},
+
+#ifdef HAVE_HIPSPARSE
             {"csrlsvchol", testing_csrlsvchol<false, T>},
             {"csrlsvcholHost", testing_csrlsvchol<true, T>},
+#endif
         };
 
         // Grab function from the map and execute


### PR DESCRIPTION
Due to a small oversight, hipsolver-bench does not build correctly when building without sparse functionality. This PR should address that.

Credit to @jibrealkhan for discovering the failure.