### PR TITLE
remove hipblasLT and move rocPRIM for static CI jobs

### DIFF
--- a/.jenkins/static.groovy
+++ b/.jenkins/static.groovy
@@ -15,7 +15,7 @@ def runCI =
 
     def prj  = new rocProject('hipSOLVER', 'StaticLibrary')
     prj.paths.build_command = './install.sh -cd --static -p /opt/rocm/lib/cmake'
-    prj.libraryDependencies = ['hipBLAS-common', 'hipBLASLt', 'rocBLAS', 'rocSPARSE', 'rocSOLVER', 'hipSPARSE', 'rocPRIM']
+    prj.libraryDependencies = ['hipBLAS-common', 'rocPRIM', 'rocBLAS', 'rocSPARSE', 'rocSOLVER', 'hipSPARSE']
     prj.defaults.ccache = true
 
     // Define test architectures, optional rocm version argument is available


### PR DESCRIPTION
hipblasLT is not used in static builds and rocPRIM needs to be before rocSOLVER in the dependency chain.