### PR TITLE
Add sparse QR solver functions (csrlsvqr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,9 +97,9 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 
 * Added compatibility API with hipsolverSp prefix
 * Added compatibility-only functions
-  * csrlsvchol
-    * hipsolverSpScsrlsvcholHost, hipsolverSpDcsrlsvcholHost
-    * hipsolverSpScsrlsvchol, hipsolverSpDcsrlsvchol
+  * `csrlsvchol`
+    * `hipsolverSpScsrlsvcholHost`, `hipsolverSpDcsrlsvcholHost`
+    * `hipsolverSpScsrlsvchol`, `hipsolverSpDcsrlsvchol`
 * Added rocSPARSE and SuiteSparse as optional dependencies to hipSOLVER (rocSOLVER backend only). Use the `BUILD_WITH_SPARSE` CMake option to enable
   functionality for the hipsolverSp API (on by default).
 * Added hipSPARSE as an optional dependency to hipsolver-test. Use the `BUILD_WITH_SPARSE` CMake option to enable tests of the hipsolverSp API (on by default).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,9 +97,9 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 
 * Added compatibility API with hipsolverSp prefix
 * Added compatibility-only functions
-  * `csrlsvchol`
-    * `hipsolverSpScsrlsvcholHost`, `hipsolverSpDcsrlsvcholHost`
-    * `hipsolverSpScsrlsvchol`, `hipsolverSpDcsrlsvchol`
+  * csrlsvchol
+    * hipsolverSpScsrlsvcholHost, hipsolverSpDcsrlsvcholHost
+    * hipsolverSpScsrlsvchol, hipsolverSpDcsrlsvchol
 * Added rocSPARSE and SuiteSparse as optional dependencies to hipSOLVER (rocSOLVER backend only). Use the `BUILD_WITH_SPARSE` CMake option to enable
   functionality for the hipsolverSp API (on by default).
 * Added hipSPARSE as an optional dependency to hipsolver-test. Use the `BUILD_WITH_SPARSE` CMake option to enable tests of the hipsolverSp API (on by default).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 ## (Unreleased) hipSOLVER
 
 ### Added
+* Added compatibility-only functions
+  * csrlsvqr
+    * hipsolverSpScsrlsvqr, hipsolverSpDcsrlsvqr, hipsolverSpCcsrlsvqr, hipsolverSpZcsrlsvqr
 ### Changed
 ### Removed
 ### Optimized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Full documentation for hipSOLVER is available at the [hipSOLVER Documentation](h
 * Added compatibility-only functions
   * csrlsvqr
     * hipsolverSpScsrlsvqr, hipsolverSpDcsrlsvqr, hipsolverSpCcsrlsvqr, hipsolverSpZcsrlsvqr
+
 ### Changed
 ### Removed
 ### Optimized

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -75,6 +75,7 @@ set(hipsolverDn_test_source
 
 set(hipsolverSp_test_source
   csrlsvchol_gtest.cpp
+  csrlsvqr_gtest.cpp
 )
 
 set(hipsolverRf_test_source

--- a/clients/gtest/csrlsvqr_gtest.cpp
+++ b/clients/gtest/csrlsvqr_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2024 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #include "testing_csrlsvqr.hpp"

--- a/clients/gtest/csrlsvqr_gtest.cpp
+++ b/clients/gtest/csrlsvqr_gtest.cpp
@@ -109,15 +109,15 @@ TEST_P(CSRLSVQR, __double)
     run_tests<double>();
 }
 
-TEST_P(CSRLSVQR, __float_complex)
-{
-    run_tests<rocblas_float_complex>();
-}
+// TEST_P(CSRLSVQR, __float_complex)
+// {
+//     run_tests<rocblas_float_complex>();
+// }
 
-TEST_P(CSRLSVQR, __double_complex)
-{
-    run_tests<rocblas_double_complex>();
-}
+// TEST_P(CSRLSVQR, __double_complex)
+// {
+//     run_tests<rocblas_double_complex>();
+// }
 
 // TEST_P(CSRLSVQRHOST, __float)
 // {

--- a/clients/gtest/csrlsvqr_gtest.cpp
+++ b/clients/gtest/csrlsvqr_gtest.cpp
@@ -1,0 +1,154 @@
+/* ************************************************************************
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#include "testing_csrlsvqr.hpp"
+
+using ::testing::Combine;
+using ::testing::TestWithParam;
+using ::testing::Values;
+using ::testing::ValuesIn;
+using namespace std;
+
+typedef std::tuple<int, vector<int>> csrlsvqr_tuple;
+
+// each n_range vector is {n}
+
+// each nnz_range vector is {nnzA, reorder, base1}
+
+// case when n = 20 and nnz = 60 also execute the bad arguments test
+// (null handle, null pointers and invalid values)
+
+// for checkin_lapack tests
+const vector<int> n_range = {
+    20,
+    50,
+};
+const vector<vector<int>> nnz_range = {
+    {60, 0, 1},
+    {60, 1, 0},
+    {100, 2, 0},
+    {140, 3, 1},
+};
+
+// for daily_lapack tests
+const vector<int> large_n_range = {
+    // normal (valid) samples
+    100,
+    250,
+};
+const vector<vector<int>> large_nnz_range = {
+    // normal (valid) samples
+    {300, 0, 0},
+    {300, 1, 1},
+    {500, 2, 1},
+    {700, 3, 0},
+};
+
+Arguments csrlsvqr_setup_arguments(csrlsvqr_tuple tup)
+{
+    int         n_v   = std::get<0>(tup);
+    vector<int> nnz_v = std::get<1>(tup);
+
+    Arguments arg;
+
+    arg.set<rocblas_int>("n", n_v);
+    arg.set<rocblas_int>("nnzA", nnz_v[0]);
+    arg.set<rocblas_int>("reorder", nnz_v[1]);
+    arg.set<rocblas_int>("base1", nnz_v[2]);
+
+    arg.timing = 0;
+
+    return arg;
+}
+
+template <bool HOST>
+class CSRLSVQR_BASE : public ::TestWithParam<csrlsvqr_tuple>
+{
+protected:
+    void SetUp() override
+    {
+        if(hipsolverSpCreate(nullptr) == HIPSOLVER_STATUS_NOT_SUPPORTED)
+            GTEST_SKIP() << "Sparse dependencies could not be loaded";
+    }
+    void TearDown() override
+    {
+        EXPECT_EQ(hipGetLastError(), hipSuccess);
+    }
+
+    template <typename T>
+    void run_tests()
+    {
+        Arguments arg = csrlsvqr_setup_arguments(GetParam());
+
+        if(arg.peek<rocblas_int>("n") == 20 && arg.peek<rocblas_int>("nnzA") == 60)
+            testing_csrlsvqr_bad_arg<HOST, T>();
+
+        arg.batch_count = 1;
+        testing_csrlsvqr<HOST, T>(arg);
+    }
+};
+
+class CSRLSVQR : public CSRLSVQR_BASE<false>
+{
+};
+
+class CSRLSVQRHOST : public CSRLSVQR_BASE<true>
+{
+};
+
+// non-batch tests
+
+TEST_P(CSRLSVQR, __float)
+{
+    run_tests<float>();
+}
+
+TEST_P(CSRLSVQR, __double)
+{
+    run_tests<double>();
+}
+
+TEST_P(CSRLSVQR, __float_complex)
+{
+    run_tests<rocblas_float_complex>();
+}
+
+TEST_P(CSRLSVQR, __double_complex)
+{
+    run_tests<rocblas_double_complex>();
+}
+
+// TEST_P(CSRLSVQRHOST, __float)
+// {
+//     run_tests<float>();
+// }
+
+// TEST_P(CSRLSVQRHOST, __double)
+// {
+//     run_tests<double>();
+// }
+
+// TEST_P(CSRLSVQRHOST, __float_complex)
+// {
+//     run_tests<rocblas_float_complex>();
+// }
+
+// TEST_P(CSRLSVQRHOST, __double_complex)
+// {
+//     run_tests<rocblas_double_complex>();
+// }
+
+INSTANTIATE_TEST_SUITE_P(daily_lapack,
+                         CSRLSVQR,
+                         Combine(ValuesIn(large_n_range), ValuesIn(large_nnz_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack, CSRLSVQR, Combine(ValuesIn(n_range), ValuesIn(nnz_range)));
+
+// INSTANTIATE_TEST_SUITE_P(daily_lapack,
+//                          csrlsvqrHOST,
+//                          Combine(ValuesIn(large_n_range), ValuesIn(large_nnz_range)));
+
+// INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+//                          csrlsvqrHOST,
+//                          Combine(ValuesIn(n_range), ValuesIn(nnz_range)));

--- a/clients/gtest/sygvdx_hegvdx_gtest.cpp
+++ b/clients/gtest/sygvdx_hegvdx_gtest.cpp
@@ -153,7 +153,7 @@ TEST_P(HEGVDX, __double_complex)
 //                          SYGVDX,
 //                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(type_range)));
 
-INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+INSTANTIATE_TEST_SUITE_P(known_bug,
                          SYGVDX,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(type_range)));
 
@@ -161,6 +161,6 @@ INSTANTIATE_TEST_SUITE_P(checkin_lapack,
 //                          HEGVDX,
 //                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(type_range)));
 
-INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+INSTANTIATE_TEST_SUITE_P(known_bug,
                          HEGVDX,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(type_range)));

--- a/clients/gtest/sygvdx_hegvdx_gtest.cpp
+++ b/clients/gtest/sygvdx_hegvdx_gtest.cpp
@@ -49,7 +49,7 @@ const vector<vector<char>> type_range = {{'1', 'N', 'A', 'U'},
 const vector<vector<int>> matrix_size_range = {
     // invalid
     {-1, 1, 1, 0, 10, 1, 1},
-    // {20, 5, 5, 0, 10, 1, 1},
+    {20, 5, 5, 0, 10, 1, 1},
     // valid only when erange=A
     {20, 20, 20, 10, 0, 10, 1},
     // normal (valid) samples
@@ -129,22 +129,22 @@ class HEGVDX : public SYGVDX_HEGVDX<API_NORMAL>
 
 // non-batch tests
 
-TEST_P(SYGVDX, __float)
+TEST_P(SYGVDX, DISABLED__float)
 {
     run_tests<false, false, float>();
 }
 
-TEST_P(SYGVDX, __double)
+TEST_P(SYGVDX, DISABLED__double)
 {
     run_tests<false, false, double>();
 }
 
-TEST_P(HEGVDX, __float_complex)
+TEST_P(HEGVDX, DISABLED__float_complex)
 {
     run_tests<false, false, rocblas_float_complex>();
 }
 
-TEST_P(HEGVDX, __double_complex)
+TEST_P(HEGVDX, DISABLED__double_complex)
 {
     run_tests<false, false, rocblas_double_complex>();
 }

--- a/clients/gtest/sygvdx_hegvdx_gtest.cpp
+++ b/clients/gtest/sygvdx_hegvdx_gtest.cpp
@@ -49,7 +49,7 @@ const vector<vector<char>> type_range = {{'1', 'N', 'A', 'U'},
 const vector<vector<int>> matrix_size_range = {
     // invalid
     {-1, 1, 1, 0, 10, 1, 1},
-    {20, 5, 5, 0, 10, 1, 1},
+    // {20, 5, 5, 0, 10, 1, 1},
     // valid only when erange=A
     {20, 20, 20, 10, 0, 10, 1},
     // normal (valid) samples
@@ -153,7 +153,7 @@ TEST_P(HEGVDX, __double_complex)
 //                          SYGVDX,
 //                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(type_range)));
 
-INSTANTIATE_TEST_SUITE_P(known_bug,
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          SYGVDX,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(type_range)));
 
@@ -161,6 +161,6 @@ INSTANTIATE_TEST_SUITE_P(known_bug,
 //                          HEGVDX,
 //                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(type_range)));
 
-INSTANTIATE_TEST_SUITE_P(known_bug,
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          HEGVDX,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(type_range)));

--- a/clients/include/hipsolverSp.hpp
+++ b/clients/include/hipsolverSp.hpp
@@ -248,7 +248,7 @@ inline hipsolverStatus_t hipsolver_csrlsvqr(bool                      HOST,
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
 }
 
-inline hipsolverStatus_t hipsolver_csrlsvqr(bool                      HOST,
+/*inline hipsolverStatus_t hipsolver_csrlsvqr(bool                      HOST,
                                             hipsolverSpHandle_t       handle,
                                             int                       n,
                                             int                       nnz,
@@ -308,5 +308,5 @@ inline hipsolverStatus_t hipsolver_csrlsvqr(bool                          HOST,
                                     singularity);
     else
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
-}
+}*/
 /********************************************************/

--- a/clients/include/hipsolverSp.hpp
+++ b/clients/include/hipsolverSp.hpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -202,4 +202,111 @@ inline hipsolverStatus_t hipsolver_csrlsvchol(bool                          HOST
                                           (hipDoubleComplex*)x,
                                           singularity);
 }*/
+/********************************************************/
+
+/******************** CSRLSVQR ********************/
+// normal and strided_batched
+inline hipsolverStatus_t hipsolver_csrlsvqr(bool                      HOST,
+                                            hipsolverSpHandle_t       handle,
+                                            int                       n,
+                                            int                       nnz,
+                                            const hipsparseMatDescr_t descrA,
+                                            const float*              csrVal,
+                                            const int*                csrRowPtr,
+                                            const int*                csrColInd,
+                                            const float*              b,
+                                            double                    tol,
+                                            int                       reorder,
+                                            float*                    x,
+                                            int*                      singularity)
+{
+    if(!HOST)
+        return hipsolverSpScsrlsvqr(
+            handle, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, b, tol, reorder, x, singularity);
+    else
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+}
+
+inline hipsolverStatus_t hipsolver_csrlsvqr(bool                      HOST,
+                                            hipsolverSpHandle_t       handle,
+                                            int                       n,
+                                            int                       nnz,
+                                            const hipsparseMatDescr_t descrA,
+                                            const double*             csrVal,
+                                            const int*                csrRowPtr,
+                                            const int*                csrColInd,
+                                            const double*             b,
+                                            double                    tol,
+                                            int                       reorder,
+                                            double*                   x,
+                                            int*                      singularity)
+{
+    if(!HOST)
+        return hipsolverSpDcsrlsvqr(
+            handle, n, nnz, descrA, csrVal, csrRowPtr, csrColInd, b, tol, reorder, x, singularity);
+    else
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+}
+
+inline hipsolverStatus_t hipsolver_csrlsvqr(bool                      HOST,
+                                            hipsolverSpHandle_t       handle,
+                                            int                       n,
+                                            int                       nnz,
+                                            const hipsparseMatDescr_t descrA,
+                                            const hipsolverComplex*   csrVal,
+                                            const int*                csrRowPtr,
+                                            const int*                csrColInd,
+                                            const hipsolverComplex*   b,
+                                            double                    tol,
+                                            int                       reorder,
+                                            hipsolverComplex*         x,
+                                            int*                      singularity)
+{
+    if(!HOST)
+        return hipsolverSpCcsrlsvqr(handle,
+                                    n,
+                                    nnz,
+                                    descrA,
+                                    (hipFloatComplex*)csrVal,
+                                    csrRowPtr,
+                                    csrColInd,
+                                    (hipFloatComplex*)b,
+                                    tol,
+                                    reorder,
+                                    (hipFloatComplex*)x,
+                                    singularity);
+    else
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+}
+
+inline hipsolverStatus_t hipsolver_csrlsvqr(bool                          HOST,
+                                            hipsolverSpHandle_t           handle,
+                                            int                           n,
+                                            int                           nnz,
+                                            const hipsparseMatDescr_t     descrA,
+                                            const hipsolverDoubleComplex* csrVal,
+                                            const int*                    csrRowPtr,
+                                            const int*                    csrColInd,
+                                            const hipsolverDoubleComplex* b,
+                                            double                        tol,
+                                            int                           reorder,
+                                            hipsolverDoubleComplex*       x,
+                                            int*                          singularity)
+{
+    if(!HOST)
+        return hipsolverSpZcsrlsvqr(handle,
+                                    n,
+                                    nnz,
+                                    descrA,
+                                    (hipDoubleComplex*)csrVal,
+                                    csrRowPtr,
+                                    csrColInd,
+                                    (hipDoubleComplex*)b,
+                                    tol,
+                                    reorder,
+                                    (hipDoubleComplex*)x,
+                                    singularity);
+    else
+        return HIPSOLVER_STATUS_NOT_SUPPORTED;
+}
 /********************************************************/

--- a/clients/include/hipsolver_dispatcher.hpp
+++ b/clients/include/hipsolver_dispatcher.hpp
@@ -55,6 +55,7 @@
 
 #ifdef HAVE_HIPSPARSE
 #include "testing_csrlsvchol.hpp"
+#include "testing_csrlsvqr.hpp"
 #endif
 
 struct str_less
@@ -130,6 +131,7 @@ class hipsolver_dispatcher
 #ifdef HAVE_HIPSPARSE
             {"csrlsvchol", testing_csrlsvchol<false, T>},
             {"csrlsvcholHost", testing_csrlsvchol<true, T>},
+            {"csrlsvqr", testing_csrlsvqr<false, T>},
 #endif
         };
 

