### PR TITLE
Add hip::host to interface libraries

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -124,7 +124,8 @@ if( NOT USE_CUDA )
     list( APPEND static_depends PACKAGE rocsolver )
   endif( )
 
-  target_link_libraries( hipsolver PRIVATE roc::rocblas roc::rocsolver hip::host )
+  target_link_libraries( hipsolver PRIVATE roc::rocblas roc::rocsolver )
+  target_link_libraries( hipsolver PUBLIC hip::host )
 
   if( CUSTOM_TARGET )
     target_link_libraries( hipsolver PRIVATE hip::${CUSTOM_TARGET} )


### PR DESCRIPTION
The HIP headers are included in hipsolver.h and so the HIP runtime should be linked as public to reflect that it is part of the hipSOLVER public interface.