### PR TITLE
Reformat cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,39 +20,39 @@
 #
 # ########################################################################
 
-cmake_minimum_required( VERSION 3.7 )
+cmake_minimum_required(VERSION 3.7)
 
 # We use C++17 features, this will add compile option: -std=c++17
-set( CMAKE_CXX_STANDARD 17 )
+set(CMAKE_CXX_STANDARD 17)
 
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
-if( WIN32 )
-  set( CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/package" CACHE PATH "Install path prefix, prepended onto install directories" )
-else( )
-  set( CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories" )
-endif( )
+if(WIN32)
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/package" CACHE PATH "Install path prefix, prepended onto install directories")
+else()
+  set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories")
+endif()
 
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
-if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
+if(NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
 endif()
 
-if ( NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC} )
-  set( CMAKE_Fortran_COMPILER  "gfortran" )
+if(NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC})
+  set(CMAKE_Fortran_COMPILER  "gfortran")
 endif()
 
-project( hipsolver LANGUAGES CXX )
-if( UNIX )
-  enable_language( Fortran )
-endif( )
+project(hipsolver LANGUAGES CXX)
+if(UNIX)
+  enable_language(Fortran)
+endif()
 
 # This finds the rocm-cmake project, and installs it if not found
 # rocm-cmake contains common cmake code for rocm projects to help setup and install
-set( PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern )
-find_package( ROCM 0.7.3 CONFIG QUIET PATHS /opt/rocm )
-if( NOT ROCM_FOUND )
+set(PROJECT_EXTERN_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern)
+find_package(ROCM 0.7.3 CONFIG QUIET PATHS /opt/rocm)
+if(NOT ROCM_FOUND)
   set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
   set(rocm_cmake_url "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip")
   set(rocm_cmake_path "${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}")
@@ -73,47 +73,47 @@ if( NOT ROCM_FOUND )
 
   execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzvf "${rocm_cmake_archive}"
     WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
-  execute_process( COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
-    WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag} )
-  execute_process( COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
+  execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
+    WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag})
+  execute_process(COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
     WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
 
-  find_package( ROCM 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )
-endif( )
+  find_package(ROCM 0.7.3 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake)
+endif()
 
-include( ROCMSetupVersion )
-include( ROCMCreatePackage )
-include( ROCMInstallTargets )
-include( ROCMPackageConfigHelpers )
-include( ROCMInstallSymlinks )
-include( ROCMClients )
-include( ROCMHeaderWrapper )
+include(ROCMSetupVersion)
+include(ROCMCreatePackage)
+include(ROCMInstallTargets)
+include(ROCMPackageConfigHelpers)
+include(ROCMInstallSymlinks)
+include(ROCMClients)
+include(ROCMHeaderWrapper)
 
-set ( VERSION_STRING "2.3.0" )
-rocm_setup_version( VERSION ${VERSION_STRING} )
+set(VERSION_STRING "2.3.0")
+rocm_setup_version(VERSION ${VERSION_STRING})
 
-if( NOT DEFINED ENV{HIP_PATH})
-    set( HIP_PATH "/opt/rocm/hip" )
-else( )
-    set (HIP_PATH $ENV{HIP_PATH} )
-endif( )
+if(NOT DEFINED ENV{HIP_PATH})
+  set(HIP_PATH "/opt/rocm/hip")
+else()
+  set(HIP_PATH $ENV{HIP_PATH})
+endif()
 
 # Append our library helper cmake path and the cmake path for hip (for convenience)
 # Users may override HIP path by specifying their own in CMAKE_MODULE_PATH
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib/cmake/hip ${HIP_PATH}/cmake )
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib/cmake/hip ${HIP_PATH}/cmake)
 
 # NOTE:  workaround until hip cmake modules fixes symlink logic in their config files; remove when fixed
-list( APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/llvm /opt/rocm/hip )
+list(APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/llvm /opt/rocm/hip)
 