--- a/clients/include/testing_csrlsvqr.hpp
+++ b/clients/include/testing_csrlsvqr.hpp
@@ -233,8 +233,7 @@ void csrlsvqr_getError(hipsolverSpHandle_t       handle,
     err      = norm_error('I', n, 1, n, hX[0], hXRes[0]);
     *max_err = err > *max_err ? err : *max_err;
 
-    // TODO: Add non-positive definite test matrices
-    // also check info for singularities
+    // TODO: Add singular matrices and check info
     err = 0;
     EXPECT_EQ(hSingularity[0][0], -1);
     if(hSingularity[0][0] != -1)

--- a/clients/include/testing_csrlsvqr.hpp
+++ b/clients/include/testing_csrlsvqr.hpp
@@ -1,0 +1,639 @@
+/* ************************************************************************
+ * Copyright (C) 2024 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#pragma once
+
+#include "clientcommon.hpp"
+#include "hipsolverSp.hpp"
+
+template <bool HOST, typename T>
+void csrlsvqr_checkBadArgs(hipsolverSpHandle_t       handle,
+                           const int                 n,
+                           const int                 nnzA,
+                           const hipsparseMatDescr_t descrA,
+                           int*                      ptrA,
+                           int*                      indA,
+                           T                         valA,
+                           T                         B,
+                           T                         X,
+                           int*                      singularity)
+{
+    // handle
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_csrlsvqr(
+            HOST, nullptr, n, nnzA, descrA, valA, ptrA, indA, B, 0, 0, X, singularity),
+        HIPSOLVER_STATUS_NOT_INITIALIZED);
+
+    // values
+    // N/A
+
+#if defined(__HIP_PLATFORM_HCC__) || defined(__HIP_PLATFORM_AMD__)
+    // pointers
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_csrlsvqr(
+            HOST, handle, n, nnzA, nullptr, valA, ptrA, indA, B, 0, 0, X, singularity),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_csrlsvqr(
+            HOST, handle, n, nnzA, descrA, (T) nullptr, ptrA, indA, B, 0, 0, X, singularity),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_csrlsvqr(
+            HOST, handle, n, nnzA, descrA, valA, (int*)nullptr, indA, B, 0, 0, X, singularity),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_csrlsvqr(
+            HOST, handle, n, nnzA, descrA, valA, ptrA, (int*)nullptr, B, 0, 0, X, singularity),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_csrlsvqr(
+            HOST, handle, n, nnzA, descrA, valA, ptrA, indA, (T) nullptr, 0, 0, X, singularity),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+    EXPECT_ROCBLAS_STATUS(
+        hipsolver_csrlsvqr(
+            HOST, handle, n, nnzA, descrA, valA, ptrA, indA, B, 0, 0, (T) nullptr, singularity),
+        HIPSOLVER_STATUS_INVALID_VALUE);
+#endif
+}
+
+template <bool HOST, typename T>
+void testing_csrlsvqr_bad_arg()
+{
+    // safe arguments
+    hipsolverSp_local_handle handle;
+    int                      n    = 1;
+    int                      nnzA = 1;
+
+    hipsparse_local_mat_descr descrA;
+    hipsparseSetMatType(descrA, HIPSPARSE_MATRIX_TYPE_GENERAL);
+    hipsparseSetMatIndexBase(descrA, HIPSPARSE_INDEX_BASE_ZERO);
+
+    if(HOST)
+    {
+        // memory allocations
+        host_strided_batch_vector<int> singularity(1, 1, 1, 1);
+        host_strided_batch_vector<int> ptrA(1, 1, 1, 1);
+        host_strided_batch_vector<int> indA(1, 1, 1, 1);
+        host_strided_batch_vector<T>   valA(1, 1, 1, 1);
+        host_strided_batch_vector<T>   B(1, 1, 1, 1);
+        host_strided_batch_vector<T>   X(1, 1, 1, 1);
+
+        // check bad arguments
+        csrlsvqr_checkBadArgs<HOST>(handle,
+                                    n,
+                                    nnzA,
+                                    descrA,
+                                    ptrA.data(),
+                                    indA.data(),
+                                    valA.data(),
+                                    B.data(),
+                                    X.data(),
+                                    singularity.data());
+    }
+    else
+    {
+        // memory allocations
+        host_strided_batch_vector<int>   singularity(1, 1, 1, 1);
+        device_strided_batch_vector<int> ptrA(1, 1, 1, 1);
+        device_strided_batch_vector<int> indA(1, 1, 1, 1);
+        device_strided_batch_vector<T>   valA(1, 1, 1, 1);
+        device_strided_batch_vector<T>   B(1, 1, 1, 1);
+        device_strided_batch_vector<T>   X(1, 1, 1, 1);
+        CHECK_HIP_ERROR(ptrA.memcheck());
+        CHECK_HIP_ERROR(indA.memcheck());
+        CHECK_HIP_ERROR(valA.memcheck());
+        CHECK_HIP_ERROR(B.memcheck());
+        CHECK_HIP_ERROR(X.memcheck());
+
+        // check bad arguments
+        csrlsvqr_checkBadArgs<HOST>(handle,
+                                    n,
+                                    nnzA,
+                                    descrA,
+                                    ptrA.data(),
+                                    indA.data(),
+                                    valA.data(),
+                                    B.data(),
+                                    X.data(),
+                                    singularity.data());
+    }
+}
+
+template <bool CPU, bool GPU, typename T, typename Td, typename Ud, typename Th, typename Uh>
+void csrlsvqr_initData(hipsolverSpHandle_t handle,
+                       const int           n,
+                       const int           nnzA,
+                       hipsparseMatDescr_t descrA,
+                       Ud&                 dptrA,
+                       Ud&                 dindA,
+                       Td&                 dvalA,
+                       Td&                 dB,
+                       Uh&                 hptrA,
+                       Uh&                 hindA,
+                       Th&                 hvalA,
+                       Th&                 hB,
+                       Th&                 hX,
+                       const fs::path      testcase,
+                       bool                test = true)
+{
+    if(CPU)
+    {
+        fs::path file;
+
+        // read-in A
+        file = testcase / "ptrA";
+        read_matrix(file.string(), 1, n + 1, hptrA.data(), 1);
+        file = testcase / "indA";
+        read_matrix(file.string(), 1, nnzA, hindA.data(), 1);
+        file = testcase / "valA";
+        read_matrix(file.string(), 1, nnzA, hvalA.data(), 1);
+
+        // read-in B
+        file = testcase / "B_1";
+        read_matrix(file.string(), n, 1, hB.data(), n);
+
+        // get results (matrix X) if validation is required
+        if(test)
+        {
+            // read-in X
+            file = testcase / "X_1";
+            read_matrix(file.string(), n, 1, hX.data(), n);
+        }
+
+        // change to base 1, if applicable
+        hipsparseIndexBase_t indbase = hipsparseGetMatIndexBase(descrA);
+        if(indbase == HIPSPARSE_INDEX_BASE_ONE)
+        {
+            for(rocblas_int i = 0; i <= n; i++)
+                hptrA[0][i]++;
+
+            for(rocblas_int i = 0; i < nnzA; i++)
+                hindA[0][i]++;
+        }
+    }
+
+    if(GPU)
+    {
+        CHECK_HIP_ERROR(dptrA.transfer_from(hptrA));
+        CHECK_HIP_ERROR(dindA.transfer_from(hindA));
+        CHECK_HIP_ERROR(dvalA.transfer_from(hvalA));
+        CHECK_HIP_ERROR(dB.transfer_from(hB));
+    }
+}
+
+template <bool HOST, typename T, typename S, typename Td, typename Ud, typename Th, typename Uh>
+void csrlsvqr_getError(hipsolverSpHandle_t       handle,
+                       const int                 n,
+                       const int                 nnzA,
+                       const hipsparseMatDescr_t descrA,
+                       Ud&                       dptrA,
+                       Ud&                       dindA,
+                       Td&                       dvalA,
+                       Td&                       dB,
+                       const S                   tolerance,
+                       const int                 reorder,
+                       Td&                       dX,
+                       Uh&                       hptrA,
+                       Uh&                       hindA,
+                       Th&                       hvalA,
+                       Th&                       hB,
+                       Th&                       hX,
+                       Th&                       hXRes,
+                       Uh&                       hSingularity,
+                       double*                   max_err,
+                       const fs::path            testcase)
+{
+    // input data initialization
+    csrlsvqr_initData<true, true, T>(
+        handle, n, nnzA, descrA, dptrA, dindA, dvalA, dB, hptrA, hindA, hvalA, hB, hX, testcase);
+
+    // execute computations
+    // GPU lapack
+    CHECK_ROCBLAS_ERROR(hipsolver_csrlsvqr(HOST,
+                                           handle,
+                                           n,
+                                           nnzA,
+                                           descrA,
+                                           dvalA.data(),
+                                           dptrA.data(),
+                                           dindA.data(),
+                                           dB.data(),
+                                           tolerance,
+                                           reorder,
+                                           dX.data(),
+                                           hSingularity.data()));
+
+    CHECK_HIP_ERROR(hXRes.transfer_from(dX));
+
+    // compare computed results with original result
+    double err;
+    *max_err = 0;
+
+    err      = norm_error('I', n, 1, n, hX[0], hXRes[0]);
+    *max_err = err > *max_err ? err : *max_err;
+
+    // TODO: Add non-positive definite test matrices
+    // also check info for singularities
+    err = 0;
+    EXPECT_EQ(hSingularity[0][0], -1);
+    if(hSingularity[0][0] != -1)
+        err++;
+    *max_err += err;
+}
+
+template <bool HOST, typename T, typename S, typename Td, typename Ud, typename Th, typename Uh>
+void csrlsvqr_getPerfData(hipsolverSpHandle_t       handle,
+                          const int                 n,
+                          const int                 nnzA,
+                          const hipsparseMatDescr_t descrA,
+                          Ud&                       dptrA,
+                          Ud&                       dindA,
+                          Td&                       dvalA,
+                          Td&                       dB,
+                          const S                   tolerance,
+                          const int                 reorder,
+                          Td&                       dX,
+                          Uh&                       hptrA,
+                          Uh&                       hindA,
+                          Th&                       hvalA,
+                          Th&                       hB,
+                          Th&                       hX,
+                          Uh&                       hSingularity,
+                          double*                   gpu_time_used,
+                          double*                   cpu_time_used,
+                          const int                 hot_calls,
+                          const bool                perf,
+                          const fs::path            testcase)
+{
+    *cpu_time_used = nan(""); // no timing on cpu-lapack execution
+
+    csrlsvqr_initData<true, false, T>(
+        handle, n, nnzA, descrA, dptrA, dindA, dvalA, dB, hptrA, hindA, hvalA, hB, hX, testcase);
+
+    // cold calls
+    for(int iter = 0; iter < 2; iter++)
+    {
+        csrlsvqr_initData<false, true, T>(handle,
+                                          n,
+                                          nnzA,
+                                          descrA,
+                                          dptrA,
+                                          dindA,
+                                          dvalA,
+                                          dB,
+                                          hptrA,
+                                          hindA,
+                                          hvalA,
+                                          hB,
+                                          hX,
+                                          testcase);
+
+        CHECK_ROCBLAS_ERROR(hipsolver_csrlsvqr(HOST,
+                                               handle,
+                                               n,
+                                               nnzA,
+                                               descrA,
+                                               dvalA.data(),
+                                               dptrA.data(),
+                                               dindA.data(),
+                                               dB.data(),
+                                               tolerance,
+                                               reorder,
+                                               dX.data(),
+                                               hSingularity.data()));
+    }
+
+    // gpu-lapack performance
+    hipStream_t stream;
+    CHECK_ROCBLAS_ERROR(hipsolverGetStream(handle, &stream));
+    double start;
+
+    for(int iter = 0; iter < hot_calls; iter++)
+    {
+        csrlsvqr_initData<false, true, T>(handle,
+                                          n,
+                                          nnzA,
+                                          descrA,
+                                          dptrA,
+                                          dindA,
+                                          dvalA,
+                                          dB,
+                                          hptrA,
+                                          hindA,
+                                          hvalA,
+                                          hB,
+                                          hX,
+                                          testcase);
+
+        start = get_time_us_sync(stream);
+        hipsolver_csrlsvqr(HOST,
+                           handle,
+                           n,
+                           nnzA,
+                           descrA,
+                           dvalA.data(),
+                           dptrA.data(),
+                           dindA.data(),
+                           dB.data(),
+                           tolerance,
+                           reorder,
+                           dX.data(),
+                           hSingularity.data());
+        *gpu_time_used += get_time_us_sync(stream) - start;
+    }
+    *gpu_time_used /= hot_calls;
+}
+
+template <bool HOST, typename T>
+void testing_csrlsvqr(Arguments& argus)
+{
+    using S = decltype(std::real(T{}));
+
+    // get arguments
+    hipsolverSp_local_handle handle;
+    int                      n         = argus.get<int>("n");
+    int                      nnzA      = argus.get<int>("nnzA");
+    double                   tolerance = argus.get<double>("tolerance", 0);
+    int                      reorder   = argus.get<int>("reorder", 0);
+    int                      base1     = argus.get<int>("base1", 0);
+    int                      hot_calls = argus.iters;
+
+    // check non-supported values
+    // N/A
+
+    // check invalid sizes
+    bool invalid_size = (n < 0 || nnzA < 0);
+    if(invalid_size)
+    {
+        EXPECT_ROCBLAS_STATUS(hipsolver_csrlsvqr(HOST,
+                                                 handle,
+                                                 n,
+                                                 nnzA,
+                                                 (hipsparseMatDescr_t) nullptr,
+                                                 (T*)nullptr,
+                                                 (int*)nullptr,
+                                                 (int*)nullptr,
+                                                 (T*)nullptr,
+                                                 tolerance,
+                                                 reorder,
+                                                 (T*)nullptr,
+                                                 (int*)nullptr),
+                              HIPSOLVER_STATUS_INVALID_VALUE);
+
+        if(argus.timing)
+            rocsolver_bench_inform(inform_invalid_size);
+
+        return;
+    }
+
+    // determine existing test case
+    if(n > 0)
+    {
+        if(n <= 35)
+            n = 20;
+        else if(n <= 75)
+            n = 50;
+        else if(n <= 175)
+            n = 100;
+        else
+            n = 250;
+    }
+
+    if(n <= 50) // small case
+    {
+        if(nnzA <= 80)
+            nnzA = 60;
+        else if(nnzA <= 120)
+            nnzA = 100;
+        else
+            nnzA = 140;
+    }
+    else // large case
+    {
+        if(nnzA <= 400)
+            nnzA = 300;
+        else if(nnzA <= 600)
+            nnzA = 500;
+        else
+            nnzA = 700;
+    }
+
+    // read/set corresponding nnzA
+    fs::path testcase;
+    if(n > 0)
+    {
+        fs::path    file;
+        std::string folder
+            = std::string("posmat_") + std::to_string(n) + "_" + std::to_string(nnzA);
+        testcase = get_sparse_data_dir() / folder;
+
+        file = testcase / "ptrA";
+        read_last(file.string(), &nnzA);
+    }
+
+    // determine sizes
+    size_t size_ptrA = size_t(n) + 1;
+    size_t size_indA = size_t(nnzA);
+    size_t size_valA = size_t(nnzA);
+    size_t size_BX   = size_t(n);
+
+    size_t size_BXres = 0;
+    if(argus.unit_check || argus.norm_check)
+        size_BXres = size_BX;
+
+    double max_error = 0, gpu_time_used = 0, cpu_time_used = 0;
+
+    // memory allocations (all cases)
+    hipsparse_local_mat_descr descrA;
+    hipsparseSetMatType(descrA, HIPSPARSE_MATRIX_TYPE_GENERAL);
+    if(base1 == 0)
+        hipsparseSetMatIndexBase(descrA, HIPSPARSE_INDEX_BASE_ZERO);
+    else
+        hipsparseSetMatIndexBase(descrA, HIPSPARSE_INDEX_BASE_ONE);
+
+    host_strided_batch_vector<int> hptrA(size_ptrA, 1, size_ptrA, 1);
+    host_strided_batch_vector<int> hindA(size_indA, 1, size_indA, 1);
+    host_strided_batch_vector<T>   hvalA(size_valA, 1, size_valA, 1);
+    host_strided_batch_vector<T>   hB(size_BX, 1, size_BX, 1);
+    host_strided_batch_vector<T>   hX(size_BX, 1, size_BX, 1);
+    host_strided_batch_vector<T>   hXRes(size_BXres, 1, size_BXres, 1);
+    host_strided_batch_vector<int> hSingularity(1, 1, 1, 1);
+
+    if(HOST)
+    {
+        // memory allocations
+        host_strided_batch_vector<int> dptrA(size_ptrA, 1, size_ptrA, 1);
+        host_strided_batch_vector<int> dindA(size_indA, 1, size_indA, 1);
+        host_strided_batch_vector<T>   dvalA(size_valA, 1, size_valA, 1);
+        host_strided_batch_vector<T>   dB(size_BX, 1, size_BX, 1);
+        host_strided_batch_vector<T>   dX(size_BX, 1, size_BX, 1);
+        CHECK_HIP_ERROR(dptrA.memcheck());
+        if(size_indA)
+            CHECK_HIP_ERROR(dindA.memcheck());
+        if(size_valA)
+            CHECK_HIP_ERROR(dvalA.memcheck());
+        if(size_BX)
+            CHECK_HIP_ERROR(dB.memcheck());
+        if(size_BX)
+            CHECK_HIP_ERROR(dX.memcheck());
+
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+            csrlsvqr_getError<HOST, T>(handle,
+                                       n,
+                                       nnzA,
+                                       descrA,
+                                       dptrA,
+                                       dindA,
+                                       dvalA,
+                                       dB,
+                                       tolerance,
+                                       reorder,
+                                       dX,
+                                       hptrA,
+                                       hindA,
+                                       hvalA,
+                                       hB,
+                                       hX,
+                                       hXRes,
+                                       hSingularity,
+                                       &max_error,
+                                       testcase);
+
+        // collect performance data
+        if(argus.timing)
+            csrlsvqr_getPerfData<HOST, T>(handle,
+                                          n,
+                                          nnzA,
+                                          descrA,
+                                          dptrA,
+                                          dindA,
+                                          dvalA,
+                                          dB,
+                                          tolerance,
+                                          reorder,
+                                          dX,
+                                          hptrA,
+                                          hindA,
+                                          hvalA,
+                                          hB,
+                                          hX,
+                                          hSingularity,
+                                          &gpu_time_used,
+                                          &cpu_time_used,
+                                          hot_calls,
+                                          argus.perf,
+                                          testcase);
+    }
+
+    else
+    {
+        // memory allocations
+        device_strided_batch_vector<int> dptrA(size_ptrA, 1, size_ptrA, 1);
+        device_strided_batch_vector<int> dindA(size_indA, 1, size_indA, 1);
+        device_strided_batch_vector<T>   dvalA(size_valA, 1, size_valA, 1);
+        device_strided_batch_vector<T>   dB(size_BX, 1, size_BX, 1);
+        device_strided_batch_vector<T>   dX(size_BX, 1, size_BX, 1);
+        CHECK_HIP_ERROR(dptrA.memcheck());
+        if(size_indA)
+            CHECK_HIP_ERROR(dindA.memcheck());
+        if(size_valA)
+            CHECK_HIP_ERROR(dvalA.memcheck());
+        if(size_BX)
+            CHECK_HIP_ERROR(dB.memcheck());
+        if(size_BX)
+            CHECK_HIP_ERROR(dX.memcheck());
+
+        // check computations
+        if(argus.unit_check || argus.norm_check)
+            csrlsvqr_getError<HOST, T>(handle,
+                                       n,
+                                       nnzA,
+                                       descrA,
+                                       dptrA,
+                                       dindA,
+                                       dvalA,
+                                       dB,
+                                       tolerance,
+                                       reorder,
+                                       dX,
+                                       hptrA,
+                                       hindA,
+                                       hvalA,
+                                       hB,
+                                       hX,
+                                       hXRes,
+                                       hSingularity,
+                                       &max_error,
+                                       testcase);
+
+        // collect performance data
+        if(argus.timing)
+            csrlsvqr_getPerfData<HOST, T>(handle,
+                                          n,
+                                          nnzA,
+                                          descrA,
+                                          dptrA,
+                                          dindA,
+                                          dvalA,
+                                          dB,
+                                          tolerance,
+                                          reorder,
+                                          dX,
+                                          hptrA,
+                                          hindA,
+                                          hvalA,
+                                          hB,
+                                          hX,
+                                          hSingularity,
+                                          &gpu_time_used,
+                                          &cpu_time_used,
+                                          hot_calls,
+                                          argus.perf,
+                                          testcase);
+    }
+
+    // validate results for rocsolver-test
+    // using n * machine_precision as tolerance
+    if(argus.unit_check)
+        ROCSOLVER_TEST_CHECK(T, max_error, n);
+
+    // output results for rocsolver-bench
+    if(argus.timing)
+    {
+        if(!argus.perf)
+        {
+            std::cerr << "\n============================================\n";
+            std::cerr << "Arguments:\n";
+            std::cerr << "============================================\n";
+            rocsolver_bench_output("n", "nnzA");
+            rocsolver_bench_output(n, nnzA);
+
+            std::cerr << "\n============================================\n";
+            std::cerr << "Results:\n";
+            std::cerr << "============================================\n";
+            if(argus.norm_check)
+            {
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us", "error");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used, max_error);
+            }
+            else
+            {
+                rocsolver_bench_output("cpu_time_us", "gpu_time_us");
+                rocsolver_bench_output(cpu_time_used, gpu_time_used);
+            }
+            std::cerr << std::endl;
+        }
+        else
+        {
+            if(argus.norm_check)
+                rocsolver_bench_output(gpu_time_used, max_error);
+            else
+                rocsolver_bench_output(gpu_time_used);
+        }
+    }
+
+    // ensure all arguments were consumed
+    argus.validate_consumed();
+}

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -723,6 +723,62 @@ inline void
     fclose(mat);
 }
 
+// complex float:
+inline void read_matrix(
+    const std::string filenameS, const int m, const int n, hipsolverComplex* A, const int lda)
+{
+    const char* filename = filenameS.c_str();
+    FILE*       mat;
+    mat = fopen(filename, "r");
+    float v;
+
+    if(mat == NULL)
+        throw std::invalid_argument(std::string("Error: Could not open file ") + filename
+                                    + " with test data...");
+
+    for(int j = 0; j < n; ++j)
+    {
+        for(int i = 0; i < m; ++i)
+        {
+            int read = fscanf(mat, "%g", &v);
+            if(read != 1)
+                throw std::out_of_range(std::string("Error: Could not read element from file ")
+                                        + filename);
+            A[i + j * lda] = {v, 0};
+        }
+    }
+
+    fclose(mat);
+}
+
+// complex double:
+inline void read_matrix(
+    const std::string filenameS, const int m, const int n, hipsolverDoubleComplex* A, const int lda)
+{
+    const char* filename = filenameS.c_str();
+    FILE*       mat;
+    mat = fopen(filename, "r");
+    double v;
+
+    if(mat == NULL)
+        throw std::invalid_argument(std::string("Error: Could not open file ") + filename
+                                    + " with test data...");
+
+    for(int j = 0; j < n; ++j)
+    {
+        for(int i = 0; i < m; ++i)
+        {
+            int read = fscanf(mat, "%lg", &v);
+            if(read != 1)
+                throw std::out_of_range(std::string("Error: Could not read element from file ")
+                                        + filename);
+            A[i + j * lda] = {v, 0};
+        }
+    }
+
+    fclose(mat);
+}
+
 /* =============================================================================================== */
 
 /* ============================================================================================ */

--- a/docs/howto/usage.rst
+++ b/docs/howto/usage.rst
@@ -115,16 +115,20 @@ Unsupported methods
   * :ref:`hipsolverSpXcsrlsvcholHost <sparse_csrlsvcholHost>` with `reorder = 1`
   * :ref:`hipsolverSpXcsrlsvchol <sparse_csrlsvchol>` with `reorder = 1`
 
+- The functions :ref:`hipsolverSpScsrlsvqr <sparse_csrlsvqr>` are currently implemented by converting the sparse input matrix to a dense
+  matrix, and therefore do not support any reordering method.
+
 .. _sparse_performance:
 
 Performance implications of the hipsolverSp API
 ------------------------------------------------
 
-- The third-party SuiteSparse library is used to provide host-side functionality for the hipsolverSp API when using the rocSOLVER
-  backend. At present, SuiteSparse does not support single precision arrays, therefore hipSOLVER must allocate temporary double
-  precision arrays and copy the values one-by-one to and from the user-provided arguments.
+- The third-party SuiteSparse library is used to provide host-side functionality for :ref:`hipsolverSpXcsrlsvchol <sparse_csrlsvchol>`
+  when using the rocSOLVER backend. At present, SuiteSparse does not support single precision arrays, therefore hipSOLVER must allocate
+  temporary double precision arrays and copy the values one-by-one to and from the user-provided arguments.
 
-  (Single precision hipsolverSp functions are expected to perform slower and require more memory usage than double precision functions.)
+  (Single precision :ref:`hipsolverSpScsrlsvchol <sparse_csrlsvchol>` is expected to perform slower and require more memory usage than the
+  double precision version.)
 
 - A fully-featured, GPU-accelerated Cholesky factorization for sparse matrices has not yet been implemented in either rocSOLVER or
   rocSPARSE. Therefore, we rely on SuiteSparse to provide this functionality. The functions :ref:`hipsolverSpXcsrlsvchol <sparse_csrlsvchol>`
@@ -133,6 +137,13 @@ Performance implications of the hipsolverSp API
 
   (:ref:`hipsolverSpXcsrlsvchol <sparse_csrlsvchol>` may perform slower and will require more memory usage than
   :ref:`hipsolverSpXcsrlsvcholHost <sparse_csrlsvcholHost>`.)
+
+- The functions :ref:`hipsolverSpScsrlsvqr <sparse_csrlsvqr>` are currently implemented by converting the sparse input matrix to a dense
+  matrix, and then running the dense factorization and linear solver on the result. This may result in slower-than-expected performance and
+  significant memory usage for large matrices.
+
+  (:ref:`hipsolverSpXcsrlsvqr <sparse_csrlsvqr>` must allocate enough memory to hold a dense matrix, and will have similar performance
+  to :ref:`hipsolverXXgels <gels>`)
 
 
 .. _refactor_api_differences:

--- a/docs/howto/usage.rst
+++ b/docs/howto/usage.rst
@@ -116,7 +116,13 @@ Unsupported methods
   * :ref:`hipsolverSpXcsrlsvchol <sparse_csrlsvchol>` with `reorder = 1`
 
 - The function :ref:`hipsolverSpScsrlsvqr <sparse_csrlsvqr>` is currently implemented by converting the sparse input matrix to a dense
-  matrix, and therefore do not support any reordering method.
+  matrix, and therefore does not support any reordering method. The host path is also currently unsupported.
+
+Arguments not referenced by rocSOLVER
+--------------------------------------
+
+- The `reorder` and `tolerance` arguments of :ref:`hipsolverSpScsrlsvqr <sparse_csrlsvqr>` are not referenced by the rocSOLVER
+  backend.
 
 .. _sparse_performance:
 

--- a/docs/howto/usage.rst
+++ b/docs/howto/usage.rst
@@ -115,7 +115,7 @@ Unsupported methods
   * :ref:`hipsolverSpXcsrlsvcholHost <sparse_csrlsvcholHost>` with `reorder = 1`
   * :ref:`hipsolverSpXcsrlsvchol <sparse_csrlsvchol>` with `reorder = 1`
 
-- The functions :ref:`hipsolverSpScsrlsvqr <sparse_csrlsvqr>` are currently implemented by converting the sparse input matrix to a dense
+- The function :ref:`hipsolverSpScsrlsvqr <sparse_csrlsvqr>` is currently implemented by converting the sparse input matrix to a dense
   matrix, and therefore do not support any reordering method.
 
 .. _sparse_performance:
@@ -135,11 +135,11 @@ Performance implications of the hipsolverSp API
   will allocate space for sparse matrices on the host, copy the data to the host, use SuiteSparse to perform the symbolic factorization, and
   then copy the resulting data back to the device.
 
-  (:ref:`hipsolverSpXcsrlsvchol <sparse_csrlsvchol>` may perform slower and will require more memory usage than
+  (:ref:`hipsolverSpXcsrlsvchol <sparse_csrlsvchol>` might perform slower and will require more memory usage than
   :ref:`hipsolverSpXcsrlsvcholHost <sparse_csrlsvcholHost>`.)
 
-- The functions :ref:`hipsolverSpScsrlsvqr <sparse_csrlsvqr>` are currently implemented by converting the sparse input matrix to a dense
-  matrix, and then running the dense factorization and linear solver on the result. This may result in slower-than-expected performance and
+- The function :ref:`hipsolverSpScsrlsvqr <sparse_csrlsvqr>` is currently implemented by converting the sparse input matrix to a dense
+  matrix, and then running the dense factorization and linear solver on the result. This might result in slower-than-expected performance and
   significant memory usage for large matrices.
 
   (:ref:`hipsolverSpXcsrlsvqr <sparse_csrlsvqr>` must allocate enough memory to hold a dense matrix, and will have similar performance

--- a/docs/reference/intro.rst
+++ b/docs/reference/intro.rst
@@ -182,6 +182,7 @@ Refer to the :ref:`hipsolverSp compatibility API <library_sparse>` for more deta
 
     :ref:`hipsolverSpXcsrlsvcholHost <sparse_csrlsvcholHost>`, x, x, ,
     :ref:`hipsolverSpXcsrlsvchol <sparse_csrlsvchol>`, x, x, ,
+    :ref:`hipsolverSpXcsrlsvqr <sparse_csrlsvqr>`, x, x, ,
 
 Refactorization routines
 ------------------------------

--- a/docs/reference/sparse-api/sparse.rst
+++ b/docs/reference/sparse-api/sparse.rst
@@ -40,10 +40,6 @@ hipsolverSp<type>csrlsvcholHost()
 
 hipsolverSp<type>csrlsvqr()
 ---------------------------------------------------
-.. doxygenfunction:: hipsolverSpZcsrlsvqr
-   :outline:
-.. doxygenfunction:: hipsolverSpCcsrlsvqr
-   :outline:
 .. doxygenfunction:: hipsolverSpDcsrlsvqr
    :outline:
 .. doxygenfunction:: hipsolverSpScsrlsvqr

--- a/docs/reference/sparse-api/sparse.rst
+++ b/docs/reference/sparse-api/sparse.rst
@@ -36,3 +36,15 @@ hipsolverSp<type>csrlsvcholHost()
    :outline:
 .. doxygenfunction:: hipsolverSpScsrlsvcholHost
 
+.. _sparse_csrlsvqr:
+
+hipsolverSp<type>csrlsvqr()
+---------------------------------------------------
+.. doxygenfunction:: hipsolverSpZcsrlsvqr
+   :outline:
+.. doxygenfunction:: hipsolverSpCcsrlsvqr
+   :outline:
+.. doxygenfunction:: hipsolverSpDcsrlsvqr
+   :outline:
+.. doxygenfunction:: hipsolverSpScsrlsvqr
+

--- a/library/include/internal/hipsolver-sparse.h
+++ b/library/include/internal/hipsolver-sparse.h
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2023 Advanced Micro Devices, Inc.
+ * Copyright (C) 2023-2024 Advanced Micro Devices, Inc.
  * ************************************************************************ */
 
 #ifndef HIPSOLVER_SPARSE_H
@@ -74,6 +74,59 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpDcsrlsvcholHost(hipsolverSpHandle_
                                                               int                       reorder,
                                                               double*                   x,
                                                               int* singularity);
+
+// linear solver based on QR
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpScsrlsvqr(hipsolverSpHandle_t       handle,
+                                                        int                       n,
+                                                        int                       nnz,
+                                                        const hipsparseMatDescr_t descrA,
+                                                        const float*              csrVal,
+                                                        const int*                csrRowPts,
+                                                        const int*                csrColInd,
+                                                        const float*              b,
+                                                        double                    tolerance,
+                                                        int                       reorder,
+                                                        float*                    x,
+                                                        int*                      singularity);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpDcsrlsvqr(hipsolverSpHandle_t       handle,
+                                                        int                       n,
+                                                        int                       nnz,
+                                                        const hipsparseMatDescr_t descrA,
+                                                        const double*             csrVal,
+                                                        const int*                csrRowPts,
+                                                        const int*                csrColInd,
+                                                        const double*             b,
+                                                        double                    tolerance,
+                                                        int                       reorder,
+                                                        double*                   x,
+                                                        int*                      singularity);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpCcsrlsvqr(hipsolverSpHandle_t       handle,
+                                                        int                       n,
+                                                        int                       nnz,
+                                                        const hipsparseMatDescr_t descrA,
+                                                        const hipFloatComplex*    csrVal,
+                                                        const int*                csrRowPts,
+                                                        const int*                csrColInd,
+                                                        const hipFloatComplex*    b,
+                                                        double                    tolerance,
+                                                        int                       reorder,
+                                                        hipFloatComplex*          x,
+                                                        int*                      singularity);
+
+HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpZcsrlsvqr(hipsolverSpHandle_t       handle,
+                                                        int                       n,
+                                                        int                       nnz,
+                                                        const hipsparseMatDescr_t descrA,
+                                                        const hipDoubleComplex*   csrVal,
+                                                        const int*                csrRowPts,
+                                                        const int*                csrColInd,
+                                                        const hipDoubleComplex*   b,
+                                                        double                    tolerance,
+                                                        int                       reorder,
+                                                        hipDoubleComplex*         x,
+                                                        int*                      singularity);
 
 #ifdef __cplusplus
 }

--- a/library/include/internal/hipsolver-sparse.h
+++ b/library/include/internal/hipsolver-sparse.h
@@ -102,32 +102,6 @@ HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpDcsrlsvqr(hipsolverSpHandle_t     
                                                         double*                   x,
                                                         int*                      singularity);
 
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpCcsrlsvqr(hipsolverSpHandle_t       handle,
-                                                        int                       n,
-                                                        int                       nnz,
-                                                        const hipsparseMatDescr_t descrA,
-                                                        const hipFloatComplex*    csrVal,
-                                                        const int*                csrRowPts,
-                                                        const int*                csrColInd,
-                                                        const hipFloatComplex*    b,
-                                                        double                    tolerance,
-                                                        int                       reorder,
-                                                        hipFloatComplex*          x,
-                                                        int*                      singularity);
-
-HIPSOLVER_EXPORT hipsolverStatus_t hipsolverSpZcsrlsvqr(hipsolverSpHandle_t       handle,
-                                                        int                       n,
-                                                        int                       nnz,
-                                                        const hipsparseMatDescr_t descrA,
-                                                        const hipDoubleComplex*   csrVal,
-                                                        const int*                csrRowPts,
-                                                        const int*                csrColInd,
-                                                        const hipDoubleComplex*   b,
-                                                        double                    tolerance,
-                                                        int                       reorder,
-                                                        hipDoubleComplex*         x,
-                                                        int*                      singularity);
-
 #ifdef __cplusplus
 }
 #endif

--- a/library/src/amd_detail/dlopen/rocsparse.cpp
+++ b/library/src/amd_detail/dlopen/rocsparse.cpp
@@ -26,10 +26,16 @@
 
 HIPSOLVER_BEGIN_NAMESPACE
 
+fp_rocsparse_create_handle      g_rocsparse_create_handle;
+fp_rocsparse_destroy_handle     g_rocsparse_destroy_handle;
 fp_rocsparse_create_mat_descr   g_rocsparse_create_mat_descr;
 fp_rocsparse_destroy_mat_descr  g_rocsparse_destroy_mat_descr;
 fp_rocsparse_get_mat_type       g_rocsparse_get_mat_type;
 fp_rocsparse_get_mat_index_base g_rocsparse_get_mat_index_base;
+fp_rocsparse_scsr2dense         g_rocsparse_scsr2dense;
+fp_rocsparse_dcsr2dense         g_rocsparse_dcsr2dense;
+fp_rocsparse_ccsr2dense         g_rocsparse_ccsr2dense;
+fp_rocsparse_zcsr2dense         g_rocsparse_zcsr2dense;
 
 static bool load_rocsparse()
 {
@@ -51,6 +57,10 @@ static bool load_rocsparse()
     if(!handle)
         return false;
 
+    if(!load_function(handle, "rocsparse_create_handle", g_rocsparse_create_handle))
+        return false;
+    if(!load_function(handle, "rocsparse_destroy_handle", g_rocsparse_destroy_handle))
+        return false;
     if(!load_function(handle, "rocsparse_create_mat_descr", g_rocsparse_create_mat_descr))
         return false;
     if(!load_function(handle, "rocsparse_destroy_mat_descr", g_rocsparse_destroy_mat_descr))
@@ -58,6 +68,15 @@ static bool load_rocsparse()
     if(!load_function(handle, "rocsparse_get_mat_type", g_rocsparse_get_mat_type))
         return false;
     if(!load_function(handle, "rocsparse_get_mat_index_base", g_rocsparse_get_mat_index_base))
+        return false;
+
+    if(!load_function(handle, "rocsparse_scsr2dense", g_rocsparse_scsr2dense))
+        return false;
+    if(!load_function(handle, "rocsparse_dcsr2dense", g_rocsparse_dcsr2dense))
+        return false;
+    if(!load_function(handle, "rocsparse_ccsr2dense", g_rocsparse_ccsr2dense))
+        return false;
+    if(!load_function(handle, "rocsparse_zcsr2dense", g_rocsparse_zcsr2dense))
         return false;
 
     return true;

--- a/library/src/amd_detail/dlopen/rocsparse.hpp
+++ b/library/src/amd_detail/dlopen/rocsparse.hpp
@@ -27,6 +27,12 @@
 #include <rocsparse/rocsparse.h>
 #else
 
+#if defined(rocsparse_ILP64)
+typedef int64_t rocsparse_int;
+#else
+typedef int32_t rocsparse_int;
+#endif
+
 // type definitions
 typedef enum rocsparse_status_
 {
@@ -61,11 +67,30 @@ typedef enum rocsparse_matrix_type_
     rocsparse_matrix_type_triangular = 3 /**< triangular matrix type. */
 } rocsparse_matrix_type;
 
+typedef struct _rocsparse_handle*    rocsparse_handle;
 typedef struct _rocsparse_mat_descr* rocsparse_mat_descr;
+
+typedef struct
+{
+    float x, y;
+} rocsparse_float_complex;
+
+typedef struct
+{
+    double x, y;
+} rocsparse_double_complex;
 
 HIPSOLVER_BEGIN_NAMESPACE
 
 // function declarations
+typedef rocsparse_status (*fp_rocsparse_create_handle)(rocsparse_handle* handle);
+extern fp_rocsparse_create_handle g_rocsparse_create_handle;
+#define rocsparse_create_handle ::hipsolver::g_rocsparse_create_handle
+
+typedef rocsparse_status (*fp_rocsparse_destroy_handle)(rocsparse_handle handle);
+extern fp_rocsparse_destroy_handle g_rocsparse_destroy_handle;
+#define rocsparse_destroy_handle ::hipsolver::g_rocsparse_destroy_handle
+
 typedef rocsparse_status (*fp_rocsparse_create_mat_descr)(rocsparse_mat_descr* descr);
 extern fp_rocsparse_create_mat_descr g_rocsparse_create_mat_descr;
 #define rocsparse_create_mat_descr ::hipsolver::g_rocsparse_create_mat_descr
@@ -81,6 +106,54 @@ extern fp_rocsparse_get_mat_type g_rocsparse_get_mat_type;
 typedef rocsparse_index_base (*fp_rocsparse_get_mat_index_base)(rocsparse_mat_descr descr);
 extern fp_rocsparse_get_mat_index_base g_rocsparse_get_mat_index_base;
 #define rocsparse_get_mat_index_base ::hipsolver::g_rocsparse_get_mat_index_base
+
+typedef rocsparse_status (*fp_rocsparse_scsr2dense)(rocsparse_handle          handle,
+                                                    rocsparse_int             m,
+                                                    rocsparse_int             n,
+                                                    const rocsparse_mat_descr descr,
+                                                    const float*              csr_val,
+                                                    const rocsparse_int*      csr_row_ptr,
+                                                    const rocsparse_int*      csr_col_ind,
+                                                    float*                    A,
+                                                    rocsparse_int             ld);
+extern fp_rocsparse_scsr2dense g_rocsparse_scsr2dense;
+#define rocsparse_scsr2dense ::hipsolver::g_rocsparse_scsr2dense
+
+typedef rocsparse_status (*fp_rocsparse_dcsr2dense)(rocsparse_handle          handle,
+                                                    rocsparse_int             m,
+                                                    rocsparse_int             n,
+                                                    const rocsparse_mat_descr descr,
+                                                    const double*             csr_val,
+                                                    const rocsparse_int*      csr_row_ptr,
+                                                    const rocsparse_int*      csr_col_ind,
+                                                    double*                   A,
+                                                    rocsparse_int             ld);
+extern fp_rocsparse_dcsr2dense g_rocsparse_dcsr2dense;
+#define rocsparse_dcsr2dense ::hipsolver::g_rocsparse_dcsr2dense
+
+typedef rocsparse_status (*fp_rocsparse_ccsr2dense)(rocsparse_handle               handle,
+                                                    rocsparse_int                  m,
+                                                    rocsparse_int                  n,
+                                                    const rocsparse_mat_descr      descr,
+                                                    const rocsparse_float_complex* csr_val,
+                                                    const rocsparse_int*           csr_row_ptr,
+                                                    const rocsparse_int*           csr_col_ind,
+                                                    rocsparse_float_complex*       A,
+                                                    rocsparse_int                  ld);
+extern fp_rocsparse_ccsr2dense g_rocsparse_ccsr2dense;
+#define rocsparse_ccsr2dense ::hipsolver::g_rocsparse_ccsr2dense
+
+typedef rocsparse_status (*fp_rocsparse_zcsr2dense)(rocsparse_handle                handle,
+                                                    rocsparse_int                   m,
+                                                    rocsparse_int                   n,
+                                                    const rocsparse_mat_descr       descr,
+                                                    const rocsparse_double_complex* csr_val,
+                                                    const rocsparse_int*            csr_row_ptr,
+                                                    const rocsparse_int*            csr_col_ind,
+                                                    rocsparse_double_complex*       A,
+                                                    rocsparse_int                   ld);
+extern fp_rocsparse_zcsr2dense g_rocsparse_zcsr2dense;
+#define rocsparse_zcsr2dense ::hipsolver::g_rocsparse_zcsr2dense
 
 HIPSOLVER_END_NAMESPACE
 

--- a/library/src/amd_detail/hipsolver_sparse.cpp
+++ b/library/src/amd_detail/hipsolver_sparse.cpp
@@ -390,6 +390,7 @@ try
     hipsolverSpHandle* sp = (hipsolverSpHandle*)handle;
     sp->free_all();
     rocblas_destroy_handle(sp->handle);
+    rocsparse_destroy_handle(sp->sphandle);
     rocsolver_destroy_rfinfo(sp->rfinfo);
     cholmod_finish(&sp->c_handle);
     delete sp;
@@ -1110,6 +1111,8 @@ try
         return HIPSOLVER_STATUS_INVALID_VALUE;
     if(!b || !x || !singularity)
         return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(reorder < 0 || reorder > 3)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
     rocsparse_index_base  indbase = rocsparse_get_mat_index_base((rocsparse_mat_descr)descrA);
@@ -1135,6 +1138,10 @@ try
 
     rocblas_status st
         = rocsolver_sgels(sp->handle, rocblas_operation_none, n, n, 1, denseA, n, x, n, info);
+
+    // finalize singularity
+    CHECK_HIP_ERROR(hipMemcpy((void*)singularity, info, sizeof(int), hipMemcpyDeviceToHost));
+    *singularity = *singularity - 1;
 
     CHECK_HIP_ERROR(hipFree(denseA));
     CHECK_HIP_ERROR(hipFree(info));
@@ -1170,6 +1177,8 @@ try
         return HIPSOLVER_STATUS_INVALID_VALUE;
     if(!b || !x || !singularity)
         return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(reorder < 0 || reorder > 3)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
     rocsparse_index_base  indbase = rocsparse_get_mat_index_base((rocsparse_mat_descr)descrA);
@@ -1195,6 +1204,10 @@ try
 
     rocblas_status st
         = rocsolver_dgels(sp->handle, rocblas_operation_none, n, n, 1, denseA, n, x, n, info);
+
+    // finalize singularity
+    CHECK_HIP_ERROR(hipMemcpy((void*)singularity, info, sizeof(int), hipMemcpyDeviceToHost));
+    *singularity = *singularity - 1;
 
     CHECK_HIP_ERROR(hipFree(denseA));
     CHECK_HIP_ERROR(hipFree(info));
@@ -1229,6 +1242,8 @@ try
     if(!csrRowPtr || !csrColInd || !csrVal || !descrA)
         return HIPSOLVER_STATUS_INVALID_VALUE;
     if(!b || !x || !singularity)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(reorder < 0 || reorder > 3)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
@@ -1271,6 +1286,10 @@ try
                                         n,
                                         info);
 
+    // finalize singularity
+    CHECK_HIP_ERROR(hipMemcpy((void*)singularity, info, sizeof(int), hipMemcpyDeviceToHost));
+    *singularity = *singularity - 1;
+
     CHECK_HIP_ERROR(hipFree(denseA));
     CHECK_HIP_ERROR(hipFree(info));
 
@@ -1304,6 +1323,8 @@ try
     if(!csrRowPtr || !csrColInd || !csrVal || !descrA)
         return HIPSOLVER_STATUS_INVALID_VALUE;
     if(!b || !x || !singularity)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(reorder < 0 || reorder > 3)
         return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
@@ -1345,6 +1366,10 @@ try
                                         (rocblas_double_complex*)x,
                                         n,
                                         info);
