### PR TITLE
Parse `$ENV{HIP_PATH}` value with `TO_CMAKE_PATH` before using it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ rocm_setup_version(VERSION ${VERSION_STRING})
 if(NOT DEFINED ENV{HIP_PATH})
   set(HIP_PATH "/opt/rocm/hip")
 else()
-  set(HIP_PATH $ENV{HIP_PATH})
+  file(TO_CMAKE_PATH "$ENV{HIP_PATH}" HIP_PATH)
 endif()
 
 # NOTE:  workaround until hip cmake modules fixes symlink logic in their config files; remove when fixed


### PR DESCRIPTION
On Windows using a path with spaces in it without first going through `TO_CMAKE_PATH` results in errors observed downstream in https://github.com/ROCm/TheRock/issues/670 like

```
[hipSOLVER configure]   Syntax error in cmake code at
[hipSOLVER configure]
[hipSOLVER configure]     I:/TheRock/cmake/therock_subproject_dep_provider.cmake:53
[hipSOLVER configure]
[hipSOLVER configure]   when parsing string
[hipSOLVER configure]
[hipSOLVER configure]     REQUIRED;CONFIG;PATHS;C:\Program Files\AMD\ROCm\6.2\;/opt/rocm
[hipSOLVER configure]
[hipSOLVER configure]   Invalid character escape '\P'.
```

When running code like
```cmake
find_package(hip REQUIRED CONFIG PATHS ${HIP_PATH} ${ROCM_PATH} /opt/rocm)
```

See the recommendations at https://cmake.org/cmake/help/latest/command/file.html#path-conversion:

> 
> `file(TO_CMAKE_PATH "<path>" <variable>)`
> `file(TO_NATIVE_PATH "<path>" <variable>)`
> 
>  The `TO_CMAKE_PATH` mode converts a native `<path>` into a cmake-style path with forward-slashes (`/`). The input can be a single path or a system search path like `$ENV{PATH}`. A search path will be converted to a cmake-style list separated by `;` characters.
> 
>  The `TO_NATIVE_PATH` mode converts a cmake-style `<path>` into a native path with platform-specific slashes (`\` on Windows hosts and `/` elsewhere).
> 
>  Always use double quotes around the `<path>` to be sure it is treated as a single argument to this command.
