### PR TITLE
Update suitesparse packages for Ubuntu 24.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,8 @@ if( NOT USE_CUDA )
 
     if( SYSTEM_OS STREQUAL "centos" OR SYSTEM_OS STREQUAL "rhel" )
       list(APPEND hipsolver_pkgdeps "suitesparse")
+    elseif(SYSTEM_OS STREQUAL "ubuntu" AND SYSTEM_OS_VERSION VERSION_GREATER_EQUAL "24.04")
+      list(APPEND hipsolver_pkgdeps "libcholmod4" "libsuitesparseconfig7")
     else()
       list(APPEND hipsolver_pkgdeps "libcholmod3" "libsuitesparseconfig5")
     endif()


### PR DESCRIPTION
The suitesparse library has changed its ABI a few times since Ubuntu 22.04. The package names include the ABI major version, so they're a little different on the upcoming Ubuntu 24.04.

Ticket: SWDEV-455244