+
+    // finalize singularity
+    CHECK_HIP_ERROR(hipMemcpy((void*)singularity, info, sizeof(int), hipMemcpyDeviceToHost));
+    *singularity = *singularity - 1;
 
     CHECK_HIP_ERROR(hipFree(denseA));
     CHECK_HIP_ERROR(hipFree(info));

--- a/library/src/amd_detail/hipsolver_sparse.cpp
+++ b/library/src/amd_detail/hipsolver_sparse.cpp
@@ -1219,7 +1219,7 @@ catch(...)
     return hipsolver::exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverSpCcsrlsvqr(hipsolverSpHandle_t       handle,
+/*hipsolverStatus_t hipsolverSpCcsrlsvqr(hipsolverSpHandle_t       handle,
                                        int                       n,
                                        int                       nnz,
                                        const hipsparseMatDescr_t descrA,
@@ -1379,6 +1379,6 @@ try
 catch(...)
 {
     return hipsolver::exception2hip_status();
-}
+}*/
 
 } //extern C

--- a/library/src/amd_detail/hipsolver_sparse.cpp
+++ b/library/src/amd_detail/hipsolver_sparse.cpp
@@ -52,6 +52,7 @@ extern "C" {
 struct hipsolverSpHandle
 {
     rocblas_handle   handle;
+    rocsparse_handle sphandle;
     rocsolver_rfinfo rfinfo;
     cholmod_common   c_handle;
 
@@ -340,6 +341,7 @@ try
 
     hipsolverSpHandle* sp = new hipsolverSpHandle;
     rocblas_status     status;
+    rocsparse_status   sp_status;
 
     if((status = rocblas_create_handle(&sp->handle)) != rocblas_status_success)
     {
@@ -347,9 +349,17 @@ try
         return hipsolver::rocblas2hip_status(status);
     }
 
+    if((sp_status = rocsparse_create_handle(&sp->sphandle)) != rocsparse_status_success)
+    {
+        rocblas_destroy_handle(sp->handle);
+        delete sp;
+        return HIPSOLVER_STATUS_ALLOC_FAILED;
+    }
+
     if((status = rocsolver_create_rfinfo(&sp->rfinfo, sp->handle)) != rocblas_status_success)
     {
         rocblas_destroy_handle(sp->handle);
+        rocsparse_destroy_handle(sp->sphandle);
         delete sp;
         return hipsolver::rocblas2hip_status(status);
     }
@@ -357,6 +367,7 @@ try
     if(cholmod_start(&sp->c_handle) != TRUE)
     {
         rocblas_destroy_handle(sp->handle);
+        rocsparse_destroy_handle(sp->sphandle);
         rocsolver_destroy_rfinfo(sp->rfinfo);
         delete sp;
         return HIPSOLVER_STATUS_INTERNAL_ERROR;
@@ -1073,5 +1084,276 @@ catch(...)
 {
     return hipsolver::exception2hip_status();
 }*/
+
+/******************** CSRLSVQR ********************/
+hipsolverStatus_t hipsolverSpScsrlsvqr(hipsolverSpHandle_t       handle,
+                                       int                       n,
+                                       int                       nnz,
+                                       const hipsparseMatDescr_t descrA,
+                                       const float*              csrVal,
+                                       const int*                csrRowPtr,
+                                       const int*                csrColInd,
+                                       const float*              b,
+                                       double                    tolerance,
+                                       int                       reorder,
+                                       float*                    x,
+                                       int*                      singularity)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(n < 0 || nnz < 0)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!csrRowPtr || !csrColInd || !csrVal || !descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!b || !x || !singularity)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
+    rocsparse_index_base  indbase = rocsparse_get_mat_index_base((rocsparse_mat_descr)descrA);
+    if(mattype != rocsparse_matrix_type_general)
+        return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+    if(indbase != rocsparse_index_base_zero && indbase != rocsparse_index_base_one)
+        return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+
+    hipsolverSpHandle* sp = (hipsolverSpHandle*)handle;
+    *singularity          = -1;
+
+    // set up B
+    CHECK_HIP_ERROR(hipMemcpy((void*)x, b, sizeof(float) * n, hipMemcpyDeviceToDevice));
+
+    // convert A to dense matrix
+    float* denseA;
+    CHECK_HIP_ERROR(hipMalloc(&denseA, sizeof(float) * n * n));
+    rocsparse_scsr2dense(
+        sp->sphandle, n, n, (rocsparse_mat_descr)descrA, csrVal, csrRowPtr, csrColInd, denseA, n);
+
+    int* info;
+    CHECK_HIP_ERROR(hipMalloc(&info, sizeof(int)));
+
+    rocblas_status st
+        = rocsolver_sgels(sp->handle, rocblas_operation_none, n, n, 1, denseA, n, x, n, info);
+
+    CHECK_HIP_ERROR(hipFree(denseA));
+    CHECK_HIP_ERROR(hipFree(info));
+
+    return hipsolver::rocblas2hip_status(st);
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSpDcsrlsvqr(hipsolverSpHandle_t       handle,
+                                       int                       n,
+                                       int                       nnz,
+                                       const hipsparseMatDescr_t descrA,
+                                       const double*             csrVal,
+                                       const int*                csrRowPtr,
+                                       const int*                csrColInd,
+                                       const double*             b,
+                                       double                    tolerance,
+                                       int                       reorder,
+                                       double*                   x,
+                                       int*                      singularity)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(n < 0 || nnz < 0)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!csrRowPtr || !csrColInd || !csrVal || !descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!b || !x || !singularity)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
+    rocsparse_index_base  indbase = rocsparse_get_mat_index_base((rocsparse_mat_descr)descrA);
+    if(mattype != rocsparse_matrix_type_general)
+        return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+    if(indbase != rocsparse_index_base_zero && indbase != rocsparse_index_base_one)
+        return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+
+    hipsolverSpHandle* sp = (hipsolverSpHandle*)handle;
+    *singularity          = -1;
+
+    // set up B
+    CHECK_HIP_ERROR(hipMemcpy((void*)x, b, sizeof(double) * n, hipMemcpyDeviceToDevice));
+
+    // convert A to dense matrix
+    double* denseA;
+    CHECK_HIP_ERROR(hipMalloc(&denseA, sizeof(double) * n * n));
+    rocsparse_dcsr2dense(
+        sp->sphandle, n, n, (rocsparse_mat_descr)descrA, csrVal, csrRowPtr, csrColInd, denseA, n);
+
+    int* info;
+    CHECK_HIP_ERROR(hipMalloc(&info, sizeof(int)));
+
+    rocblas_status st
+        = rocsolver_dgels(sp->handle, rocblas_operation_none, n, n, 1, denseA, n, x, n, info);
+
+    CHECK_HIP_ERROR(hipFree(denseA));
+    CHECK_HIP_ERROR(hipFree(info));
+
+    return hipsolver::rocblas2hip_status(st);
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSpCcsrlsvqr(hipsolverSpHandle_t       handle,
+                                       int                       n,
+                                       int                       nnz,
+                                       const hipsparseMatDescr_t descrA,
+                                       const hipFloatComplex*    csrVal,
+                                       const int*                csrRowPtr,
+                                       const int*                csrColInd,
+                                       const hipFloatComplex*    b,
+                                       double                    tolerance,
+                                       int                       reorder,
+                                       hipFloatComplex*          x,
+                                       int*                      singularity)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(n < 0 || nnz < 0)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!csrRowPtr || !csrColInd || !csrVal || !descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!b || !x || !singularity)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
+    rocsparse_index_base  indbase = rocsparse_get_mat_index_base((rocsparse_mat_descr)descrA);
+    if(mattype != rocsparse_matrix_type_general)
+        return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+    if(indbase != rocsparse_index_base_zero && indbase != rocsparse_index_base_one)
+        return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+
+    hipsolverSpHandle* sp = (hipsolverSpHandle*)handle;
+    *singularity          = -1;
+
+    // set up B
+    CHECK_HIP_ERROR(hipMemcpy((void*)x, b, sizeof(hipFloatComplex) * n, hipMemcpyDeviceToDevice));
+
+    // convert A to dense matrix
+    hipFloatComplex* denseA;
+    CHECK_HIP_ERROR(hipMalloc(&denseA, sizeof(hipFloatComplex) * n * n));
+    rocsparse_ccsr2dense(sp->sphandle,
+                         n,
+                         n,
+                         (rocsparse_mat_descr)descrA,
+                         (rocsparse_float_complex*)csrVal,
+                         csrRowPtr,
+                         csrColInd,
+                         (rocsparse_float_complex*)denseA,
+                         n);
+
+    int* info;
+    CHECK_HIP_ERROR(hipMalloc(&info, sizeof(int)));
+
+    rocblas_status st = rocsolver_cgels(sp->handle,
+                                        rocblas_operation_none,
+                                        n,
+                                        n,
+                                        1,
+                                        (rocblas_float_complex*)denseA,
+                                        n,
+                                        (rocblas_float_complex*)x,
+                                        n,
+                                        info);
+
+    CHECK_HIP_ERROR(hipFree(denseA));
+    CHECK_HIP_ERROR(hipFree(info));
+
+    return hipsolver::rocblas2hip_status(st);
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSpZcsrlsvqr(hipsolverSpHandle_t       handle,
+                                       int                       n,
+                                       int                       nnz,
+                                       const hipsparseMatDescr_t descrA,
+                                       const hipDoubleComplex*   csrVal,
+                                       const int*                csrRowPtr,
+                                       const int*                csrColInd,
+                                       const hipDoubleComplex*   b,
+                                       double                    tolerance,
+                                       int                       reorder,
+                                       hipDoubleComplex*         x,
+                                       int*                      singularity)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(n < 0 || nnz < 0)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!csrRowPtr || !csrColInd || !csrVal || !descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+    if(!b || !x || !singularity)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
+    rocsparse_index_base  indbase = rocsparse_get_mat_index_base((rocsparse_mat_descr)descrA);
+    if(mattype != rocsparse_matrix_type_general)
+        return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+    if(indbase != rocsparse_index_base_zero && indbase != rocsparse_index_base_one)
+        return HIPSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED;
+
+    hipsolverSpHandle* sp = (hipsolverSpHandle*)handle;
+    *singularity          = -1;
+
+    // set up B
+    CHECK_HIP_ERROR(hipMemcpy((void*)x, b, sizeof(hipDoubleComplex) * n, hipMemcpyDeviceToDevice));
+
+    // convert A to dense matrix
+    hipFloatComplex* denseA;
+    CHECK_HIP_ERROR(hipMalloc(&denseA, sizeof(hipDoubleComplex) * n * n));
+    rocsparse_zcsr2dense(sp->sphandle,
+                         n,
+                         n,
+                         (rocsparse_mat_descr)descrA,
+                         (rocsparse_double_complex*)csrVal,
+                         csrRowPtr,
+                         csrColInd,
+                         (rocsparse_double_complex*)denseA,
+                         n);
+
+    int* info;
+    CHECK_HIP_ERROR(hipMalloc(&info, sizeof(int)));
+
+    rocblas_status st = rocsolver_zgels(sp->handle,
+                                        rocblas_operation_none,
+                                        n,
+                                        n,
+                                        1,
+                                        (rocblas_double_complex*)denseA,
+                                        n,
+                                        (rocblas_double_complex*)x,
+                                        n,
+                                        info);
+
+    CHECK_HIP_ERROR(hipFree(denseA));
+    CHECK_HIP_ERROR(hipFree(info));
+
+    return hipsolver::rocblas2hip_status(st);
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
 
 } //extern C

