### PR TITLE
Disable sparse build on Windows by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ option( BUILD_CODE_COVERAGE "Build hipSOLVER with code coverage enabled" OFF )
 option( BUILD_HIPBLAS_TESTS "Build additional tests to ensure hipBLAS and hipSOLVER are compatible (requires installed hipBLAS)" OFF )
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build hipSOLVER as a shared library" ON )
-option( BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality and tests enabled (requires additional dependencies)" ON )
+option( BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality and tests enabled (requires additional dependencies)" "${UNIX}" )
 option( BUILD_VERBOSE "Output additional build information" OFF )
 option( USE_CUDA "Look for CUDA and use that as a backend if found" OFF )
 option( HIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG "Skip module mode search for LAPACK" ON )

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -143,10 +143,6 @@ if( NOT USE_CUDA )
     endif( )
 
     target_link_libraries( hipsolver PRIVATE roc::rocsparse suitesparseconfig cholmod )
-    target_include_directories( hipsolver
-      SYSTEM PRIVATE
-      $<BUILD_INTERFACE:/usr/include/suitesparse/>
-    )
     set_source_files_properties(${hipsolver_source}
       PROPERTIES
         COMPILE_DEFINITIONS HAVE_ROCSPARSE

--- a/library/src/amd_detail/hipsolver_sparse.cpp
+++ b/library/src/amd_detail/hipsolver_sparse.cpp
@@ -31,21 +31,21 @@
 #include "hipsolver.h"
 #include "hipsolver_conversions.hpp"
 
-#include <rocblas/internal/rocblas_device_malloc.hpp>
-#include <rocblas/rocblas.h>
-#include <rocsolver/rocsolver.h>
 #include <algorithm>
 #include <climits>
 #include <functional>
 #include <iostream>
 #include <math.h>
-
 #include <set>
 #include <vector>
 
+#include <rocblas/internal/rocblas_device_malloc.hpp>
+#include <rocblas/rocblas.h>
+#include <rocsolver/rocsolver.h>
+
 #ifdef HAVE_ROCSPARSE
-#include <suitesparse/cholmod.h>
 #include <rocsparse/rocsparse.h>
+#include <suitesparse/cholmod.h>
 #endif
 
 #undef TRUE

--- a/library/src/amd_detail/hipsolver_sparse.cpp
+++ b/library/src/amd_detail/hipsolver_sparse.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,9 +31,9 @@
 #include "hipsolver.h"
 #include "hipsolver_conversions.hpp"
 
-#include "rocblas/internal/rocblas_device_malloc.hpp"
-#include "rocblas/rocblas.h"
-#include "rocsolver/rocsolver.h"
+#include <rocblas/internal/rocblas_device_malloc.hpp>
+#include <rocblas/rocblas.h>
+#include <rocsolver/rocsolver.h>
 #include <algorithm>
 #include <climits>
 #include <functional>
@@ -44,8 +44,8 @@
 #include <vector>
 
 #ifdef HAVE_ROCSPARSE
-#include "cholmod.h"
-#include "rocsparse/rocsparse.h"
+#include <suitesparse/cholmod.h>
+#include <rocsparse/rocsparse.h>
 #endif
 
 #undef TRUE


### PR DESCRIPTION
*  Default BUILD_WITH_SPARSE to OFF on Windows
*  Cleanup include paths in hipsolver_sparse.cpp