### PR TITLE
Update dependency names for static builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,10 +217,17 @@ endif( )
 
 # Package specific CPACK vars
 if( NOT USE_CUDA )
-  set(hipsolver_pkgdeps "rocblas >= 4.2.0" "rocsolver >= 3.26.0")
+  set(rocblas_minimum 4.2.0)
+  set(rocsolver_minimum 3.26.0)
+  rocm_package_add_dependencies(SHARED_DEPENDS "rocblas >= ${rocblas_minimum}" "rocsolver >= ${rocsolver_minimum}")
+  rocm_package_add_rpm_dependencies(STATIC_DEPENDS "rocblas-static-devel >= ${rocblas_minimum}" "rocsolver-static-devel >= ${rocsolver_minimum}")
+  rocm_package_add_deb_dependencies(STATIC_DEPENDS "rocblas-static-dev >= ${rocblas_minimum}" "rocsolver-static-dev >= ${rocsolver_minimum}")
 
   if( BUILD_WITH_SPARSE )
-    list(APPEND hipsolver_pkgdeps "rocsparse >= 2.3.0")
+    set(rocsparse_minimum 2.3.0)
+    rocm_package_add_dependencies(SHARED_DEPENDS "rocsparse >= ${rocsparse_minimum}")
+    rocm_package_add_rpm_dependencies(STATIC_DEPENDS "rocsparse-static-devel >= ${rocsparse_minimum}")
+    rocm_package_add_deb_dependencies(STATIC_DEPENDS "rocsparse-static-dev >= ${rocsparse_minimum}")
 
     if( SYSTEM_OS STREQUAL "centos" OR SYSTEM_OS STREQUAL "rhel" OR SYSTEM_OS STREQUAL "mariner" )
       list(APPEND hipsolver_pkgdeps "suitesparse")
@@ -229,9 +236,8 @@ if( NOT USE_CUDA )
     else()
       list(APPEND hipsolver_pkgdeps "libcholmod3" "libsuitesparseconfig5")
     endif()
+    rocm_package_add_dependencies(DEPENDS ${hipsolver_pkgdeps})
   endif( )
-
-  rocm_package_add_dependencies(DEPENDS ${hipsolver_pkgdeps})
 endif( )
 
 set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md" )


### PR DESCRIPTION
* Update dependency names for static builds

* Correct version numbers

This picks 947197ad21d883f82b68dca45564ff41e4077d61 from topic/init-static-libs-support, which was written after release-staging/rocm-rel-6.2 was created.

Do we need an additional PR to target develop, or can we just let the 6.2 mergeback take care of it?