### PR TITLE
Minor spelling fixes

### DIFF
--- a/clients/include/testing_sytrf.hpp
+++ b/clients/include/testing_sytrf.hpp
@@ -186,7 +186,7 @@ void sytrf_initData(const hipsolverHandle_t   handle,
             }
 
             // shuffle rows to test pivoting
-            // always the same permuation for debugging purposes
+            // always the same permutation for debugging purposes
             for(int i = 0; i < n / 2; i++)
             {
                 for(int j = 0; j < n; j++)

--- a/clients/rocsolvercommon/rocsolver_test.hpp
+++ b/clients/rocsolvercommon/rocsolver_test.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2018-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -125,7 +125,7 @@ inline void rocsolver_bench_output(T arg, Ts... args)
 //     return std::conj(scalar);
 // }
 
-// // A struct implicity convertable to and from char, used so we can customize
+// // A struct implicitly convertible to and from char, used so we can customize
 // // Google Test printing for LAPACK char arguments without affecting the default
 // // char output.
 // struct rocsolver_op_char

--- a/deps/external-gtest.cmake
+++ b/deps/external-gtest.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2016-2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2016-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -55,7 +55,7 @@ else( )
   else( )
     set( gtest_make "make" )
 
-    # The -j paramter does not work with nmake
+    # The -j parameter does not work with nmake
     if( NOT Cores EQUAL 0 )
       math( EXPR Cores "${Cores} + 1 " )
       list( APPEND gtest_make -j ${Cores} )

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -206,7 +206,7 @@ install_packages( )
 
       # Custom rocblas installation
       # Do not install rocblas if --rocblas_path flag is set,
-      # as we will be building against our own rocblas intead.
+      # as we will be building against our own rocblas instead.
       if [[ -z ${rocblas_path+foo} ]]; then
         if [[ -z ${custom_rocblas+foo} ]]; then
           # Install base rocblas package unless -b/--rocblas flag is passed
@@ -225,7 +225,7 @@ install_packages( )
 
       # Custom rocsolver installation
       # Do not install rocsolver if --rocsolver_path flag is set,
-      # as we will be building against our own rocsolver intead.
+      # as we will be building against our own rocsolver instead.
       if [[ -z ${rocsolver_path+foo} ]]; then
         if [[ -z ${custom_rocsolver+foo} ]]; then
           # Install base rocsolver package unless -s/--rocsolver flag is passed
@@ -330,7 +330,7 @@ make_absolute_path( ) {
 # #################################################
 # Pre-requisites check
 # #################################################
-# Exit code 0: alls well
+# Exit code 0: all is well
 # Exit code 1: problems with getopt
 # Exit code 2: problems with supported platforms
 

--- a/library/include/internal/hipsolver-functions.h
+++ b/library/include/internal/hipsolver-functions.h
@@ -5,7 +5,7 @@
 /*! \file
  *  \brief hipsolver-functions.h provides function wrappers around cuSOLVER
  *  and rocSOLVER functions. Some differences with the cuSOLVER API are
- *  present in order to accomodate the needs of rocSOLVER.
+ *  present in order to accommodate the needs of rocSOLVER.
  */
 
 #ifndef HIPSOLVER_FUNCTIONS_H


### PR DESCRIPTION
These are minor spelling fixes found by `check-all-the-things`.