### PR TITLE
SWDEV-516659 - Ensure the list of recommended and suggested packages are comma separated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,10 @@ if(NOT USE_CUDA)
     rocm_package_add_dependencies(DEPENDS ${hipsolver_pkgdeps})
   else()
     list(APPEND CPACK_DEBIAN_RUNTIME_PACKAGE_RECOMMENDS "rocsparse" ${hipsolver_pkgdeps})
+    # Cpack Recommends/Suggests list should be comma separated
+    string(REPLACE ";" "," CPACK_DEBIAN_RUNTIME_PACKAGE_RECOMMENDS "${CPACK_DEBIAN_RUNTIME_PACKAGE_RECOMMENDS}")
     list(APPEND CPACK_RPM_RUNTIME_PACKAGE_SUGGESTS "rocsparse" ${hipsolver_pkgdeps})
+    string(REPLACE ";" "," CPACK_RPM_RUNTIME_PACKAGE_SUGGESTS "${CPACK_RPM_RUNTIME_PACKAGE_SUGGESTS}")
   endif()
 endif()
 


### PR DESCRIPTION
A list in cmake is a semicolon(;) separated group of strings. The cpack recommends and suggests variables should have comma separated list, otherwise it will result in package installation failure.