### PR TITLE
Use proper include path for cholmod.h.

### DIFF
--- a/library/src/amd_detail/dlopen/cholmod.hpp
+++ b/library/src/amd_detail/dlopen/cholmod.hpp
@@ -24,7 +24,7 @@
 #include "lib_macros.hpp"
 
 #ifdef HAVE_ROCSPARSE
-#include <suitesparse/cholmod.h>
+#include <cholmod.h>
 #else
 
 // constants

--- a/library/src/cmake/suitesparse/FindCHOLMOD.cmake
+++ b/library/src/cmake/suitesparse/FindCHOLMOD.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,7 +45,10 @@ This module defines the following variables:
 
 #]=======================================================================]
 
-find_path(CHOLMOD_INCLUDE_DIR suitesparse/cholmod.h)
+find_path(CHOLMOD_INCLUDE_DIR
+    NAMES cholmod.h
+    PATH_SUFFIXES suitesparse
+    )
 find_library(CHOLMOD_LIBRARY cholmod)
 
 include(FindPackageHandleStandardArgs)

--- a/library/src/cmake/suitesparse/FindSuiteSparse_config.cmake
+++ b/library/src/cmake/suitesparse/FindSuiteSparse_config.cmake
@@ -1,5 +1,5 @@
 # ########################################################################
-# Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,7 +45,10 @@ This module defines the following variables:
 
 #]=======================================================================]
 
-find_path(SUITESPARSE_CONFIG_INCLUDE_DIR suitesparse/SuiteSparse_config.h)
+find_path(SUITESPARSE_CONFIG_INCLUDE_DIR
+    NAMES SuiteSparse_config.h
+    PATH_SUFFIXES suitesparse
+    )
 find_library(SUITESPARSE_CONFIG_LIBRARY suitesparseconfig)
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
It appears that the `SuiteSparse::CHOLMOD` CMake library advertises its include directory as `$PREFIX/include/suitesparse`, making the proper way to include it `#include <cholmod.h>`. When installed in the system `/usr` prefix, the `suitesparse/cholmod.h` path works by accident. When using a custom built suitesparse at a custom location, this is not so.

I believe that this change is the correct way to do it for all configurations, based on how the SuiteSparse library is set up.