### PR TITLE
Remove unused immintrin.h include

### DIFF
--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -30,7 +30,6 @@
 #include "hipsolver_datatype2string.hpp"
 #include <cassert>
 #include <cmath>
-#include <immintrin.h>
 #include <random>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
The hipsolver clients do not use x86 intrinsics, so the inclusion of this header is unnecessary (and non-portable).