### PR TITLE
Install hipsolver_client.so

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(hipsolver_f90_source
 if(BUILD_FORTRAN_BINDINGS)
   # Create hipSOLVER Fortran module
   add_library(hipsolver_fortran ${hipsolver_f90_source})
+  rocm_install(TARGETS hipsolver_fortran)
 endif()
 
 add_library(hipsolver


### PR DESCRIPTION
`libhipsolver_fortran.so` is not part of the installation but is needed by the test and benchmark client.

TheRock: https://github.com/ROCm/TheRock/issues/328