### PR TITLE
Fix broken links and typographical inconsistencies

### DIFF
--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -5,7 +5,7 @@
 .. _ug_index:
 
 ********************************************************************
-How-To
+How to
 ********************************************************************
 
 This section provides guides on how to use the hipSOLVER library and its

--- a/docs/howto/usage.rst
+++ b/docs/howto/usage.rst
@@ -234,7 +234,7 @@ Using rocSOLVER's memory model
 
 Most hipSOLVER functions take a workspace pointer and size as arguments, allowing the user to manage the device memory used
 internally by the backends. rocSOLVER, however, can maintain the device workspace automatically by default
-(see `rocSOLVER's memory model <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/userguide/memory.html>`_ for more details). In order to take
+(see :doc:`rocSOLVER's memory model <rocsolver:howto/memory>` for more details). In order to take
 advantage of this feature, users may pass a null pointer for the `work` argument or a zero size for the `lwork` argument of any function
 when using the rocSOLVER backend, and the workspace will be automatically managed behind-the-scenes. It is recommended, however, to use
 a consistent strategy for workspace management, as performance issues may arise if the internal workspace is made to flip-flop between
@@ -246,9 +246,7 @@ user-provided and automatically allocated workspaces.
 
 Using rocSOLVER's in-place functions
 --------------------------------------
-
-The solvers `gesv` and `gels` in cuSOLVER are out-of-place in the sense that the solution vectors `X` do not overwrite the
-input matrix `B`. In rocSOLVER this is not the case; when `hipsolverXXgels` or `hipsolverXXgesv` call rocSOLVER, some data
+The solvers `gesv` and `gels` in cuSOLVER are out-of-place in the sense that the solution vectors `X` do not overwrite the input matrix `B`. In rocSOLVER this is not the case; when `hipsolverXXgels` or `hipsolverXXgesv` call rocSOLVER, some data
 movements must be done internally to restore `B` and copy the results back to `X`. These copies could introduce noticeable
 overhead depending on the size of the matrices. To avoid this potential problem, users can pass `X = B` to `hipsolverXXgels`
 or `hipsolverXXgesv` when using the rocSOLVER backend; in this case, no data movements will be required, and the solution

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ hipSOLVER documentation
 
 hipSOLVER is a LAPACK marshalling library, with multiple supported backends. It sits between the application and a 'worker' LAPACK library, marshalling inputs into the backend library and marshalling results back to the application. hipSOLVER supports rocSOLVER and cuSOLVER as backends. hipSOLVER exports an interface that does not require the client to change, regardless of the chosen backend.
 
-The code is open and hosted at: https://github.com/ROCm/hipSOLVER
+The code is open and hosted at: `<https://github.com/ROCm/hipSOLVER>`__
 
 The hipSOLVER documentation is structured as follows:
 
@@ -21,7 +21,7 @@ The hipSOLVER documentation is structured as follows:
 
     * :ref:`install-linux`
 
-  .. grid-item-card:: How-to
+  .. grid-item-card:: How to
 
     * :ref:`usage_label`
 
@@ -35,7 +35,7 @@ The hipSOLVER documentation is structured as follows:
 
 :ref:`usage_label` is the starting point for new users of the library. For a list of currently implemented routines in the different APIs refer to :ref:`api-intro`.
 
-To contribute to the documentation refer to `Contributing to ROCm  <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
+To contribute to the documentation refer to :doc:`Contributing to ROCm <rocm:contribute/contributing>`.
 
-You can find licensing information on the `Licensing <https://rocm.docs.amd.com/en/latest/about/license.html>`_ page.
+You can find licensing information on the :doc:`Licensing <rocm:about/license>` page.
 

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -8,6 +8,6 @@
 Installation
 ********************************************************************
 
-This section provides a guide to install hipSOLVER in different systems. 
+This section provides a guide to install hipSOLVER on different systems. 
 
 * :ref:`install-linux`

--- a/docs/installation/install.rst
+++ b/docs/installation/install.rst
@@ -11,7 +11,7 @@ Installation on Linux
 Install pre-built packages
 ===========================
 
-Download pre-built packages from `ROCm's package servers <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/index.html>`_. Updates to each release are listed in the ``CHANGELOG.md`` file under the releases tab of the `hipSOLVER github page <https://github.com/ROCm/hipSOLVER>`_.
+Download pre-built packages from :doc:`ROCm's package servers <rocm-install-on-linux:index>`. Updates to each release are listed in the ``CHANGELOG.md`` file under the releases tab of the `hipSOLVER github page <https://github.com/ROCm/hipSOLVER>`_.
 
 * `sudo apt update && sudo apt install hipsolver`
 
@@ -68,7 +68,7 @@ The rocSOLVER backend has the following dependencies:
 4. `SuiteSparse <https://github.com/DrTimothyAldenDavis/SuiteSparse>`_ modules CHOLMOD and SuiteSparse_config (optional, required by default)
 
 rocSOLVER itself depends on rocBLAS and rocSPARSE, therefore all three libraries should be present with a standard rocSOLVER installation. For more information
-about building and installing rocSOLVER, refer to the `rocSOLVER documentation <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/userguide/install.html>`_.
+about building and installing rocSOLVER, refer to the :doc:`rocSOLVER documentation <rocsolver:installation/installlinux>`.
 
 SuiteSparse is a third-party library, and can be installed using the package managers of most distros. Together with rocSPARSE, it is used to provide
 functionality for the hipsolverSp API. If only hipsolverDn and/or hipsolverRf are needed, these dependencies can be ignored by setting the ``BUILD_WITH_SPARSE``
@@ -115,8 +115,8 @@ install the respective library via:
 
 * ``./install.sh -i``
 
-More details can be found in the `hipBLAS documentation <https://rocm.docs.amd.com/projects/hipBLAS/en/latest/index.html>`_
-and the `hipSPARSE documentation <https://rocm.docs.amd.com/projects/hipSPARSE/en/latest/index.html>`_.
+Find more details in the :doc:`hipBLAS documentation <hipblas:index>`
+and the :doc:`hipSPARSE documentation <hipsparse:index>`.
 
 Library and clients
 --------------------

--- a/docs/reference/dense-api/types.rst
+++ b/docs/reference/dense-api/types.rst
@@ -55,6 +55,6 @@ hipsolverAlgMode_t
 .. doxygenenum:: hipsolverAlgMode_t
 
 hipsolverDnFunction_t
---------------------
+---------------------
 .. doxygenenum:: hipsolverDnFunction_t
 


### PR DESCRIPTION
In this PR:

Change absolute links to relative for maintainability.
Fix inconsistencies to adhere to Google style guide.
Fix rST warnings.