### PR TITLE
Drop -mf16c flag

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -65,9 +65,6 @@ endif( )
 
 add_armor_flags( hipsolver-bench "${ARMOR_LEVEL}" )
 
-# need mf16c flag for float->half convertion
-target_compile_options( hipsolver-bench PRIVATE -mf16c)
-
 if( NOT USE_CUDA )
   target_link_libraries( hipsolver-bench PRIVATE hip::host )
 

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -125,9 +125,6 @@ if( UNIX )
   target_sources( hipsolver-test PRIVATE ${hipsolver_f90_source} )
 endif( )
 
-# need mf16c flag for float->half convertion
-target_compile_options( hipsolver-test PRIVATE -mf16c )
-
 if( NOT USE_CUDA )
   target_link_libraries( hipsolver-test PRIVATE hip::host )
 

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -40,8 +40,6 @@ foreach( exe example-c-basic;example-cpp-basic; )
 
   target_include_directories( ${exe} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> )
 
-  target_compile_options( ${exe} PRIVATE -mf16c)
-
   target_link_libraries( ${exe} PRIVATE roc::hipsolver )
 
   if( NOT USE_CUDA )


### PR DESCRIPTION
The hipsolver library does not use f16c instructions, so this flag is unnecessary (and non-portable). It was copied from hipblas, where the flag is needed.