--- a/library/src/amd_detail/hipsolver_sparse.cpp
+++ b/library/src/amd_detail/hipsolver_sparse.cpp
@@ -1111,8 +1111,8 @@ try
         return HIPSOLVER_STATUS_INVALID_VALUE;
     if(!b || !x || !singularity)
         return HIPSOLVER_STATUS_INVALID_VALUE;
-    if(reorder < 0 || reorder > 3)
-        return HIPSOLVER_STATUS_INVALID_VALUE;
+    // if(reorder < 0 || reorder > 3)
+    //     return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
     rocsparse_index_base  indbase = rocsparse_get_mat_index_base((rocsparse_mat_descr)descrA);
@@ -1177,8 +1177,8 @@ try
         return HIPSOLVER_STATUS_INVALID_VALUE;
     if(!b || !x || !singularity)
         return HIPSOLVER_STATUS_INVALID_VALUE;
-    if(reorder < 0 || reorder > 3)
-        return HIPSOLVER_STATUS_INVALID_VALUE;
+    // if(reorder < 0 || reorder > 3)
+    //     return HIPSOLVER_STATUS_INVALID_VALUE;
 
     rocsparse_matrix_type mattype = rocsparse_get_mat_type((rocsparse_mat_descr)descrA);
     rocsparse_index_base  indbase = rocsparse_get_mat_index_base((rocsparse_mat_descr)descrA);

