### PR TITLE
Disable sparse functions by default when building a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ option(BUILD_CODE_COVERAGE "Build hipSOLVER with code coverage enabled" OFF)
 option(BUILD_HIPBLAS_TESTS "Build additional tests to ensure hipBLAS and hipSOLVER are compatible (requires installed hipBLAS)" OFF)
 option(BUILD_HIPSPARSE_TESTS "Build additional tests to cover sparse functionality (requires installed hipSPARSE)" ON)
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
-option(BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality available at build time (requires installed dependencies)" ON)
+option(BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality available at build time (requires installed dependencies)" OFF)
 option(BUILD_VERBOSE "Output additional build information" OFF)
 option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
 option(HIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG "Skip module mode search for LAPACK" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake/hip /opt/rocm /opt/rocm/llvm /opt/rocm/hip)
 
 option(BUILD_SHARED_LIBS "Build hipSOLVER as a shared library" ON)
-set(BUILD_WITH_SPARSE_DEFAULT OFF)
-
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 option(BUILD_CODE_COVERAGE "Build hipSOLVER with code coverage enabled" OFF)
 option(BUILD_HIPBLAS_TESTS "Build additional tests to ensure hipBLAS and hipSOLVER are compatible (requires installed hipBLAS)" OFF)
@@ -118,7 +116,7 @@ option(HIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG "Skip module mode search for LAPACK"
 option(BUILD_FORTRAN_BINDINGS "Build the Fortran bindings" "${UNIX}")
 
 if(NOT BUILD_SHARED_LIBS)
-  set(BUILD_WITH_SPARSE CACHE OFF)
+  add_compile_definitions(HIPSOLVER_STATIC_LIB)
 endif()
 
 if(BUILD_FORTRAN_BINDINGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ option(BUILD_CODE_COVERAGE "Build hipSOLVER with code coverage enabled" OFF)
 option(BUILD_HIPBLAS_TESTS "Build additional tests to ensure hipBLAS and hipSOLVER are compatible (requires installed hipBLAS)" OFF)
 option(BUILD_HIPSPARSE_TESTS "Build additional tests to cover sparse functionality (requires installed hipSPARSE)" ON)
 # BUILD_SHARED_LIBS is a cmake built-in; we make it an explicit option such that it shows in cmake-gui
-option(BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality available at build time (requires installed dependencies)" "${BUILD_WITH_SPARSE_DEFAULT}")
+option(BUILD_WITH_SPARSE "Build hipSOLVER with sparse functionality available at build time (requires installed dependencies)" ON)
 option(BUILD_VERBOSE "Output additional build information" OFF)
 option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
 option(HIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG "Skip module mode search for LAPACK" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,11 +104,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${ROCM_PATH}/lib
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake/hip /opt/rocm /opt/rocm/llvm /opt/rocm/hip)
 
 option(BUILD_SHARED_LIBS "Build hipSOLVER as a shared library" ON)
-if(BUILD_SHARED_LIBS)
-  set(BUILD_WITH_SPARSE_DEFAULT OFF)
-else()
-  set(BUILD_WITH_SPARSE_DEFAULT ON)
-endif()
+set(BUILD_WITH_SPARSE_DEFAULT OFF)
 
 option(BUILD_ADDRESS_SANITIZER "Build with address sanitizer enabled" OFF)
 option(BUILD_CODE_COVERAGE "Build hipSOLVER with code coverage enabled" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,10 @@ option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
 option(HIPSOLVER_FIND_PACKAGE_LAPACK_CONFIG "Skip module mode search for LAPACK" ON)
 option(BUILD_FORTRAN_BINDINGS "Build the Fortran bindings" "${UNIX}")
 
+if(NOT BUILD_SHARED_LIBS)
+  set(BUILD_WITH_SPARSE CACHE OFF)
+endif()
+
 if(BUILD_FORTRAN_BINDINGS)
   enable_language(Fortran)
 endif()

--- a/library/src/amd_detail/dlopen/cholmod.cpp
+++ b/library/src/amd_detail/dlopen/cholmod.cpp
@@ -41,6 +41,7 @@ fp_cholmod_solve            g_cholmod_solve;
 
 static bool load_cholmod()
 {
+#ifndef HIPSOLVER_STATIC_LIB
 #ifdef _WIN32
     // Library users will need to call SetErrorMode(SEM_FAILCRITICALERRORS) if
     // they wish to avoid an error message box when this library is not found.
@@ -104,6 +105,9 @@ static bool load_cholmod()
         return false;
 
     return true;
+#else /* HIPSOLVER_STATIC_LIB */
+    return false;
+#endif
 }
 
 bool try_load_cholmod()

--- a/library/src/amd_detail/dlopen/load_function.hpp
+++ b/library/src/amd_detail/dlopen/load_function.hpp
@@ -36,6 +36,7 @@ HIPSOLVER_BEGIN_NAMESPACE
 template <typename Fn>
 bool load_function(void* handle, const char* symbol, Fn& fn)
 {
+#ifndef HIPSOLVER_STATIC_LIB
 #ifdef _WIN32
     fn       = (Fn)(GetProcAddress((HMODULE)handle, symbol));
     bool err = !fn;
@@ -48,6 +49,9 @@ bool load_function(void* handle, const char* symbol, Fn& fn)
 #endif
 #endif /* _WIN32 */
     return !err;
+#else /* HIPSOLVER_STATIC_LIB */
+    return false;
+#endif
 }
 
 HIPSOLVER_END_NAMESPACE

--- a/library/src/amd_detail/dlopen/rocsparse.cpp
+++ b/library/src/amd_detail/dlopen/rocsparse.cpp
@@ -33,6 +33,7 @@ fp_rocsparse_get_mat_index_base g_rocsparse_get_mat_index_base;
 
 static bool load_rocsparse()
 {
+#ifndef HIPSOLVER_STATIC_LIB
 #ifdef _WIN32
     // Library users will need to call SetErrorMode(SEM_FAILCRITICALERRORS) if
     // they wish to avoid an error message box when this library is not found.
@@ -60,6 +61,9 @@ static bool load_rocsparse()
         return false;
 
     return true;
+#else /* HIPSOLVER_STATIC_LIB */
+    return false;
+#endif
 }
 
 bool try_load_rocsparse()


### PR DESCRIPTION
Disable sparse functions by default when building a static library.