### PR TITLE
Centralize CMake CXX settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,6 @@
 
 cmake_minimum_required(VERSION 3.7)
 
-# We use C++17 features, this will add compile option: -std=c++17
-set(CMAKE_CXX_STANDARD 17)
-
 # Consider removing this in the future
 # This should appear before the project command, because it does not use FORCE
 if(WIN32)
@@ -47,6 +44,10 @@ project(hipsolver LANGUAGES CXX)
 if(UNIX)
   enable_language(Fortran)
 endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # This finds the rocm-cmake project, and installs it if not found
 # rocm-cmake contains common cmake code for rocm projects to help setup and install

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -87,9 +87,7 @@ else()
   target_link_libraries(hipsolver-bench PRIVATE ${CUDA_LIBRARIES} Threads::Threads)
 endif()
 
-set_target_properties(hipsolver-bench PROPERTIES CXX_EXTENSIONS NO)
 set_target_properties(hipsolver-bench PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging")
-# add_dependencies(hipsolver-bench hipsolver-bench-common)
 
 rocm_install(TARGETS hipsolver-bench COMPONENT benchmarks)
 

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -147,7 +147,6 @@ else()
   target_link_libraries(hipsolver-test PRIVATE ${CUDA_LIBRARIES} Threads::Threads)
 endif()
 
-set_target_properties(hipsolver-test PROPERTIES CXX_EXTENSIONS NO)
 set_target_properties(hipsolver-test PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging")
 
 rocm_install(TARGETS hipsolver-test COMPONENT tests)

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -61,7 +61,6 @@ foreach(exe example-c-basic;example-cpp-basic;)
   endif()
 
   set_target_properties(${exe} PROPERTIES LINKER_LANGUAGE CXX)
-  set_target_properties(${exe} PROPERTIES CXX_EXTENSIONS NO)
   set_target_properties(${exe} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging")
 
 endforeach()

--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -177,7 +177,6 @@ target_include_directories(hipsolver
 )
 
 rocm_set_soversion(hipsolver ${hipsolver_SOVERSION})
-set_target_properties(hipsolver PROPERTIES CXX_EXTENSIONS NO)
 set_target_properties(hipsolver PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging")
 
 # Package that helps me set visibility for function names exported from shared library


### PR DESCRIPTION
This matches the way that rocSOLVER sets the CXX language properties.