--- a/library/src/nvidia_detail/hipsolver_sparse.cpp
+++ b/library/src/nvidia_detail/hipsolver_sparse.cpp
@@ -448,7 +448,7 @@ catch(...)
     return hipsolver::exception2hip_status();
 }
 
-hipsolverStatus_t hipsolverSpCcsrlsvqr(hipsolverSpHandle_t       handle,
+/*hipsolverStatus_t hipsolverSpCcsrlsvqr(hipsolverSpHandle_t       handle,
                                        int                       n,
                                        int                       nnzA,
                                        const hipsparseMatDescr_t descrA,
@@ -520,6 +520,6 @@ try
 catch(...)
 {
     return hipsolver::exception2hip_status();
-}
+}*/
 
 } //extern C

--- a/library/src/nvidia_detail/hipsolver_sparse.cpp
+++ b/library/src/nvidia_detail/hipsolver_sparse.cpp
@@ -373,4 +373,153 @@ catch(...)
     return hipsolver::exception2hip_status();
 }*/
 
+/******************** CSRLSVQR ********************/
+hipsolverStatus_t hipsolverSpScsrlsvqr(hipsolverSpHandle_t       handle,
+                                       int                       n,
+                                       int                       nnzA,
+                                       const hipsparseMatDescr_t descrA,
+                                       const float*              csrVal,
+                                       const int*                csrRowPtr,
+                                       const int*                csrColInd,
+                                       const float*              b,
+                                       double                    tolerance,
+                                       int                       reorder,
+                                       float*                    x,
+                                       int*                      singularity)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cusolverSpScsrlsvqr((cusolverSpHandle_t)handle,
+                                                          n,
+                                                          nnzA,
+                                                          (cusparseMatDescr_t)descrA,
+                                                          csrVal,
+                                                          csrRowPtr,
+                                                          csrColInd,
+                                                          b,
+                                                          tolerance,
+                                                          reorder,
+                                                          x,
+                                                          singularity));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSpDcsrlsvqr(hipsolverSpHandle_t       handle,
+                                       int                       n,
+                                       int                       nnzA,
+                                       const hipsparseMatDescr_t descrA,
+                                       const double*             csrVal,
+                                       const int*                csrRowPtr,
+                                       const int*                csrColInd,
+                                       const double*             b,
+                                       double                    tolerance,
+                                       int                       reorder,
+                                       double*                   x,
+                                       int*                      singularity)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cusolverSpDcsrlsvqr((cusolverSpHandle_t)handle,
+                                                          n,
+                                                          nnzA,
+                                                          (cusparseMatDescr_t)descrA,
+                                                          csrVal,
+                                                          csrRowPtr,
+                                                          csrColInd,
+                                                          b,
+                                                          tolerance,
+                                                          reorder,
+                                                          x,
+                                                          singularity));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSpCcsrlsvqr(hipsolverSpHandle_t       handle,
+                                       int                       n,
+                                       int                       nnzA,
+                                       const hipsparseMatDescr_t descrA,
+                                       const hipFloatComplex*    csrVal,
+                                       const int*                csrRowPtr,
+                                       const int*                csrColInd,
+                                       const hipFloatComplex*    b,
+                                       double                    tolerance,
+                                       int                       reorder,
+                                       hipFloatComplex*          x,
+                                       int*                      singularity)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cusolverSpCcsrlsvqr((cusolverSpHandle_t)handle,
+                                                          n,
+                                                          nnzA,
+                                                          (cusparseMatDescr_t)descrA,
+                                                          csrVal,
+                                                          csrRowPtr,
+                                                          csrColInd,
+                                                          b,
+                                                          tolerance,
+                                                          reorder,
+                                                          x,
+                                                          singularity));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
+hipsolverStatus_t hipsolverSpZcsrlsvqr(hipsolverSpHandle_t       handle,
+                                       int                       n,
+                                       int                       nnzA,
+                                       const hipsparseMatDescr_t descrA,
+                                       const hipDoubleComplex*   csrVal,
+                                       const int*                csrRowPtr,
+                                       const int*                csrColInd,
+                                       const hipDoubleComplex*   b,
+                                       double                    tolerance,
+                                       int                       reorder,
+                                       hipDoubleComplex*         x,
+                                       int*                      singularity)
+try
+{
+    if(!handle)
+        return HIPSOLVER_STATUS_NOT_INITIALIZED;
+    if(!descrA)
+        return HIPSOLVER_STATUS_INVALID_VALUE;
+
+    return hipsolver::cuda2hip_status(cusolverSpZcsrlsvqr((cusolverSpHandle_t)handle,
+                                                          n,
+                                                          nnzA,
+                                                          (cusparseMatDescr_t)descrA,
+                                                          csrVal,
+                                                          csrRowPtr,
+                                                          csrColInd,
+                                                          b,
+                                                          tolerance,
+                                                          reorder,
+                                                          x,
+                                                          singularity));
+}
+catch(...)
+{
+    return hipsolver::exception2hip_status();
+}
+
 } //extern C

