### PR TITLE
Fix dead link to rocSOLVER API

### DIFF
--- a/docs/reference/api/index.rst
+++ b/docs/reference/api/index.rst
@@ -10,7 +10,7 @@ hipSOLVER regular API
 
 This document provides the method signatures for wrapper functions that are currently implemented in hipSOLVER.
 For a complete description of the functions' behavior and arguments, see the corresponding backend documentation
-at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/>`_ and/or `rocSOLVER API <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/index.html>`_.
+at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/>`_ and/or :doc:`rocSOLVER API <rocsolver:reference/intro>`.
 
 The hipSOLVER API is designed to be similar to the cuSOLVER and rocSOLVER interfaces, but it requires some minor adjustments to ensure
 the best performance out of both backends. Generally, this involves the addition of workspace parameters and some additional API methods.

--- a/docs/reference/compat-api/index.rst
+++ b/docs/reference/compat-api/index.rst
@@ -10,7 +10,7 @@ hipSOLVER compatibility API - Dense Matrices
 
 This document provides the method signatures for the wrapper functions that are currently implemented in hipSOLVER.
 For a complete description of the functions' behavior and arguments, see the corresponding backend documentation
-at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/>`_ and/or `rocSOLVER API <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/index.html>`_.
+at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/>`_ and/or :doc:`rocSOLVER API <rocsolver:reference/intro>`.
 
 For ease of porting from existing cuSOLVER applications to hipSOLVER, functions in the hipsolverDn compatibility API are designed to have
 method signatures that are consistent with the cusolverDn interface. However, :ref:`performance issues <compat_performance>` may arise when

--- a/docs/reference/refactor-api/index.rst
+++ b/docs/reference/refactor-api/index.rst
@@ -10,7 +10,7 @@ hipSOLVER Compatibility API - Refactorization
 
 This document provides the method signatures for the wrapper functions that are currently implemented in hipSOLVER.
 For a complete description of the functions' behavior and arguments, see the corresponding backend documentation
-at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/index.html#cuds-api>`_ and/or `rocSOLVER API <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/index.html>`_.
+at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/index.html#cuds-api>`_ and/or :doc:`rocSOLVER API <rocsolver:reference/intro>`.
 
 For ease of porting from existing cuSOLVER applications to hipSOLVER, functions in the hipsolverRf compatibility API are designed to have
 method signatures that are consistent with the cusolverRf interface. At present, equivalent functions have not been added to hipSOLVER's regular API.

--- a/docs/reference/sparse-api/index.rst
+++ b/docs/reference/sparse-api/index.rst
@@ -10,7 +10,7 @@ hipSOLVER compatibility API - Sparse Matrices
 
 This document provides the method signatures for the wrapper functions that are currently implemented in hipSOLVER.
 For a complete description of the functions' behavior and arguments, see the corresponding backend documentation
-at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/index.html#cuds-api>`_ and/or `rocSOLVER API <https://rocm.docs.amd.com/projects/rocSOLVER/en/latest/api/index.html>`_.
+at `cuSOLVER API <https://docs.nvidia.com/cuda/cusolver/index.html#cuds-api>`_ and/or :doc:`rocSOLVER API <rocsolver:reference/intro>`.
 
 For ease of porting from existing cuSOLVER applications to hipSOLVER, functions in the hipsolverSp compatibility API are designed to have
 method signatures that are consistent with the cusolverSp interface. At present, equivalent functions have not been added to hipSOLVER's


### PR DESCRIPTION
There was a small merge conflict with the cherry-pick because the develop was updated to use the intersphinx link while docs/6.1.2 was not. I did a local build and confirmed the link works correctly.