### PR TITLE
Disable sparse build on Windows by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](https://hipsolver.readthedocs.io/en/latest/).
 
 
+## hipSOLVER 2.1.1 for ROCm 6.1.1
+### Changed
+- `BUILD_WITH_SPARSE` now defaults to OFF on Windows.
+
+### Fixed
+- Fixed benchmark client build when `BUILD_WITH_SPARSE` is OFF.
+
+
 ## hipSOLVER 2.1.0 for ROCm 6.1.0
 ### Added
 - Added compatibility API with hipsolverSp prefix
@@ -37,7 +45,7 @@ Full documentation for hipSOLVER is available at [hipsolver.readthedocs.io](http
 ### Fixed
 - Fixed conflicts between the hipsolver-dev and -asan packages by excluding
   hipsolver_module.f90 from the latter
-  
+
 
 ## hipSOLVER 1.8.1 for ROCm 5.7.0
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ option( BUILD_CODE_COVERAGE "Build hipSOLVER with code coverage enabled" OFF )
 option( BUILD_HIPBLAS_TESTS "Build additional tests to ensure hipBLAS and hipSOLVER are compatible (requires installed hipBLAS)" OFF )
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
 option( BUILD_SHARED_LIBS "Build hipSOLVER as a shared library" ON )
-option( BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality and tests enabled (requires additional dependencies)" ON )
+option( BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality and tests enabled (requires additional dependencies)" "${UNIX}" )
 option( BUILD_VERBOSE "Output additional build information" OFF )
 option( USE_CUDA "Look for CUDA and use that as a backend if found" OFF )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -89,7 +89,7 @@ include( ROCMInstallSymlinks )
 include( ROCMClients )
 include( ROCMHeaderWrapper )
 
-set ( VERSION_STRING "2.1.0" )
+set ( VERSION_STRING "2.1.1" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 if( NOT DEFINED ENV{HIP_PATH})

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -55,6 +55,10 @@ target_link_libraries( hipsolver-bench PRIVATE
   roc::hipsolver
 )
 if( BUILD_WITH_SPARSE )
+  set_source_files_properties(client.cpp
+    PROPERTIES
+      COMPILE_DEFINITIONS HAVE_HIPSPARSE
+  )
   target_link_libraries( hipsolver-bench PRIVATE roc::hipsparse )
 endif( )
 if( UNIX )

--- a/clients/include/hipsolver_dispatcher.hpp
+++ b/clients/include/hipsolver_dispatcher.hpp
@@ -27,7 +27,6 @@
 #include <map>
 #include <string>
 
-#include "testing_csrlsvchol.hpp"
 #include "testing_gebrd.hpp"
 #include "testing_gels.hpp"
 #include "testing_geqrf.hpp"
@@ -53,6 +52,10 @@
 #include "testing_sygvj_hegvj.hpp"
 #include "testing_sytrd_hetrd.hpp"
 #include "testing_sytrf.hpp"
+
+#ifdef HAVE_HIPSPARSE
+#include "testing_csrlsvchol.hpp"
+#endif
 
 struct str_less
 {
@@ -120,8 +123,10 @@ class hipsolver_dispatcher
             {"sygvdx", testing_sygvdx_hegvdx<API_COMPAT, false, false, T>},
             {"sygvj", testing_sygvj_hegvj<API_NORMAL, false, false, T>},
             {"sytrd", testing_sytrd_hetrd<false, false, false, T>},
+#ifdef HAVE_HIPSPARSE
             {"csrlsvchol", testing_csrlsvchol<false, T>},
             {"csrlsvcholHost", testing_csrlsvchol<true, T>},
+#endif
         };
 
         // Grab function from the map and execute

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -136,10 +136,6 @@ if( NOT USE_CUDA )
     endif( )
 
     target_link_libraries( hipsolver PRIVATE roc::rocsparse suitesparseconfig cholmod )
-    target_include_directories( hipsolver
-      SYSTEM PRIVATE
-      $<BUILD_INTERFACE:/usr/include/suitesparse/>
-    )
     set_source_files_properties(${hipsolver_source}
       PROPERTIES
         COMPILE_DEFINITIONS HAVE_ROCSPARSE

--- a/library/src/amd_detail/hipsolver_sparse.cpp
+++ b/library/src/amd_detail/hipsolver_sparse.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,18 +31,21 @@
 #include "hipsolver.h"
 #include "hipsolver_conversions.hpp"
 
-#include "rocblas/internal/rocblas_device_malloc.hpp"
-#include "rocblas/rocblas.h"
-#include "rocsolver/rocsolver.h"
 #include <algorithm>
 #include <climits>
 #include <functional>
 #include <iostream>
 #include <math.h>
+#include <set>
+#include <vector>
+
+#include <rocblas/internal/rocblas_device_malloc.hpp>
+#include <rocblas/rocblas.h>
+#include <rocsolver/rocsolver.h>
 
 #ifdef HAVE_ROCSPARSE
-#include "cholmod.h"
-#include "rocsparse/rocsparse.h"
+#include <rocsparse/rocsparse.h>
+#include <suitesparse/cholmod.h>
 #endif
 
 #undef TRUE


### PR DESCRIPTION
Cherry-pick the change to disable sparse functionality on Windows for the ROCm 6.1. This can still be built from source on Windows if the appropriate libraries are available, but it's not going to be in the AMD-provided build.

Ticket: SWDEV-435846