--- a/library/src/nvidia_detail/hipsolver_sparse.cpp
+++ b/library/src/nvidia_detail/hipsolver_sparse.cpp
@@ -471,13 +471,13 @@ try
                                                           n,
                                                           nnzA,
                                                           (cusparseMatDescr_t)descrA,
-                                                          csrVal,
+                                                          (cuComplex*)csrVal,
                                                           csrRowPtr,
                                                           csrColInd,
-                                                          b,
+                                                          (cuComplex*)b,
                                                           tolerance,
                                                           reorder,
-                                                          x,
+                                                          (cuComplex*)x,
                                                           singularity));
 }
 catch(...)
@@ -508,13 +508,13 @@ try
                                                           n,
                                                           nnzA,
                                                           (cusparseMatDescr_t)descrA,
-                                                          csrVal,
+                                                          (cuDoubleComplex*)csrVal,
                                                           csrRowPtr,
                                                           csrColInd,
-                                                          b,
+                                                          (cuDoubleComplex*)b,
                                                           tolerance,
                                                           reorder,
-                                                          x,
+                                                          (cuDoubleComplex*)x,
                                                           singularity));
 }
 catch(...)


### PR DESCRIPTION
This adds hipsolverSpXcsrlsvqr for all scalar types. To accomplish this it also:

- Loads additional rocsparse functions (rocsparse_*csr2dense, rocsparse_create_handle, rocsparse_destroy_handle)
- Adds a field containing a rocsparse handle to hipsolverSpHandle_t
- Adds a shim to create complex test cases from real ones.