-option( BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF )
-option( BUILD_CODE_COVERAGE "Build hipSOLVER with code coverage enabled" OFF )
-option( BUILD_HIPBLAS_TESTS "Build additional tests to ensure hipBLAS and hipSOLVER are compatible (requires installed hipBLAS)" OFF )
+option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
+option(BUILD_CODE_COVERAGE "Build hipSOLVER with code coverage enabled" OFF)
+option(BUILD_HIPBLAS_TESTS "Build additional tests to ensure hipBLAS and hipSOLVER are compatible (requires installed hipBLAS)" OFF)
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
-option( BUILD_SHARED_LIBS "Build hipSOLVER as a shared library" ON )
-option( BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality and tests enabled (requires additional dependencies)" "${UNIX}" )
-option( BUILD_VERBOSE "Output additional build information" OFF )
-option( USE_CUDA "Look for CUDA and use that as a backend if found" OFF )
-option( HIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG "Skip module mode search for LAPACK" ON )
+option(BUILD_SHARED_LIBS "Build hipSOLVER as a shared library" ON)
+option(BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality and tests enabled (requires additional dependencies)" "${UNIX}")
+option(BUILD_VERBOSE "Output additional build information" OFF)
+option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
+option(HIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG "Skip module mode search for LAPACK" ON)
 
 add_library(hipsolver-common INTERFACE)
 target_compile_options(hipsolver-common INTERFACE
@@ -131,29 +131,29 @@ if(BUILD_ADDRESS_SANITIZER)
   )
 endif()
 
-if( CMAKE_BUILD_TYPE STREQUAL "Debug" )
-  set( DEFAULT_ARMOR_LEVEL 1 )
-else( )
-  set( DEFAULT_ARMOR_LEVEL 0 )
-endif( )
-set( ARMOR_LEVEL "${DEFAULT_ARMOR_LEVEL}" CACHE STRING "Enables increasingly expensive runtime correctness checks" )
-include( armor-config )
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(DEFAULT_ARMOR_LEVEL 1)
+else()
+  set(DEFAULT_ARMOR_LEVEL 0)
+endif()
+set(ARMOR_LEVEL "${DEFAULT_ARMOR_LEVEL}" CACHE STRING "Enables increasingly expensive runtime correctness checks")
+include(armor-config)
 
 # Find CUDA if the user wants a CUDA version.
-if (USE_CUDA)
-    find_package( CUDA REQUIRED )
+if(USE_CUDA)
+  find_package(CUDA REQUIRED)
 endif()
 
 # Hip headers required of all clients; clients use hip to allocate device memory
-if( USE_CUDA)
-    find_package( HIP MODULE REQUIRED )
-else( )
-    find_package( hip REQUIRED CONFIG PATHS ${HIP_PATH} ${ROCM_PATH} /opt/rocm )
-endif( )
+if(USE_CUDA)
+  find_package(HIP MODULE REQUIRED)
+else()
+  find_package(hip REQUIRED CONFIG PATHS ${HIP_PATH} ${ROCM_PATH} /opt/rocm)
+endif()
 
-if( USE_CUDA )
-    list( APPEND HIP_INCLUDE_DIRS "${HIP_ROOT_DIR}/include" )
-endif( )
+if(USE_CUDA)
+  list(APPEND HIP_INCLUDE_DIRS "${HIP_ROOT_DIR}/include")
+endif()
 
 # FOR OPTIONAL CODE COVERAGE
 if(BUILD_CODE_COVERAGE)
@@ -173,7 +173,7 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
   )
 endif()
 
-if( WIN32 )
+if(WIN32)
   add_compile_definitions(
     WIN32_LEAN_AND_MEAN
     _CRT_SECURE_NO_WARNINGS
@@ -181,9 +181,9 @@ if( WIN32 )
   )
 endif()
 
-add_subdirectory( library )
+add_subdirectory(library)
 
-include( clients/cmake/build-options.cmake )
+include(clients/cmake/build-options.cmake)
 
 if(NOT SYSTEM_OS)
   rocm_set_os_id(SYSTEM_OS)
@@ -192,7 +192,7 @@ if(NOT SYSTEM_OS)
 endif()
 
 # Build clients of the library
-if( BUILD_CLIENTS_SAMPLES OR BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
+if(BUILD_CLIENTS_SAMPLES OR BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS)
   set(GFORTRAN_RPM "libgfortran4")
   set(GFORTRAN_DEB "libgfortran4")
   if(SYSTEM_OS STREQUAL "centos" OR SYSTEM_OS STREQUAL "rhel")
@@ -203,33 +203,33 @@ if( BUILD_CLIENTS_SAMPLES OR BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
     set(GFORTRAN_DEB "libgfortran5")
   endif()
   rocm_package_setup_component(clients)
-  if( UNIX )
+  if(UNIX)
     set(DEP_ARGS DEPENDS RPM "${GFORTRAN_RPM}" DEB "${GFORTRAN_DEB}")
   endif()
-  if( BUILD_CLIENTS_TESTS )
+  if(BUILD_CLIENTS_TESTS)
     rocm_package_setup_client_component(tests ${DEP_ARGS})
   endif()
-  if( BUILD_CLIENTS_BENCHMARKS )
+  if(BUILD_CLIENTS_BENCHMARKS)
     rocm_package_setup_client_component(benchmarks ${DEP_ARGS})
   endif()
-  add_subdirectory( clients )
-endif( )
+  add_subdirectory(clients)
+endif()
 
 # Package specific CPACK vars
-if( NOT USE_CUDA )
+if(NOT USE_CUDA)
   set(rocblas_minimum 4.2.0)
   set(rocsolver_minimum 3.27.0)
   rocm_package_add_dependencies(SHARED_DEPENDS "rocblas >= ${rocblas_minimum}" "rocsolver >= ${rocsolver_minimum}")
   rocm_package_add_rpm_dependencies(STATIC_DEPENDS "rocblas-static-devel >= ${rocblas_minimum}" "rocsolver-static-devel >= ${rocsolver_minimum}")
   rocm_package_add_deb_dependencies(STATIC_DEPENDS "rocblas-static-dev >= ${rocblas_minimum}" "rocsolver-static-dev >= ${rocsolver_minimum}")
 
-  if( BUILD_WITH_SPARSE )
+  if(BUILD_WITH_SPARSE)
     set(rocsparse_minimum 2.3.0)
     rocm_package_add_dependencies(SHARED_DEPENDS "rocsparse >= ${rocsparse_minimum}")
     rocm_package_add_rpm_dependencies(STATIC_DEPENDS "rocsparse-static-devel >= ${rocsparse_minimum}")
     rocm_package_add_deb_dependencies(STATIC_DEPENDS "rocsparse-static-dev >= ${rocsparse_minimum}")
 
-    if( SYSTEM_OS STREQUAL "centos" OR SYSTEM_OS STREQUAL "rhel" OR SYSTEM_OS STREQUAL "mariner" )
+    if(SYSTEM_OS STREQUAL "centos" OR SYSTEM_OS STREQUAL "rhel" OR SYSTEM_OS STREQUAL "mariner")
       list(APPEND hipsolver_pkgdeps "suitesparse")
     elseif(SYSTEM_OS STREQUAL "ubuntu" AND SYSTEM_OS_VERSION VERSION_GREATER_EQUAL "24.04")
       list(APPEND hipsolver_pkgdeps "libcholmod5" "libsuitesparseconfig7")
@@ -237,11 +237,11 @@ if( NOT USE_CUDA )
       list(APPEND hipsolver_pkgdeps "libcholmod3" "libsuitesparseconfig5")
     endif()
     rocm_package_add_dependencies(DEPENDS ${hipsolver_pkgdeps})
-  endif( )
-endif( )
+  endif()
+endif()
 
-set( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md" )
-set( CPACK_RPM_PACKAGE_LICENSE "MIT" )
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.md")
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 
 if(WIN32)
   set(CPACK_SOURCE_GENERATOR "ZIP")
@@ -258,16 +258,16 @@ else()
   endif()
 endif()
 
-set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" )
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}")
 
 # Give hipsolver compiled for CUDA backend a different name
-if( NOT USE_CUDA )
-    set( package_name hipsolver )
-else( )
-    set( package_name hipsolver-alt )
-endif( )
+if(NOT USE_CUDA)
+  set(package_name hipsolver)
+else()
+  set(package_name hipsolver-alt)
+endif()
 
-set( HIPSOLVER_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file" )
+set(HIPSOLVER_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file")
 
 rocm_create_package(
     NAME ${package_name}
@@ -278,63 +278,50 @@ rocm_create_package(
 )
 
 # ADDITIONAL TARGETS FOR CODE COVERAGE
-if(BUILD_CODE_COVERAGE)
-
 #
 # > make coverage_cleanup (clean coverage related files.)
 # > make coverage GTEST_FILTER=<>
 # will run:
 #  > make coverage_analysis GTEST_FILTER=<> (analyze tests)
 #  > make coverage_output (generate html documentation)
-#
-#
+if(BUILD_CODE_COVERAGE)
+  set(coverage_test ./clients/staging/hipsolver-test)
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(coverage_test ./clients/staging/hipsolver-test-d)
+  endif()
 
-set(coverage_test ./clients/staging/hipsolver-test)
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(coverage_test ./clients/staging/hipsolver-test-d)
-endif()
+  # Run coverage analysis
+  add_custom_target(coverage_analysis
+     COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
+     COMMAND ${coverage_test} --gtest_filter=\"\${GTEST_FILTER}\"
+     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
 
-#
-# Run coverage analysis
-#
-add_custom_target(coverage_analysis
-   COMMAND echo Coverage GTEST_FILTER=\${GTEST_FILTER}
-   COMMAND ${coverage_test} --gtest_filter=\"\${GTEST_FILTER}\"
-   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
- )
+  add_dependencies(coverage_analysis hipsolver)
 
-add_dependencies(coverage_analysis hipsolver)
+  # Prepare coverage output
+  # This little script is generated because the option '--gcov-tool <program name>' of lcov cannot take arguments.
+  add_custom_target(coverage_output
+      DEPENDS coverage_analysis
+      COMMAND mkdir -p lcoverage
+      COMMAND echo "\\#!/bin/bash" > llvm-gcov.sh
+      COMMAND echo "\\# THIS FILE HAS BEEN GENERATED" >> llvm-gcov.sh
+      COMMAND printf "exec /opt/rocm/llvm/bin/llvm-cov gcov $$\\@" >> llvm-gcov.sh
+      COMMAND chmod +x llvm-gcov.sh
+  )
 
-#
-# Prepare coverage output
-# This little script is generated because the option '--gcov-tool <program name>' of lcov cannot take arguments.
-#
-add_custom_target(coverage_output
-    DEPENDS coverage_analysis
-    COMMAND mkdir -p lcoverage
-    COMMAND echo "\\#!/bin/bash" > llvm-gcov.sh
-    COMMAND echo "\\# THIS FILE HAS BEEN GENERATED" >> llvm-gcov.sh
-    COMMAND printf "exec /opt/rocm/llvm/bin/llvm-cov gcov $$\\@" >> llvm-gcov.sh
-    COMMAND chmod +x llvm-gcov.sh
-    )
+  # Generate coverage output.
+  add_custom_command(TARGET coverage_output
+    COMMAND lcov --directory . --base-directory . --gcov-tool ${CMAKE_BINARY_DIR}/llvm-gcov.sh --capture -o lcoverage/raw_main_coverage.info
+    COMMAND lcov --remove lcoverage/raw_main_coverage.info "'/opt/*'" "'/usr/*'" -o lcoverage/main_coverage.info
+    COMMAND genhtml --ignore-errors source lcoverage/main_coverage.info --output-directory lcoverage
+  )
 
-#
-# Generate coverage output.
-#
-add_custom_command(TARGET coverage_output
-  COMMAND lcov --directory . --base-directory . --gcov-tool ${CMAKE_BINARY_DIR}/llvm-gcov.sh --capture -o lcoverage/raw_main_coverage.info
-  COMMAND lcov --remove lcoverage/raw_main_coverage.info "'/opt/*'" "'/usr/*'" -o lcoverage/main_coverage.info
-  COMMAND genhtml --ignore-errors source lcoverage/main_coverage.info --output-directory lcoverage
-    )
+  add_custom_target(coverage DEPENDS coverage_output)
 
-add_custom_target(coverage DEPENDS coverage_output)
-
-#
-# Coverage cleanup
-#
-add_custom_target(coverage_cleanup
-    COMMAND find ${CMAKE_BINARY_DIR} -name *.gcda -delete
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
-
+  # Coverage cleanup
+  add_custom_target(coverage_cleanup
+      COMMAND find ${CMAKE_BINARY_DIR} -name *.gcda -delete
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
 endif()

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -22,34 +22,34 @@
 
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
-if( WIN32 )
-  set( CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/package" CACHE PATH "Install path prefix, prepended onto install directories" )
-else( )
-  set( CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories" )
-endif( )
+if(WIN32)
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/package" CACHE PATH "Install path prefix, prepended onto install directories")
+else()
+  set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories")
+endif()
 
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
-if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
+if(NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
 endif()
 
 # This project may compile dependencies for clients
-project( hipsolver-clients LANGUAGES CXX )
-if( UNIX )
-  enable_language( Fortran )
-endif( )
+project(hipsolver-clients LANGUAGES CXX)
+if(UNIX)
+  enable_language(Fortran)
+endif()
 
 # We use C++17 features, this will add compile option: -std=c++17
-set( CMAKE_CXX_STANDARD 17 )
+set(CMAKE_CXX_STANDARD 17)
 
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-include( build-options )
+include(build-options)
 
 # Linking lapack library requires fortran flags
-set( THREADS_PREFER_PTHREAD_FLAG ON )
-find_package( Threads REQUIRED )
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 if(HIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG)
   find_package(LAPACK 3.7 REQUIRED CONFIG)
 else()
@@ -63,23 +63,23 @@ if(NOT LAPACK_LIBRARIES)
   )
 endif()
 
-if( NOT TARGET hipsolver )
-  find_package( hipsolver REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
-endif( )
+if(NOT TARGET hipsolver)
+  find_package(hipsolver REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
+endif()
 
-if( UNIX )
+if(UNIX)
   set(hipsolver_f90_source_clients
     include/hipsolver_fortran.f90
   )
-endif( )
+endif()
 
-if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
-  if( UNIX )
+if(BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS)
+  if(UNIX)
     add_library(hipsolver_fortran_client STATIC ${hipsolver_f90_source_clients})
     add_dependencies(hipsolver_fortran_client hipsolver_fortran)
     include_directories(${CMAKE_BINARY_DIR}/include/hipsolver)
     include_directories(${CMAKE_BINARY_DIR}/include/hipsolver/internal)
-  endif( )
+  endif()
 
   add_library(clients-common INTERFACE)
   target_include_directories(clients-common INTERFACE
@@ -111,15 +111,15 @@ if( BUILD_CLIENTS_TESTS OR BUILD_CLIENTS_BENCHMARKS )
     COMPONENT tests
   )
 
-  if( BUILD_CLIENTS_TESTS )
-    add_subdirectory( gtest )
-  endif( )
+  if(BUILD_CLIENTS_TESTS)
+    add_subdirectory(gtest)
+  endif()
 
-  if( BUILD_CLIENTS_BENCHMARKS )
-    add_subdirectory( benchmarks )
-  endif( )
-endif( )
+  if(BUILD_CLIENTS_BENCHMARKS)
+    add_subdirectory(benchmarks)
+  endif()
+endif()
 
-if( BUILD_CLIENTS_SAMPLES )
-  add_subdirectory( samples )
-endif( )
+if(BUILD_CLIENTS_SAMPLES)
+  add_subdirectory(samples)
+endif()

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -20,77 +20,77 @@
 #
 # ########################################################################
 
-if( BUILD_WITH_SPARSE )
-  if( NOT TARGET hipsparse )
-    if( CUSTOM_HIPSPARSE )
-      set ( ENV{hipsparse_DIR} ${CUSTOM_HIPSPARSE})
-      find_package( hipsparse REQUIRED CONFIG NO_CMAKE_PATH )
-    else( )
-      find_package( hipsparse REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
-    endif( )
-  endif( )
-endif( )
+if(BUILD_WITH_SPARSE)
+  if(NOT TARGET hipsparse)
+    if(CUSTOM_HIPSPARSE)
+      set(ENV{hipsparse_DIR} ${CUSTOM_HIPSPARSE})
+      find_package(hipsparse REQUIRED CONFIG NO_CMAKE_PATH)
+    else()
+      find_package(hipsparse REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
+    endif()
+  endif()
+endif()
 
-add_executable( hipsolver-bench client.cpp )
+add_executable(hipsolver-bench client.cpp)
 
 # Internal header includes
-target_include_directories( hipsolver-bench
+target_include_directories(hipsolver-bench
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
 )
 
 # External header includes included as system files
-target_include_directories( hipsolver-bench
+target_include_directories(hipsolver-bench
   SYSTEM PRIVATE
     $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
 )
 
-target_link_libraries( hipsolver-bench PRIVATE
+target_link_libraries(hipsolver-bench PRIVATE
   ${LAPACK_LIBRARIES}
   hipsolver-common
   clients-common
   roc::hipsolver
 )
-if( BUILD_WITH_SPARSE )
+if(BUILD_WITH_SPARSE)
   set_source_files_properties(client.cpp
     PROPERTIES
       COMPILE_DEFINITIONS HAVE_HIPSPARSE
   )
-  target_link_libraries( hipsolver-bench PRIVATE roc::hipsparse )
-endif( )
-if( UNIX )
-  target_link_libraries( hipsolver-bench PRIVATE hipsolver_fortran_client )
-endif( )
+  target_link_libraries(hipsolver-bench PRIVATE roc::hipsparse)
+endif()
+if(UNIX)
+  target_link_libraries(hipsolver-bench PRIVATE hipsolver_fortran_client)
+endif()
 
-add_armor_flags( hipsolver-bench "${ARMOR_LEVEL}" )
+add_armor_flags(hipsolver-bench "${ARMOR_LEVEL}")
 
-if( NOT USE_CUDA )
-  target_link_libraries( hipsolver-bench PRIVATE hip::host )
+if(NOT USE_CUDA)
+  target_link_libraries(hipsolver-bench PRIVATE hip::host)
 
-  if( CUSTOM_TARGET )
-    target_link_libraries( hipsolver-bench PRIVATE hip::${CUSTOM_TARGET} )
-  endif( )
-
-  if( UNIX AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-    # hip-clang needs specific flag to turn on pthread and m
-    target_link_libraries( hipsolver-bench PRIVATE -lpthread -lm )
+  if(CUSTOM_TARGET)
+    target_link_libraries(hipsolver-bench PRIVATE hip::${CUSTOM_TARGET})
   endif()
-else( )
-  target_compile_definitions( hipsolver-bench PRIVATE __HIP_PLATFORM_NVIDIA__ )
 
-  target_include_directories( hipsolver-bench
+  if(UNIX AND CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
+    # hip-clang needs specific flag to turn on pthread and m
+    target_link_libraries(hipsolver-bench PRIVATE -lpthread -lm)
+  endif()
+else()
+  target_compile_definitions(hipsolver-bench PRIVATE __HIP_PLATFORM_NVIDIA__)
+
+  target_include_directories(hipsolver-bench
     PRIVATE
       $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
   )
 
-  target_link_libraries( hipsolver-bench PRIVATE ${CUDA_LIBRARIES} Threads::Threads )
-endif( )
+  target_link_libraries(hipsolver-bench PRIVATE ${CUDA_LIBRARIES} Threads::Threads)
+endif()
 
-set_target_properties( hipsolver-bench PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO )
-set_target_properties( hipsolver-bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
-#add_dependencies( hipsolver-bench hipsolver-bench-common )
+set_target_properties(hipsolver-bench PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO)
+set_target_properties(hipsolver-bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging")
+# add_dependencies(hipsolver-bench hipsolver-bench-common)
 
 rocm_install(TARGETS hipsolver-bench COMPONENT benchmarks)
 
-target_compile_definitions( hipsolver-bench PRIVATE HIPSOLVER_BENCH ROCM_USE_FLOAT16 )
+target_compile_definitions(hipsolver-bench PRIVATE HIPSOLVER_BENCH ROCM_USE_FLOAT16)

--- a/clients/cmake/build-options.cmake
+++ b/clients/cmake/build-options.cmake
@@ -27,17 +27,17 @@
 # presented in the superbuild GUI, but then passed into the ExternalProject as -D
 # parameters, which would already define them.
 
-if( NOT BUILD_CLIENTS_TESTS )
-  option( BUILD_CLIENTS_TESTS "Build hipSOLVER unit tests" OFF )
-endif( )
+if(NOT BUILD_CLIENTS_TESTS)
+  option(BUILD_CLIENTS_TESTS "Build hipSOLVER unit tests" OFF)
+endif()
 
-if( NOT BUILD_CLIENTS_BENCHMARKS )
-  option( BUILD_CLIENTS_BENCHMARKS "Build hipSOLVER benchmarks" OFF )
-endif( )
+if(NOT BUILD_CLIENTS_BENCHMARKS)
+  option(BUILD_CLIENTS_BENCHMARKS "Build hipSOLVER benchmarks" OFF)
+endif()
 
-if( NOT BUILD_CLIENTS_SAMPLES )
-  option( BUILD_CLIENTS_SAMPLES "Build hipSOLVER samples" OFF )
-endif( )
+if(NOT BUILD_CLIENTS_SAMPLES)
+  option(BUILD_CLIENTS_SAMPLES "Build hipSOLVER samples" OFF)
+endif()
 
 
 

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -20,29 +20,29 @@
 #
 # ########################################################################
 
-find_package( GTest REQUIRED )
+find_package(GTest REQUIRED)
 
-if( BUILD_HIPBLAS_TESTS )
-  if( NOT TARGET hipblas )
-    if( CUSTOM_HIPBLAS )
-      set ( ENV{hipblas_DIR} ${CUSTOM_HIPBLAS})
-      find_package( hipblas REQUIRED CONFIG NO_CMAKE_PATH )
-    else( )
-      find_package( hipblas REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
-    endif( )
-  endif( )
-endif( )
+if(BUILD_HIPBLAS_TESTS)
+  if(NOT TARGET hipblas)
+    if(CUSTOM_HIPBLAS)
+      set(ENV{hipblas_DIR} ${CUSTOM_HIPBLAS})
+      find_package(hipblas REQUIRED CONFIG NO_CMAKE_PATH)
+    else()
+      find_package(hipblas REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
+    endif()
+  endif()
+endif()
 
-if( BUILD_WITH_SPARSE )
-  if( NOT TARGET hipsparse )
-    if( CUSTOM_HIPSPARSE )
-      set ( ENV{hipsparse_DIR} ${CUSTOM_HIPSPARSE})
-      find_package( hipsparse REQUIRED CONFIG NO_CMAKE_PATH )
-    else( )
-      find_package( hipsparse REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm )
-    endif( )
-  endif( )
-endif( )
+if(BUILD_WITH_SPARSE)
+  if(NOT TARGET hipsparse)
+    if(CUSTOM_HIPSPARSE)
+      set(ENV{hipsparse_DIR} ${CUSTOM_HIPSPARSE})
+      find_package(hipsparse REQUIRED CONFIG NO_CMAKE_PATH)
+    else()
+      find_package(hipsparse REQUIRED CONFIG PATHS ${ROCM_PATH} /opt/rocm)
+    endif()
+  endif()
+endif()
 
 set(hipsolverDn_test_source
   hipsolver_gtest_main.cpp
@@ -86,25 +86,25 @@ set(others_test_source
   params_gtest.cpp
 )
 
-add_executable( hipsolver-test ${others_test_source} ${hipsolverDn_test_source} ${hipsolverRf_test_source} )
+add_executable(hipsolver-test ${others_test_source} ${hipsolverDn_test_source} ${hipsolverRf_test_source})
 
-target_include_directories( hipsolver-test
+target_include_directories(hipsolver-test
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
 )
 
-add_armor_flags( hipsolver-test "${ARMOR_LEVEL}" )
+add_armor_flags(hipsolver-test "${ARMOR_LEVEL}")
 
-target_compile_definitions( hipsolver-test PRIVATE GOOGLE_TEST )
+target_compile_definitions(hipsolver-test PRIVATE GOOGLE_TEST)
 
 # External header includes included as SYSTEM files
-target_include_directories( hipsolver-test
+target_include_directories(hipsolver-test
   SYSTEM PRIVATE
     $<BUILD_INTERFACE:${CBLAS_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
 )
 
-target_link_libraries( hipsolver-test PRIVATE
+target_link_libraries(hipsolver-test PRIVATE
   ${LAPACK_LIBRARIES}
   hipsolver-common
   clients-common
@@ -112,43 +112,43 @@ target_link_libraries( hipsolver-test PRIVATE
   Threads::Threads
   roc::hipsolver
 )
-if( BUILD_HIPBLAS_TESTS )
-  target_link_libraries( hipsolver-test PRIVATE roc::hipblas )
-  target_sources( hipsolver-test PRIVATE hipblas_include1_gtest.cpp hipblas_include2_gtest.cpp )
-endif( )
-if( BUILD_WITH_SPARSE )
-  target_link_libraries( hipsolver-test PRIVATE roc::hipsparse )
-  target_sources( hipsolver-test PRIVATE ${hipsolverSp_test_source} )
-endif( )
-if( UNIX )
-  target_link_libraries( hipsolver-test PRIVATE hipsolver_fortran_client )
-  target_sources( hipsolver-test PRIVATE ${hipsolver_f90_source} )
-endif( )
+if(BUILD_HIPBLAS_TESTS)
+  target_link_libraries(hipsolver-test PRIVATE roc::hipblas)
+  target_sources(hipsolver-test PRIVATE hipblas_include1_gtest.cpp hipblas_include2_gtest.cpp)
+endif()
+if(BUILD_WITH_SPARSE)
+  target_link_libraries(hipsolver-test PRIVATE roc::hipsparse)
+  target_sources(hipsolver-test PRIVATE ${hipsolverSp_test_source})
+endif()
+if(UNIX)
+  target_link_libraries(hipsolver-test PRIVATE hipsolver_fortran_client)
+  target_sources(hipsolver-test PRIVATE ${hipsolver_f90_source})
+endif()
 
-if( NOT USE_CUDA )
-  target_link_libraries( hipsolver-test PRIVATE hip::host )
+if(NOT USE_CUDA)
+  target_link_libraries(hipsolver-test PRIVATE hip::host)
 
-  if( CUSTOM_TARGET )
-    target_link_libraries( hipsolver-test PRIVATE hip::${CUSTOM_TARGET} )
-  endif( )
-
-  if( CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" )
-    # hip-clang needs specific flag to turn on pthread and m
-    target_link_libraries( hipsolver-test PRIVATE -lpthread -lm )
+  if(CUSTOM_TARGET)
+    target_link_libraries(hipsolver-test PRIVATE hip::${CUSTOM_TARGET})
   endif()
-else( )
-  target_compile_definitions( hipsolver-test PRIVATE __HIP_PLATFORM_NVIDIA__ )
 
-  target_include_directories( hipsolver-test
+  if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
+    # hip-clang needs specific flag to turn on pthread and m
+    target_link_libraries(hipsolver-test PRIVATE -lpthread -lm)
+  endif()
+else()
+  target_compile_definitions(hipsolver-test PRIVATE __HIP_PLATFORM_NVIDIA__)
+
+  target_include_directories(hipsolver-test
     PRIVATE
       $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
   )
 
-  target_link_libraries( hipsolver-test PRIVATE ${CUDA_LIBRARIES} Threads::Threads )
-endif( )
+  target_link_libraries(hipsolver-test PRIVATE ${CUDA_LIBRARIES} Threads::Threads)
+endif()
 
-set_target_properties( hipsolver-test PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO )
-set_target_properties( hipsolver-test PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
+set_target_properties(hipsolver-test PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO)
+set_target_properties(hipsolver-test PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging")
 
 rocm_install(TARGETS hipsolver-test COMPONENT tests)
 

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -20,8 +20,8 @@
 #
 # ########################################################################
 
-add_executable( example-c-basic example_basic.c )
-add_executable( example-cpp-basic example_basic.cpp )
+add_executable(example-c-basic example_basic.c)
+add_executable(example-cpp-basic example_basic.cpp)
 
 # We test for C99 compatibility in the example-c.c test
 set_source_files_properties(example_basic.c PROPERTIES LANGUAGE CXX)
@@ -30,38 +30,38 @@ set_source_files_properties(example_basic.c PROPERTIES COMPILE_FLAGS "-xc -std=c
 # Test for C++11 compatibility in one of the samples
 set_property(TARGET example-cpp-basic PROPERTY CXX_STANDARD 11)
 
-foreach( exe example-c-basic;example-cpp-basic; )
+foreach(exe example-c-basic;example-cpp-basic;)
 
   # External header includes included as SYSTEM files
-  target_include_directories( ${exe}
+  target_include_directories(${exe}
     SYSTEM PRIVATE
       $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
   )
 
-  target_include_directories( ${exe} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include> )
+  target_include_directories(${exe} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
-  target_link_libraries( ${exe} PRIVATE roc::hipsolver )
+  target_link_libraries(${exe} PRIVATE roc::hipsolver)
 
-  if( NOT USE_CUDA )
-    target_link_libraries( ${exe} PRIVATE hip::host )
+  if(NOT USE_CUDA)
+    target_link_libraries(${exe} PRIVATE hip::host)
 
-    if( CUSTOM_TARGET )
-      target_link_libraries( ${exe} PRIVATE hip::${CUSTOM_TARGET} )
-    endif( )
+    if(CUSTOM_TARGET)
+      target_link_libraries(${exe} PRIVATE hip::${CUSTOM_TARGET})
+    endif()
 
-  else( )
-    target_compile_definitions( ${exe} PRIVATE __HIP_PLATFORM_NVIDIA__ )
+  else()
+    target_compile_definitions(${exe} PRIVATE __HIP_PLATFORM_NVIDIA__)
 
-    target_include_directories( ${exe}
+    target_include_directories(${exe}
       PRIVATE
         $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
     )
 
-    target_link_libraries( ${exe} PRIVATE ${CUDA_LIBRARIES} )
-  endif( )
+    target_link_libraries(${exe} PRIVATE ${CUDA_LIBRARIES})
+  endif()
 
   set_target_properties(${exe} PROPERTIES LINKER_LANGUAGE CXX)
-  set_target_properties( ${exe} PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO )
-  set_target_properties( ${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
+  set_target_properties(${exe} PROPERTIES DEBUG_POSTFIX "-d" CXX_EXTENSIONS NO)
+  set_target_properties(${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging")
 
-endforeach( )
+endforeach()

--- a/cmake/armor-config.cmake
+++ b/cmake/armor-config.cmake
@@ -27,18 +27,18 @@
 #     Note: Some checks are added by the optimizer, so it can help to build
 #           with optimizations enabled. e.g. -Og
 # 2 - Expensive correctness checks (debug iterators)
-macro( add_armor_flags target level )
-  if( UNIX AND "${level}" GREATER "0" )
-    if( "${level}" GREATER "1" )
+macro(add_armor_flags target level)
+  if(UNIX AND "${level}" GREATER "0")
+    if("${level}" GREATER "1")
       # Building with std debug iterators is enabled by the defines below, but
       # requires building C++ dependencies with the same defines.
-      target_compile_definitions( ${target} PRIVATE
+      target_compile_definitions(${target} PRIVATE
         _GLIBCXX_DEBUG
       )
-    endif( )
-    target_compile_definitions( ${target} PRIVATE
+    endif()
+    target_compile_definitions(${target} PRIVATE
       $<$<NOT:$<BOOL:${BUILD_ADDRESS_SANITIZER}>>:_FORTIFY_SOURCE=1> # requires optimizations to work
       _GLIBCXX_ASSERTIONS
     )
-  endif( )
-endmacro( )
+  endif()
+endmacro()

--- a/cmake/get-cli-arguments.cmake
+++ b/cmake/get-cli-arguments.cmake
@@ -2,24 +2,24 @@
 # NOTE: Even if the user specifies CMAKE_INSTALL_PREFIX on the command line, the parameter is
 # not returned because it does not have the matching helpstring
 
-function( append_cmake_cli_arguments initial_cli_args return_cli_args )
+function(append_cmake_cli_arguments initial_cli_args return_cli_args)
 
   # Retrieves the contents of CMakeCache.txt
-  get_cmake_property( cmake_properties CACHE_VARIABLES )
+  get_cmake_property(cmake_properties CACHE_VARIABLES)
 
-  foreach( property ${cmake_properties} )
-    get_property(help_string CACHE ${property} PROPERTY HELPSTRING )
+  foreach(property ${cmake_properties})
+    get_property(help_string CACHE ${property} PROPERTY HELPSTRING)
 
     # Properties specified on the command line have boilerplate text
-    if( help_string MATCHES "variable specified on the command line" )
-      # message( STATUS "property: ${property}")
-      # message( STATUS "value: ${${property}}")
+    if(help_string MATCHES "variable specified on the command line")
+      # message(STATUS "property: ${property}")
+      # message(STATUS "value: ${${property}}")
 
-      list( APPEND cli_args "-D${property}=${${property}}")
-    endif( )
-  endforeach( )
+      list(APPEND cli_args "-D${property}=${${property}}")
+    endif()
+  endforeach()
 
-  # message( STATUS "get_command_line_arguments: ${cli_args}")
-  set( ${return_cli_args} ${${initial_cli_args}} ${cli_args} PARENT_SCOPE )
+  # message(STATUS "get_command_line_arguments: ${cli_args}")
+  set(${return_cli_args} ${${initial_cli_args}} ${cli_args} PARENT_SCOPE)
 
-endfunction( )
+endfunction()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -24,76 +24,76 @@
 # This script can be invoked manually by the user with 'cmake -P'
 
 # The ROCm platform requires Ubuntu 16.04 or Fedora 24, which has cmake 3.5
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required(VERSION 3.5)
 
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../cmake )
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../cmake)
 
 # Consider removing this in the future
 # It can be annoying for visual studio developers to build a project that tries to install into 'program files'
-if( WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
-  set( CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/package" CACHE PATH "Install path prefix, prepended onto install directories" FORCE )
-endif( )
+if(WIN32 AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/package" CACHE PATH "Install path prefix, prepended onto install directories" FORCE)
+endif()
 
 # This has to be initialized before the project() command appears
 # Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
-if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
+if(NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
 endif()
 
-if( NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC} )
-  set( CMAKE_Fortran_COMPILER  "gfortran" )
+if(NOT DEFINED CMAKE_Fortran_COMPILER AND NOT DEFINED ENV{FC})
+  set(CMAKE_Fortran_COMPILER  "gfortran")
 endif()
 
 # The superbuild does not build anything itself; all compiling is done in external projects
-project( hipsolver-dependencies NONE )
+project(hipsolver-dependencies NONE)
 
-option( BUILD_BOOST "Download and build boost library" ON )
-option( BUILD_GTEST "Download and build googletest library" ON )
-option( BUILD_LAPACK "Download and build lapack library" ON )
-# option( BUILD_VERBOSE "Print helpful build debug information" OFF )
+option(BUILD_BOOST "Download and build boost library" ON)
+option(BUILD_GTEST "Download and build googletest library" ON)
+option(BUILD_LAPACK "Download and build lapack library" ON)
+# option(BUILD_VERBOSE "Print helpful build debug information" OFF)
 
-# if( BUILD_VERBOSE )
-#   message( STATUS "CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}" )
-#   message( STATUS "CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}" )
-#   message( STATUS "CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}" )
-#   message( STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}" )
-#   message( STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}" )
-#   message( STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}" )
-#   message( STATUS "CMAKE_CURRENT_LIST_FILE: ${CMAKE_CURRENT_LIST_FILE}" )
-# endif( )
+# if(BUILD_VERBOSE)
+#   message(STATUS "CMAKE_MODULE_PATH: ${CMAKE_MODULE_PATH}")
+#   message(STATUS "CMAKE_BINARY_DIR: ${CMAKE_BINARY_DIR}")
+#   message(STATUS "CMAKE_SOURCE_DIR: ${CMAKE_SOURCE_DIR}")
+#   message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
+#   message(STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
+#   message(STATUS "CMAKE_CURRENT_LIST_DIR: ${CMAKE_CURRENT_LIST_DIR}")
+#   message(STATUS "CMAKE_CURRENT_LIST_FILE: ${CMAKE_CURRENT_LIST_FILE}")
+# endif()
 
 # This module scrapes the CMakeCache.txt file and attempts to get all the cli options the user specified to cmake invocation
-include( get-cli-arguments )
+include(get-cli-arguments)
 
 # The following is a series of super-build projects; this cmake project will download and build
-if( BUILD_GTEST )
-  include( external-gtest )
+if(BUILD_GTEST)
+  include(external-gtest)
 
-  list( APPEND hipsolver_dependencies googletest )
-  set( gtest_custom_target COMMAND cd ${GTEST_BINARY_ROOT}$<SEMICOLON> ${CMAKE_COMMAND} --build . --target install )
-endif( )
+  list(APPEND hipsolver_dependencies googletest)
+  set(gtest_custom_target COMMAND cd ${GTEST_BINARY_ROOT}$<SEMICOLON> ${CMAKE_COMMAND} --build . --target install)
+endif()
 
-if( BUILD_LAPACK )
-  include( external-lapack )
+if(BUILD_LAPACK)
+  include(external-lapack)
 
-  list( APPEND hipsolver_dependencies lapack )
-  set( lapack_custom_target COMMAND cd ${LAPACK_BINARY_ROOT}$<SEMICOLON> ${CMAKE_COMMAND} --build . --target install )
-endif( )
+  list(APPEND hipsolver_dependencies lapack)
+  set(lapack_custom_target COMMAND cd ${LAPACK_BINARY_ROOT}$<SEMICOLON> ${CMAKE_COMMAND} --build . --target install)
+endif()
 
-if( BUILD_BOOST )
-  include( external-boost )
+if(BUILD_BOOST)
+  include(external-boost)
 
-  list( APPEND hipsolver_dependencies boost )
-  set( boost_custom_target COMMAND cd ${BOOST_BINARY_ROOT}$<SEMICOLON> ${Boost.Command} install )
-endif( )
+  list(APPEND hipsolver_dependencies boost)
+  set(boost_custom_target COMMAND cd ${BOOST_BINARY_ROOT}$<SEMICOLON> ${Boost.Command} install)
+endif()
 
 # POLICY CMP0037 - "Target names should not be reserved and should match a validity pattern"
 # Familiar target names like 'install' should be OK at the super-build level
-if( POLICY CMP0037 )
-  cmake_policy( SET CMP0037 OLD )
-endif( )
+if(POLICY CMP0037)
+  cmake_policy(SET CMP0037 OLD)
+endif()
 
-add_custom_target( install
+add_custom_target(install
   ${boost_custom_target}
   ${gtest_custom_target}
   ${lapack_custom_target}

--- a/deps/external-boost.cmake
+++ b/deps/external-boost.cmake
@@ -20,14 +20,14 @@
 #
 # ########################################################################
 
-message( STATUS "Configuring boost external dependency" )
-include( ExternalProject )
-set( PREFIX_BOOST ${CMAKE_INSTALL_PREFIX} CACHE PATH "Location where boost should install, defaults to /usr/local" )
+message(STATUS "Configuring boost external dependency")
+include(ExternalProject)
+set(PREFIX_BOOST ${CMAKE_INSTALL_PREFIX} CACHE PATH "Location where boost should install, defaults to /usr/local")
 
 # We need to detect the compiler the user is attempting to invoke with CMake,
 # we do our best to translate cmake parameters into bjam parameters
-enable_language( CXX )
-include( build-bitness )
+enable_language(CXX)
+include(build-bitness)
 
 # TODO:  Options should be added to allow downloading Boost straight from github
 
@@ -36,144 +36,144 @@ include( build-bitness )
 # ExternalProject
 
 # Change this one line to upgrade to newer versions of boost
-set( ext.Boost_VERSION "1.64.0" CACHE STRING "Boost version to download/use" )
-mark_as_advanced( ext.Boost_VERSION )
-string( REPLACE "." "_" ext.Boost_Version_Underscore ${ext.Boost_VERSION} )
+set(ext.Boost_VERSION "1.64.0" CACHE STRING "Boost version to download/use")
+mark_as_advanced(ext.Boost_VERSION)
+string(REPLACE "." "_" ext.Boost_Version_Underscore ${ext.Boost_VERSION})
 
-message( STATUS "ext.Boost_VERSION: " ${ext.Boost_VERSION} )
+message(STATUS "ext.Boost_VERSION: " ${ext.Boost_VERSION})
 
-if( WIN32 )
+if(WIN32)
   # For newer cmake versions, 7z archives are much smaller to download
-  if( CMAKE_VERSION VERSION_LESS "3.1.0" )
-    set( Boost_Ext "zip" )
-  else( )
-    set( Boost_Ext "7z" )
-  endif( )
-else( )
-  set( Boost_Ext "tar.bz2" )
-endif( )
+  if(CMAKE_VERSION VERSION_LESS "3.1.0")
+    set(Boost_Ext "zip")
+  else()
+    set(Boost_Ext "7z")
+  endif()
+else()
+  set(Boost_Ext "tar.bz2")
+endif()
 
-if( WIN32 )
-  set( Boost.Command b2 --prefix=${PREFIX_BOOST} )
-else( )
-  set( Boost.Command ./b2 --prefix=${PREFIX_BOOST} )
-endif( )
+if(WIN32)
+  set(Boost.Command b2 --prefix=${PREFIX_BOOST})
+else()
+  set(Boost.Command ./b2 --prefix=${PREFIX_BOOST})
+endif()
 
-if( CMAKE_COMPILER_IS_GNUCXX )
-  list( APPEND Boost.Command cxxflags=-fPIC -std=c++11 )
-elseif( XCODE_VERSION OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang") )
-  list( APPEND Boost.Command cxxflags=-std=c++11 -stdlib=libc++ linkflags=-stdlib=libc++ )
-endif( )
+if(CMAKE_COMPILER_IS_GNUCXX)
+  list(APPEND Boost.Command cxxflags=-fPIC -std=c++11)
+elseif(XCODE_VERSION OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+  list(APPEND Boost.Command cxxflags=-std=c++11 -stdlib=libc++ linkflags=-stdlib=libc++)
+endif()
 
-include( ProcessorCount )
-ProcessorCount( Cores )
-if( NOT Cores EQUAL 0 )
+include(ProcessorCount)
+ProcessorCount(Cores)
+if(NOT Cores EQUAL 0)
   # Travis can fail to build Boost sporadically; uses 32 cores, reduce stress on VM
-  if( DEFINED ENV{TRAVIS} )
-    if( Cores GREATER 8 )
-      set( Cores 8 )
-    endif( )
-  endif( )
+  if(DEFINED ENV{TRAVIS})
+    if(Cores GREATER 8)
+      set(Cores 8)
+    endif()
+  endif()
 
   # Add build thread in addition to the number of cores that we have
-  math( EXPR Cores "${Cores} + 1 " )
-else( )
+  math(EXPR Cores "${Cores} + 1 ")
+else()
   # If we could not detect # of cores, assume 1 core and add an additional build thread
-  set( Cores "2" )
-endif( )
-
-message( STATUS "ExternalBoost using ( " ${Cores} " ) cores to build with" )
-message( STATUS "ExternalBoost building [ program_options, serialization, filesystem, system, regex ] components" )
-
-list( APPEND Boost.Command -j ${Cores} --with-program_options --with-serialization --with-filesystem --with-system --with-regex )
-
-if( BUILD_64 )
-  list( APPEND Boost.Command address-model=64 )
-else( )
-  list( APPEND Boost.Command address-model=32 )
-endif( )
-
-if( MSVC10 )
-  list( APPEND Boost.Command toolset=msvc-10.0 )
-elseif( MSVC11 )
-  list( APPEND Boost.Command toolset=msvc-11.0 )
-elseif( MSVC12 )
-  list( APPEND Boost.Command toolset=msvc-12.0 )
-elseif( MSVC14 )
-  list( APPEND Boost.Command toolset=msvc-14.0 )
-elseif( XCODE_VERSION OR ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" ) )
-  list( APPEND Boost.Command toolset=clang )
-elseif( CMAKE_COMPILER_IS_GNUCXX )
-  list( APPEND Boost.Command toolset=gcc )
-endif( )
-
-if( WIN32 AND (ext.Boost_VERSION VERSION_LESS "1.60.0") )
-  list( APPEND Boost.Command define=BOOST_LOG_USE_WINNT6_API )
-endif( )
-
-if( NOT DEFINED ext.Boost_LINK )
-  if( ${BUILD_SHARED_LIBS} MATCHES "ON" )
-    set( ext.Boost_LINK "shared" CACHE STRING "Which boost link method?  static | shared | static,shared" )
-  else( )
-    set( ext.Boost_LINK "static" CACHE STRING "Which boost link method?  static | shared | static,shared" )
-  endif( )
+  set(Cores "2")
 endif()
-mark_as_advanced( ext.Boost_LINK )
 
-if( WIN32 )
+message(STATUS "ExternalBoost using (" ${Cores} ") cores to build with")
+message(STATUS "ExternalBoost building [ program_options, serialization, filesystem, system, regex ] components")
+
+list(APPEND Boost.Command -j ${Cores} --with-program_options --with-serialization --with-filesystem --with-system --with-regex)
+
+if(BUILD_64)
+  list(APPEND Boost.Command address-model=64)
+else()
+  list(APPEND Boost.Command address-model=32)
+endif()
+
+if(MSVC10)
+  list(APPEND Boost.Command toolset=msvc-10.0)
+elseif(MSVC11)
+  list(APPEND Boost.Command toolset=msvc-11.0)
+elseif(MSVC12)
+  list(APPEND Boost.Command toolset=msvc-12.0)
+elseif(MSVC14)
+  list(APPEND Boost.Command toolset=msvc-14.0)
+elseif(XCODE_VERSION OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+  list(APPEND Boost.Command toolset=clang)
+elseif(CMAKE_COMPILER_IS_GNUCXX)
+  list(APPEND Boost.Command toolset=gcc)
+endif()
+
+if(WIN32 AND (ext.Boost_VERSION VERSION_LESS "1.60.0"))
+  list(APPEND Boost.Command define=BOOST_LOG_USE_WINNT6_API)
+endif()
+
+if(NOT DEFINED ext.Boost_LINK)
+  if(${BUILD_SHARED_LIBS} MATCHES "ON")
+    set(ext.Boost_LINK "shared" CACHE STRING "Which boost link method?  static | shared | static,shared")
+  else()
+    set(ext.Boost_LINK "static" CACHE STRING "Which boost link method?  static | shared | static,shared")
+  endif()
+endif()
+mark_as_advanced(ext.Boost_LINK)
+
+if(WIN32)
     # Versioned is the default on windows
-    set( ext.Boost_LAYOUT "versioned" CACHE STRING "Which boost layout method?  versioned | tagged | system" )
+    set(ext.Boost_LAYOUT "versioned" CACHE STRING "Which boost layout method?  versioned | tagged | system")
 
     # For windows, default to build both variants to support the VS IDE
-    set( ext.Boost_VARIANT "debug,release" CACHE STRING "Which boost variant?  debug | release | debug,release" )
-else( )
+    set(ext.Boost_VARIANT "debug,release" CACHE STRING "Which boost variant?  debug | release | debug,release")
+else()
     # Tagged builds provide unique enough names to be able to build both variants
-    set( ext.Boost_LAYOUT "tagged" CACHE STRING "Which boost layout method?  versioned | tagged | system" )
+    set(ext.Boost_LAYOUT "tagged" CACHE STRING "Which boost layout method?  versioned | tagged | system")
 
    # For Linux, typically a build tree only needs one variant
-   if( ${CMAKE_BUILD_TYPE} MATCHES "Debug")
-     set( ext.Boost_VARIANT "debug" CACHE STRING "Which boost variant?  debug | release | debug,release" )
-   else( )
-     set( ext.Boost_VARIANT "release" CACHE STRING "Which boost variant?  debug | release | debug,release" )
-   endif( )
-endif( )
-mark_as_advanced( ext.Boost_LAYOUT )
-mark_as_advanced( ext.Boost_VARIANT )
+   if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+     set(ext.Boost_VARIANT "debug" CACHE STRING "Which boost variant?  debug | release | debug,release")
+   else()
+     set(ext.Boost_VARIANT "release" CACHE STRING "Which boost variant?  debug | release | debug,release")
+   endif()
+endif()
+mark_as_advanced(ext.Boost_LAYOUT)
+mark_as_advanced(ext.Boost_VARIANT)
 
-list( APPEND Boost.Command --layout=${ext.Boost_LAYOUT} link=${ext.Boost_LINK} variant=${ext.Boost_VARIANT} )
+list(APPEND Boost.Command --layout=${ext.Boost_LAYOUT} link=${ext.Boost_LINK} variant=${ext.Boost_VARIANT})
 
-message( STATUS "Boost.Command: ${Boost.Command}" )
+message(STATUS "Boost.Command: ${Boost.Command}")
 
 # If the user has a cached local copy stored somewhere, they can define the full path to the package in a BOOST_URL environment variable
-if( DEFINED ENV{BOOST_URL} )
-  set( ext.Boost_URL "$ENV{BOOST_URL}" CACHE STRING "URL to download Boost from" )
-else( )
-  set( ext.Boost_URL "http://sourceforge.net/projects/boost/files/boost/${ext.Boost_VERSION}/boost_${ext.Boost_Version_Underscore}.${Boost_Ext}/download" CACHE STRING "URL to download Boost from" )
-endif( )
-mark_as_advanced( ext.Boost_URL )
+if(DEFINED ENV{BOOST_URL})
+  set(ext.Boost_URL "$ENV{BOOST_URL}" CACHE STRING "URL to download Boost from")
+else()
+  set(ext.Boost_URL "http://sourceforge.net/projects/boost/files/boost/${ext.Boost_VERSION}/boost_${ext.Boost_Version_Underscore}.${Boost_Ext}/download" CACHE STRING "URL to download Boost from")
+endif()
+mark_as_advanced(ext.Boost_URL)
 
-set( Boost.Bootstrap "" )
-set( ext.HASH "" )
-if( WIN32 )
-  set( Boost.Bootstrap "bootstrap.bat" )
+set(Boost.Bootstrap "")
+set(ext.HASH "")
+if(WIN32)
+  set(Boost.Bootstrap "bootstrap.bat")
 
-  if( CMAKE_VERSION VERSION_LESS "3.1.0" )
+  if(CMAKE_VERSION VERSION_LESS "3.1.0")
     # .zip file
-    set( ext.HASH "b99973c805f38b549dbeaf88701c0abeff8b0e8eaa4066df47cac10a32097523" )
-  else( )
+    set(ext.HASH "b99973c805f38b549dbeaf88701c0abeff8b0e8eaa4066df47cac10a32097523")
+  else()
     # .7z file
-    set( ext.HASH "49c6abfeb5b480f6a86119c0d57235966b4690ee6ff9e6401ee868244808d155" )
-  endif( )
-else( )
-  set( Boost.Bootstrap "./bootstrap.sh" )
+    set(ext.HASH "49c6abfeb5b480f6a86119c0d57235966b4690ee6ff9e6401ee868244808d155")
+  endif()
+else()
+  set(Boost.Bootstrap "./bootstrap.sh")
 
   # .tar.bz2
-  set( ext.HASH "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332" )
+  set(ext.HASH "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332")
 
-  if( XCODE_VERSION OR ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" ) )
-    list( APPEND Boost.Bootstrap --with-toolset=clang )
-  endif( )
-endif( )
+  if(XCODE_VERSION OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    list(APPEND Boost.Bootstrap --with-toolset=clang)
+  endif()
+endif()
 
 # Below is a fancy CMake command to download, build and install Boost on the users computer
 ExternalProject_Add(
@@ -190,10 +190,10 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
 )
 
-set_property( TARGET boost PROPERTY FOLDER "extern" )
-ExternalProject_Get_Property( boost install_dir )
-ExternalProject_Get_Property( boost binary_dir )
+set_property(TARGET boost PROPERTY FOLDER "extern")
+ExternalProject_Get_Property(boost install_dir)
+ExternalProject_Get_Property(boost binary_dir)
 
 # For use by the user of ExternalGtest.cmake
-set( BOOST_INSTALL_ROOT ${install_dir} )
-set( BOOST_BINARY_ROOT ${binary_dir} )
+set(BOOST_INSTALL_ROOT ${install_dir})
+set(BOOST_BINARY_ROOT ${binary_dir})

--- a/deps/external-gtest.cmake
+++ b/deps/external-gtest.cmake
@@ -21,55 +21,55 @@
 # ########################################################################
 
 
-message( STATUS "Configuring gtest external dependency" )
-include( ExternalProject )
+message(STATUS "Configuring gtest external dependency")
+include(ExternalProject)
 
-# set( gtest_cmake_args -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>/package )
-set( PREFIX_GTEST ${CMAKE_INSTALL_PREFIX} CACHE PATH "Location where boost should install, defaults to /usr/local" )
-set( gtest_cmake_args -DCMAKE_INSTALL_PREFIX=${PREFIX_GTEST} )
-append_cmake_cli_arguments( gtest_cmake_args gtest_cmake_args )
+# set(gtest_cmake_args -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>/package)
+set(PREFIX_GTEST ${CMAKE_INSTALL_PREFIX} CACHE PATH "Location where boost should install, defaults to /usr/local")
+set(gtest_cmake_args -DCMAKE_INSTALL_PREFIX=${PREFIX_GTEST})
+append_cmake_cli_arguments(gtest_cmake_args gtest_cmake_args)
 
-set( gtest_git_repository "https://github.com/google/googletest.git" CACHE STRING "URL to download gtest from" )
-set( gtest_git_tag "release-1.11.0" CACHE STRING "URL to download gtest from" )
+set(gtest_git_repository "https://github.com/google/googletest.git" CACHE STRING "URL to download gtest from")
+set(gtest_git_tag "release-1.11.0" CACHE STRING "URL to download gtest from")
 
-if( MSVC )
-  list( APPEND gtest_cmake_args -Dgtest_force_shared_crt=ON -DCMAKE_DEBUG_POSTFIX=d )
-# else( )
+if(MSVC)
+  list(APPEND gtest_cmake_args -Dgtest_force_shared_crt=ON -DCMAKE_DEBUG_POSTFIX=d)
+# else()
   # GTEST_USE_OWN_TR1_TUPLE necessary to compile with hipcc
-  # list( APPEND gtest_cmake_args -DGTEST_USE_OWN_TR1_TUPLE=1 )
-endif( )
+  # list(APPEND gtest_cmake_args -DGTEST_USE_OWN_TR1_TUPLE=1)
+endif()
 
-if( CMAKE_CONFIGURATION_TYPES )
-  set( gtest_make
+if(CMAKE_CONFIGURATION_TYPES)
+  set(gtest_make
         COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
         COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Debug
   )
-else( )
+else()
   # Add build thread in addition to the number of cores that we have
-  include( ProcessorCount )
-  ProcessorCount( Cores )
+  include(ProcessorCount)
+  ProcessorCount(Cores)
 
   # If we are not using an IDE, assume nmake with visual studio
-  if( MSVC )
-    set( gtest_make "nmake" )
-  else( )
-    set( gtest_make "make" )
+  if(MSVC)
+    set(gtest_make "nmake")
+  else()
+    set(gtest_make "make")
 
     # The -j parameter does not work with nmake
-    if( NOT Cores EQUAL 0 )
-      math( EXPR Cores "${Cores} + 1 " )
-      list( APPEND gtest_make -j ${Cores} )
-    else( )
+    if(NOT Cores EQUAL 0)
+      math(EXPR Cores "${Cores} + 1 ")
+      list(APPEND gtest_make -j ${Cores})
+    else()
       # If we could not detect # of cores, assume 1 core and add an additional build thread
-      list( APPEND gtest_make -j 2 )
-    endif( )
-  endif( )
+      list(APPEND gtest_make -j 2)
+    endif()
+  endif()
 
-  message( STATUS "ExternalGmock using ( " ${Cores} " ) cores to build with" )
-endif( )
+  message(STATUS "ExternalGmock using (" ${Cores} ") cores to build with")
+endif()
 
-# message( STATUS "gtest_make ( " ${gtest_make} " ) " )
-# message( STATUS "gtest_cmake_args ( " ${gtest_cmake_args} " ) " )
+# message(STATUS "gtest_make (" ${gtest_make} ") ")
+# message(STATUS "gtest_cmake_args (" ${gtest_cmake_args} ") ")
 
 # Master branch has a new structure that combines googletest with googlemock
 ExternalProject_Add(
@@ -84,21 +84,21 @@ ExternalProject_Add(
   LOG_INSTALL 1
 )
 
-ExternalProject_Get_Property( googletest source_dir )
+ExternalProject_Get_Property(googletest source_dir)
 
 # For visual studio, the path 'debug' is hardcoded because that is the default VS configuration for a build.
 # Doesn't matter if its the gtest or gtestd project above
-set( package_dir "${PREFIX_GTEST}" )
-if( CMAKE_CONFIGURATION_TYPES )
+set(package_dir "${PREFIX_GTEST}")
+if(CMAKE_CONFIGURATION_TYPES)
   # Create a package by bundling libraries and header files
-  if( BUILD_64 )
-    set( LIB_DIR lib64 )
-  else( )
-    set( LIB_DIR lib )
-  endif( )
+  if(BUILD_64)
+    set(LIB_DIR lib64)
+  else()
+    set(LIB_DIR lib)
+  endif()
 
-  set( gtest_lib_dir "<BINARY_DIR>/${LIB_DIR}" )
-  ExternalProject_Add_Step( googletest createPackage
+  set(gtest_lib_dir "<BINARY_DIR>/${LIB_DIR}")
+  ExternalProject_Add_Step(googletest createPackage
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${gtest_lib_dir}/Debug ${package_dir}/${LIB_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${gtest_lib_dir}/Release ${package_dir}/${LIB_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${gtest_lib_dir}/Debug ${package_dir}/${LIB_DIR}
@@ -107,12 +107,12 @@ if( CMAKE_CONFIGURATION_TYPES )
     COMMAND ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/gtest/include/gtest ${package_dir}/include/gtest
     DEPENDEES install
   )
-endif( )
+endif()
 
-set_property( TARGET googletest PROPERTY FOLDER "extern")
-ExternalProject_Get_Property( googletest install_dir )
-ExternalProject_Get_Property( googletest binary_dir )
+set_property(TARGET googletest PROPERTY FOLDER "extern")
+ExternalProject_Get_Property(googletest install_dir)
+ExternalProject_Get_Property(googletest binary_dir)
 
 # For use by the user of ExternalGtest.cmake
-set( GTEST_INSTALL_ROOT ${install_dir} )
-set( GTEST_BINARY_ROOT ${binary_dir} )
+set(GTEST_INSTALL_ROOT ${install_dir})
+set(GTEST_BINARY_ROOT ${binary_dir})

--- a/deps/external-lapack.cmake
+++ b/deps/external-lapack.cmake
@@ -20,30 +20,30 @@
 #
 # ########################################################################
 
-message( STATUS "Configuring lapack external dependency" )
-include( ExternalProject )
+message(STATUS "Configuring lapack external dependency")
+include(ExternalProject)
 
-# set( lapack_cmake_args -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>/package )
-set( PREFIX_LAPACK ${CMAKE_INSTALL_PREFIX} CACHE PATH "Location where lapack should install, defaults to /usr/local" )
-set( lapack_cmake_args -DCMAKE_INSTALL_PREFIX=${PREFIX_LAPACK} )
-append_cmake_cli_arguments( lapack_cmake_args lapack_cmake_args )
+# set(lapack_cmake_args -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>/package)
+set(PREFIX_LAPACK ${CMAKE_INSTALL_PREFIX} CACHE PATH "Location where lapack should install, defaults to /usr/local")
+set(lapack_cmake_args -DCMAKE_INSTALL_PREFIX=${PREFIX_LAPACK})
+append_cmake_cli_arguments(lapack_cmake_args lapack_cmake_args)
 
-set( lapack_git_repository "https://github.com/Reference-LAPACK/lapack-release" CACHE STRING "URL to download lapack from" )
-set( lapack_git_tag "lapack-3.7.1" CACHE STRING "git branch" )
+set(lapack_git_repository "https://github.com/Reference-LAPACK/lapack-release" CACHE STRING "URL to download lapack from")
+set(lapack_git_tag "lapack-3.7.1" CACHE STRING "git branch")
 
-# message( STATUS "lapack_make ( " ${lapack_make} " ) " )
-# message( STATUS "lapack_cmake_args ( " ${lapack_cmake_args} " ) " )
+# message(STATUS "lapack_make (" ${lapack_make} ") ")
+# message(STATUS "lapack_cmake_args (" ${lapack_cmake_args} ") ")
 
-enable_language( Fortran )
-include( GNUInstallDirs )
+enable_language(Fortran)
+include(GNUInstallDirs)
 
 # lapack cmake exports has a bug on debian architectures, they do not take into account the
 # lib/<machine> paths
 # if CMAKE_INSTALL_LIBDIR is of the form above, strip the machine
 # Match against a '/' in CMAKE_INSTALL_LIBDIR, i.e. lib/x86_64-linux-gnu
-if( ${CMAKE_INSTALL_LIBDIR} MATCHES "lib/.*" )
-  list( APPEND lapack_cmake_args "-DCMAKE_INSTALL_LIBDIR=lib" )
-endif( )
+if(${CMAKE_INSTALL_LIBDIR} MATCHES "lib/.*")
+  list(APPEND lapack_cmake_args "-DCMAKE_INSTALL_LIBDIR=lib")
+endif()
 
 ExternalProject_Add(
   lapack
@@ -56,12 +56,12 @@ ExternalProject_Add(
   LOG_INSTALL 1
 )
 
-ExternalProject_Get_Property( lapack source_dir )
+ExternalProject_Get_Property(lapack source_dir)
 
-set_property( TARGET lapack PROPERTY FOLDER "extern" )
-ExternalProject_Get_Property( lapack install_dir )
-ExternalProject_Get_Property( lapack binary_dir )
+set_property(TARGET lapack PROPERTY FOLDER "extern")
+ExternalProject_Get_Property(lapack install_dir)
+ExternalProject_Get_Property(lapack binary_dir)
 
 # For use by the user of ExternalGtest.cmake
-set( LAPACK_INSTALL_ROOT ${install_dir} )
-set( LAPACK_BINARY_ROOT ${binary_dir} )
+set(LAPACK_INSTALL_ROOT ${install_dir})
+set(LAPACK_BINARY_ROOT ${binary_dir})

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ import re
 from rocm_docs import ROCmDocs
 
 with open('../CMakeLists.txt', encoding='utf-8') as f:
-    match = re.search(r'set \( VERSION_STRING \"?([0-9.]+)[^0-9.]+', f.read())
+    match = re.search(r'set\s*\(\s*VERSION_STRING\s*\"?([0-9.]+)[^0-9.]+', f.read())
     if not match:
         raise ValueError("VERSION not found!")
     version_number = match[1]

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -22,41 +22,41 @@
 
 
 # This is incremented when the ABI to the library changes
-set( hipsolver_SOVERSION 0.3 )
+set(hipsolver_SOVERSION 0.3)
 
-list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib/cmake/hip /opt/rocm/lib/cmake/hip ${HIP_PATH}/cmake )
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib/cmake/hip /opt/rocm/lib/cmake/hip ${HIP_PATH}/cmake)
 
 # This option only works for make/nmake and the ninja generators, but no reason it shouldn't be on all the time
 # This tells cmake to create a compile_commands.json file that can be used with clang tooling or vim
-set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Print out compiler flags for viewing/debug
-if( BUILD_VERBOSE )
-  message( STATUS "hipsolver_VERSION: " ${hipsolver_VERSION} )
-  message( STATUS "\t==>CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE} )
-  message( STATUS "\t==>BUILD_SHARED_LIBS: " ${BUILD_SHARED_LIBS} )
-  message( STATUS "\t==>CMAKE_INSTALL_PREFIX link: " ${CMAKE_INSTALL_PREFIX} )
-  message( STATUS "\t==>CMAKE_MODULE_PATH link: " ${CMAKE_MODULE_PATH} )
-  message( STATUS "\t==>CMAKE_PREFIX_PATH link: " ${CMAKE_PREFIX_PATH} )
+if(BUILD_VERBOSE)
+  message(STATUS "hipsolver_VERSION: " ${hipsolver_VERSION})
+  message(STATUS "\t==>CMAKE_BUILD_TYPE: " ${CMAKE_BUILD_TYPE})
+  message(STATUS "\t==>BUILD_SHARED_LIBS: " ${BUILD_SHARED_LIBS})
+  message(STATUS "\t==>CMAKE_INSTALL_PREFIX link: " ${CMAKE_INSTALL_PREFIX})
+  message(STATUS "\t==>CMAKE_MODULE_PATH link: " ${CMAKE_MODULE_PATH})
+  message(STATUS "\t==>CMAKE_PREFIX_PATH link: " ${CMAKE_PREFIX_PATH})
 
-  message( STATUS "\t==>CMAKE_CXX_COMPILER flags: " ${CMAKE_CXX_FLAGS} )
-  message( STATUS "\t==>CMAKE_CXX_COMPILER debug flags: " ${CMAKE_CXX_FLAGS_DEBUG} )
-  message( STATUS "\t==>CMAKE_CXX_COMPILER release flags: " ${CMAKE_CXX_FLAGS_RELEASE} )
-  message( STATUS "\t==>CMAKE_CXX_COMPILER relwithdebinfo flags: " ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} )
-  message( STATUS "\t==>CMAKE_EXE_LINKER link flags: " ${CMAKE_EXE_LINKER_FLAGS} )
-endif( )
+  message(STATUS "\t==>CMAKE_CXX_COMPILER flags: " ${CMAKE_CXX_FLAGS})
+  message(STATUS "\t==>CMAKE_CXX_COMPILER debug flags: " ${CMAKE_CXX_FLAGS_DEBUG})
+  message(STATUS "\t==>CMAKE_CXX_COMPILER release flags: " ${CMAKE_CXX_FLAGS_RELEASE})
+  message(STATUS "\t==>CMAKE_CXX_COMPILER relwithdebinfo flags: " ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+  message(STATUS "\t==>CMAKE_EXE_LINKER link flags: " ${CMAKE_EXE_LINKER_FLAGS})
+endif()
 
-if( NOT USE_CUDA )
-  find_package( hip REQUIRED PATHS ${ROCM_PATH} /opt/rocm ${HIP_PATH} )
+if(NOT USE_CUDA)
+  find_package(hip REQUIRED PATHS ${ROCM_PATH} /opt/rocm ${HIP_PATH})
 else()
-  find_package( HIP REQUIRED )
+  find_package(HIP REQUIRED)
 endif()
 
 # configure a header file to pass the CMake version settings to the source, and package the header files in the output archive
-configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/include/internal/hipsolver-version.h.in"
-	"${PROJECT_BINARY_DIR}/include/hipsolver/internal/hipsolver-version.h" )
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/internal/hipsolver-version.h.in"
+	"${PROJECT_BINARY_DIR}/include/hipsolver/internal/hipsolver-version.h")
 
-set( hipsolver_headers_public
+set(hipsolver_headers_public
   include/hipsolver.h
   include/internal/hipsolver-types.h
   include/internal/hipsolver-functions.h
@@ -68,18 +68,18 @@ set( hipsolver_headers_public
   ${PROJECT_BINARY_DIR}/include/hipsolver/internal/hipsolver-version.h
 )
 
-source_group( "Header Files\\Public" FILES ${hipsolver_headers_public} )
+source_group("Header Files\\Public" FILES ${hipsolver_headers_public})
 
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include/hipsolver/internal)
 
 # Build into subdirectories
-add_subdirectory( src )
+add_subdirectory(src)
 
 # The following code is setting variables to control the behavior of CPack to generate our
-# if( WIN32 )
-#     set( CPACK_SOURCE_GENERATOR "ZIP" )
-#     set( CPACK_GENERATOR "ZIP" )
-# else( )
-#     set( CPACK_SOURCE_GENERATOR "TGZ" )
-#     set( CPACK_GENERATOR "DEB;RPM" CACHE STRING "cpack list: 7Z, DEB, IFW, NSIS, NSIS64, RPM, STGZ, TBZ2, TGZ, TXZ, TZ, ZIP" )
-# endif( )
+# if(WIN32)
+#     set(CPACK_SOURCE_GENERATOR "ZIP")
+#     set(CPACK_GENERATOR "ZIP")
+# else()
+#     set(CPACK_SOURCE_GENERATOR "TGZ")
+#     set(CPACK_GENERATOR "DEB;RPM" CACHE STRING "cpack list: 7Z, DEB, IFW, NSIS, NSIS64, RPM, STGZ, TBZ2, TGZ, TXZ, TZ, ZIP")
+# endif()

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 
 # ########################################################################
-# A helper function to prefix a source list of files with a common path into a new list(non-destructive)
+# A helper function to prefix a source list of files with a common path into a new list (non-destructive)
 # ########################################################################
 function(prepend_path prefix source_list_of_files return_list_of_files)
   foreach(file ${${source_list_of_files}})

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -22,26 +22,26 @@
 
 
 # ########################################################################
-# A helper function to prefix a source list of files with a common path into a new list (non-destructive)
+# A helper function to prefix a source list of files with a common path into a new list(non-destructive)
 # ########################################################################
-function( prepend_path prefix source_list_of_files return_list_of_files )
-  foreach( file ${${source_list_of_files}} )
-    if(IS_ABSOLUTE ${file} )
-      list( APPEND new_list ${file} )
-    else( )
-      list( APPEND new_list ${prefix}/${file} )
-    endif( )
-  endforeach( )
-  set( ${return_list_of_files} ${new_list} PARENT_SCOPE )
-endfunction( )
+function(prepend_path prefix source_list_of_files return_list_of_files)
+  foreach(file ${${source_list_of_files}})
+    if(IS_ABSOLUTE ${file})
+      list(APPEND new_list ${file})
+    else()
+      list(APPEND new_list ${prefix}/${file})
+    endif()
+  endforeach()
+  set(${return_list_of_files} ${new_list} PARENT_SCOPE)
+endfunction()
 
 # ########################################################################
 # Main
 # ########################################################################
-prepend_path( ".." hipsolver_headers_public relative_hipsolver_headers_public )
+prepend_path(".." hipsolver_headers_public relative_hipsolver_headers_public)
 
-if( NOT USE_CUDA )
-  set( hipsolver_source
+if(NOT USE_CUDA)
+  set(hipsolver_source
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_conversions.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_dense.cpp"
@@ -50,8 +50,8 @@ if( NOT USE_CUDA )
     "${CMAKE_CURRENT_SOURCE_DIR}/amd_detail/hipsolver_sparse.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/common/hipsolver_dense_common.cpp"
   )
-else( )
-  set( hipsolver_source
+else()
+  set(hipsolver_source
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_conversions.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_dense.cpp"
@@ -60,111 +60,111 @@ else( )
     "${CMAKE_CURRENT_SOURCE_DIR}/nvidia_detail/hipsolver_sparse.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/common/hipsolver_dense_common.cpp"
   )
-endif( )
+endif()
 
-set (hipsolver_f90_source
+set(hipsolver_f90_source
   hipsolver_module.f90
 )
 
-if( UNIX )
+if(UNIX)
   # Create hipSOLVER Fortran module
   add_library(hipsolver_fortran ${hipsolver_f90_source})
-endif( )
+endif()
 
-add_library( hipsolver
+add_library(hipsolver
   ${hipsolver_source}
   ${relative_hipsolver_headers_public}
 )
-add_library( roc::hipsolver ALIAS hipsolver )
+add_library(roc::hipsolver ALIAS hipsolver)
 
 target_link_libraries(hipsolver PRIVATE
   $<BUILD_INTERFACE:hipsolver-common> # https://gitlab.kitware.com/cmake/cmake/-/issues/15415
 )
 
-add_armor_flags( hipsolver "${ARMOR_LEVEL}" )
+add_armor_flags(hipsolver "${ARMOR_LEVEL}")
 
-if( WIN32 )
-  if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS )
-    add_custom_command( TARGET hipsolver
+if(WIN32)
+  if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
+    add_custom_command(TARGET hipsolver
       POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/$<TARGET_FILE_NAME:hipsolver>" "${PROJECT_BINARY_DIR}/clients/staging/$<TARGET_FILE_NAME:hipsolver>"
     )
-    if( ${CMAKE_BUILD_TYPE} MATCHES "Debug" )
-      add_custom_command( TARGET hipsolver
+    if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+      add_custom_command(TARGET hipsolver
         POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_BINARY_DIR}/staging/hipsolver-d.pdb" "${PROJECT_BINARY_DIR}/clients/staging/hipsolver-d.pdb"
       )
-    endif( )
-  endif( )
-endif( )
+    endif()
+  endif()
+endif()
 
-set( static_depends )
+set(static_depends)
 
 # Build hipsolver from source on AMD platform
-if( NOT USE_CUDA )
+if(NOT USE_CUDA)
   # Find rocBLAS
-  if( NOT TARGET rocblas )
-    if( CUSTOM_ROCBLAS )
-      set ( ENV{rocblas_DIR} ${CUSTOM_ROCBLAS})
-      find_package( rocblas REQUIRED CONFIG NO_CMAKE_PATH )
-    else( )
-      find_package( rocblas REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocblas )
-    endif( )
-    list( APPEND static_depends PACKAGE rocblas )
-  endif( )
+  if(NOT TARGET rocblas)
+    if(CUSTOM_ROCBLAS)
+      set(ENV{rocblas_DIR} ${CUSTOM_ROCBLAS})
+      find_package(rocblas REQUIRED CONFIG NO_CMAKE_PATH)
+    else()
+      find_package(rocblas REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocblas)
+    endif()
+    list(APPEND static_depends PACKAGE rocblas)
+  endif()
 
   # Find rocSOLVER
-  if( NOT TARGET rocsolver )
-    if( CUSTOM_ROCSOLVER )
-      set ( ENV{rocsolver_DIR} ${CUSTOM_ROCSOLVER})
-      find_package( rocsolver REQUIRED CONFIG NO_CMAKE_PATH )
-    else( )
-      find_package( rocsolver REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocsolver /usr/local/rocsolver )
-    endif( )
-    list( APPEND static_depends PACKAGE rocsolver )
-  endif( )
+  if(NOT TARGET rocsolver)
+    if(CUSTOM_ROCSOLVER)
+      set(ENV{rocsolver_DIR} ${CUSTOM_ROCSOLVER})
+      find_package(rocsolver REQUIRED CONFIG NO_CMAKE_PATH)
+    else()
+      find_package(rocsolver REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocsolver /usr/local/rocsolver)
+    endif()
+    list(APPEND static_depends PACKAGE rocsolver)
+  endif()
 
-  target_link_libraries( hipsolver PRIVATE roc::rocblas roc::rocsolver )
-  target_link_libraries( hipsolver PUBLIC hip::host )
+  target_link_libraries(hipsolver PRIVATE roc::rocblas roc::rocsolver)
+  target_link_libraries(hipsolver PUBLIC hip::host)
 
-  if( CUSTOM_TARGET )
-    target_link_libraries( hipsolver PRIVATE hip::${CUSTOM_TARGET} )
-  endif( )
+  if(CUSTOM_TARGET)
+    target_link_libraries(hipsolver PRIVATE hip::${CUSTOM_TARGET})
+  endif()
 
-  if( BUILD_WITH_SPARSE )
+  if(BUILD_WITH_SPARSE)
     # Find rocSPARSE
-    if( NOT TARGET rocsparse )
-      if( CUSTOM_ROCSPARSE )
-        set ( ENV{rocsparse_DIR} ${CUSTOM_ROCSPARSE})
-        find_package( rocsparse REQUIRED CONFIG NO_CMAKE_PATH )
-      else( )
-        find_package( rocsparse REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocsparse )
-      endif( )
-      list( APPEND static_depends PACKAGE rocsparse )
-    endif( )
+    if(NOT TARGET rocsparse)
+      if(CUSTOM_ROCSPARSE)
+        set(ENV{rocsparse_DIR} ${CUSTOM_ROCSPARSE})
+        find_package(rocsparse REQUIRED CONFIG NO_CMAKE_PATH)
+      else()
+        find_package(rocsparse REQUIRED CONFIG PATHS /opt/rocm /opt/rocm/rocsparse)
+      endif()
+      list(APPEND static_depends PACKAGE rocsparse)
+    endif()
 
-    target_link_libraries( hipsolver PRIVATE roc::rocsparse suitesparseconfig cholmod )
+    target_link_libraries(hipsolver PRIVATE roc::rocsparse suitesparseconfig cholmod)
     set_source_files_properties(${hipsolver_source}
       PROPERTIES
         COMPILE_DEFINITIONS HAVE_ROCSPARSE
     )
-  endif( )
+  endif()
 
-else( )
-  target_compile_definitions( hipsolver PRIVATE __HIP_PLATFORM_NVIDIA__ )
+else()
+  target_compile_definitions(hipsolver PRIVATE __HIP_PLATFORM_NVIDIA__)
 
-  target_link_libraries( hipsolver PRIVATE ${CUDA_cusolver_LIBRARY} )
+  target_link_libraries(hipsolver PRIVATE ${CUDA_cusolver_LIBRARY})
 
   # External header includes included as system files
-  target_include_directories( hipsolver
+  target_include_directories(hipsolver
     SYSTEM PRIVATE
       $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
       $<BUILD_INTERFACE:${CUDA_INCLUDE_DIRS}>
   )
-endif( )
+endif()
 
 # Internal header includes
-target_include_directories( hipsolver
+target_include_directories(hipsolver
   PUBLIC  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/library/include>
           $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/library/include/internal>
           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/hipsolver>
@@ -176,31 +176,31 @@ target_include_directories( hipsolver
           ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-rocm_set_soversion( hipsolver ${hipsolver_SOVERSION} )
-set_target_properties( hipsolver PROPERTIES CXX_EXTENSIONS NO )
-set_target_properties( hipsolver PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
-set_target_properties( hipsolver PROPERTIES DEBUG_POSTFIX "-d" )
+rocm_set_soversion(hipsolver ${hipsolver_SOVERSION})
+set_target_properties(hipsolver PROPERTIES CXX_EXTENSIONS NO)
+set_target_properties(hipsolver PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging")
+set_target_properties(hipsolver PROPERTIES DEBUG_POSTFIX "-d")
 
 # Package that helps me set visibility for function names exported from shared library
-include( GenerateExportHeader )
-set_target_properties( hipsolver PROPERTIES CXX_VISIBILITY_PRESET "hidden" VISIBILITY_INLINES_HIDDEN ON )
-generate_export_header( hipsolver EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/hipsolver/internal/hipsolver-export.h )
+include(GenerateExportHeader)
+set_target_properties(hipsolver PROPERTIES CXX_VISIBILITY_PRESET "hidden" VISIBILITY_INLINES_HIDDEN ON)
+generate_export_header(hipsolver EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/hipsolver/internal/hipsolver-export.h)
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/library/include ${PROJECT_BINARY_DIR}/include/hipsolver)
-if (BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
+if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
   rocm_wrap_header_file(
     internal/hipsolver-version.h internal/hipsolver-export.h
     GUARDS SYMLINK WRAPPER
     WRAPPER_LOCATIONS ${CMAKE_INSTALL_INCLUDEDIR} hipsolver/${CMAKE_INSTALL_INCLUDEDIR}
     ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/hipsolver/internal/hipsolver-version.h
   )
-endif( )
+endif()
 
 
 # Following Boost conventions of prefixing 'lib' on static built libraries, across all platforms
-if( NOT BUILD_SHARED_LIBS )
-  set_target_properties( hipsolver PROPERTIES PREFIX "lib" )
-endif( )
+if(NOT BUILD_SHARED_LIBS)
+  set_target_properties(hipsolver PROPERTIES PREFIX "lib")
+endif()
 
 ############################################################
 # Installation
@@ -211,7 +211,7 @@ rocm_install_targets(
     ${CMAKE_BINARY_DIR}/include
 )
 
-if ( NOT USE_CUDA )
+if(NOT USE_CUDA)
   rocm_export_targets(
     TARGETS roc::hipsolver
     DEPENDS PACKAGE hip
@@ -219,32 +219,32 @@ if ( NOT USE_CUDA )
       ${static_depends}
     NAMESPACE roc::
   )
-else( )
+else()
   rocm_export_targets(
     TARGETS roc::hipsolver
     DEPENDS PACKAGE HIP
     NAMESPACE roc::
   )
-endif( )
+endif()
 
-if( UNIX )
+if(UNIX)
   # Exclude include folder for ASAN package
-  if( NOT ENABLE_ASAN_PACKAGING )
+  if(NOT ENABLE_ASAN_PACKAGING)
     # Force installation of .f90 module files
     install(FILES "hipsolver_module.f90"
             DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/hipsolver")
-  endif( )
-endif( )
+  endif()
+endif()
 
 if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
   rocm_install(
     DIRECTORY
        "${PROJECT_BINARY_DIR}/hipsolver"
-        DESTINATION "." )
+        DESTINATION ".")
 
-  if ( NOT WIN32 )
+  if(NOT WIN32)
 
-    #Create SymLink for Fortran Object Module for backward compatibility
+    # Create SymLink for Fortran Object Module for backward compatibility
     rocm_install(
       CODE "
         set(PREFIX \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX})
@@ -257,7 +257,7 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
         endforeach()
         "
     )
-  endif() #NOT WIN32
-  message( STATUS "Backward Compatible Sym Link Created for include directories" )
+  endif() # NOT WIN32
+  message(STATUS "Backward Compatible Sym Link Created for include directories")
 endif()
 


### PR DESCRIPTION
There are a few manual touchups for indentation levels, but this is mostly just running:

    sed -Ei \
        -e 's/\( /\(/g' \
        -e 's/([^[:space:]]+) \)/\1\)/g' \
        -e 's/(if|elif|endif|set|list|file) \(/\1(/g' \
        -e 's/#(\w)/# \1/'

These transformations eliminate spacing after opening parentheses, before closing parentheses (if there was any text on the same line), between the keyword and the opening parentheses, and ensure there is a space after comment markers.