### PR TITLE
Compatibility API tests for code coverage

### DIFF
--- a/clients/gtest/gebrd_gtest.cpp
+++ b/clients/gtest/gebrd_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -113,6 +113,10 @@ class GEBRD_FORTRAN : public GEBRD_BASE<API_FORTRAN>
 {
 };
 
+class GEBRD_COMPAT: public GEBRD_BASE<API_COMPAT>
+{
+};
+
 // non-batch tests
 
 TEST_P(GEBRD, __float)
@@ -155,6 +159,26 @@ TEST_P(GEBRD_FORTRAN, __double_complex)
     run_tests<false, false, rocblas_double_complex>();
 }
 
+TEST_P(GEBRD_COMPAT, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(GEBRD_COMPAT, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(GEBRD_COMPAT, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(GEBRD_COMPAT, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
 // INSTANTIATE_TEST_SUITE_P(daily_lapack,
 //                          GEBRD,
 //                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(large_n_size_range)));
@@ -169,4 +193,12 @@ INSTANTIATE_TEST_SUITE_P(checkin_lapack,
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          GEBRD_FORTRAN,
+                         Combine(ValuesIn(matrix_size_range), ValuesIn(n_size_range)));
+//
+// INSTANTIATE_TEST_SUITE_P(daily_lapack,
+//                          GEBRD_COMPAT,
+//                          Combine(ValuesIn(large_matrix_size_range), ValuesIn(large_n_size_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         GEBRD_COMPAT,
                          Combine(ValuesIn(matrix_size_range), ValuesIn(n_size_range)));

--- a/clients/gtest/gesvdj_gtest.cpp
+++ b/clients/gtest/gesvdj_gtest.cpp
@@ -145,6 +145,9 @@ class GESVDJ_FORTRAN : public GESVDJ_BASE<API_FORTRAN>
 {
 };
 
+class GESVDJ_COMPAT : public GESVDJ_BASE<API_COMPAT>
+{
+};
 // non-batch tests
 
 TEST_P(GESVDJ, __float)
@@ -229,6 +232,25 @@ TEST_P(GESVDJ_FORTRAN, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
+TEST_P(GESVDJ_COMPAT, strided_batched__float)
+{
+    run_tests<false, true, float>();
+}
+
+TEST_P(GESVDJ_COMPAT, strided_batched__double)
+{
+    run_tests<false, true, double>();
+}
+
+TEST_P(GESVDJ_COMPAT, strided_batched__float_complex)
+{
+    run_tests<false, true, rocblas_float_complex>();
+}
+
+TEST_P(GESVDJ_COMPAT, strided_batched__double_complex)
+{
+    run_tests<false, true, rocblas_double_complex>();
+}
 // INSTANTIATE_TEST_SUITE_P(daily_lapack,
 //                          GESVDJ,
 //                          Combine(ValuesIn(large_size_range), ValuesIn(large_opt_range)));
@@ -243,4 +265,12 @@ INSTANTIATE_TEST_SUITE_P(checkin_lapack,
 
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          GESVDJ_FORTRAN,
+                         Combine(ValuesIn(size_range), ValuesIn(opt_range)));
+
+// INSTANTIATE_TEST_SUITE_P(daily_lapack,
+//                          GESVDJ_COMPAT,
+//                          Combine(ValuesIn(large_size_range), ValuesIn(large_opt_range)));
+
+INSTANTIATE_TEST_SUITE_P(checkin_lapack,
+                         GESVDJ_COMPAT,
                          Combine(ValuesIn(size_range), ValuesIn(opt_range)));

--- a/clients/gtest/gesvdj_gtest.cpp
+++ b/clients/gtest/gesvdj_gtest.cpp
@@ -1,5 +1,5 @@
 /* ************************************************************************
- * Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -145,9 +145,6 @@ class GESVDJ_FORTRAN : public GESVDJ_BASE<API_FORTRAN>
 {
 };
 
-class GESVDJ_COMPAT : public GESVDJ_BASE<API_COMPAT>
-{
-};
 // non-batch tests
 
 TEST_P(GESVDJ, __float)
@@ -190,23 +187,6 @@ TEST_P(GESVDJ_FORTRAN, __double_complex)
     run_tests<false, false, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_COMPAT, __float)
-{
-    run_tests<false, false, float>();
-}
-
-TEST_P(GESVDJ_COMPAT, __double)
-{
-    run_tests<false, false, double>();
-}
-
-TEST_P(GESVDJ_COMPAT, __float_complex)
-{
-    run_tests<false, false, rocblas_float_complex>();
-}
-
-TEST_P(GESVDJ_COMPAT, __double_complex)
-{
     run_tests<false, false, rocblas_double_complex>();
 }
 
@@ -287,10 +267,3 @@ INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          GESVDJ_FORTRAN,
                          Combine(ValuesIn(size_range), ValuesIn(opt_range)));
 
-// INSTANTIATE_TEST_SUITE_P(daily_lapack,
-//                          GESVDJ_COMPAT,
-//                          Combine(ValuesIn(large_size_range), ValuesIn(large_opt_range)));
-
-INSTANTIATE_TEST_SUITE_P(checkin_lapack,
-                         GESVDJ_COMPAT,
-                         Combine(ValuesIn(size_range), ValuesIn(opt_range)));

--- a/clients/gtest/gesvdj_gtest.cpp
+++ b/clients/gtest/gesvdj_gtest.cpp
@@ -190,6 +190,26 @@ TEST_P(GESVDJ_FORTRAN, __double_complex)
     run_tests<false, false, rocblas_double_complex>();
 }
 
+TEST_P(GESVDJ_COMPAT, __float)
+{
+    run_tests<false, false, float>();
+}
+
+TEST_P(GESVDJ_COMPAT, __double)
+{
+    run_tests<false, false, double>();
+}
+
+TEST_P(GESVDJ_COMPAT, __float_complex)
+{
+    run_tests<false, false, rocblas_float_complex>();
+}
+
+TEST_P(GESVDJ_COMPAT, __double_complex)
+{
+    run_tests<false, false, rocblas_double_complex>();
+}
+
 // strided_batched tests
 
 TEST_P(GESVDJ, strided_batched__float)

--- a/clients/gtest/gesvdj_gtest.cpp
+++ b/clients/gtest/gesvdj_gtest.cpp
@@ -187,9 +187,6 @@ TEST_P(GESVDJ_FORTRAN, __double_complex)
     run_tests<false, false, rocblas_double_complex>();
 }
 
-    run_tests<false, false, rocblas_double_complex>();
-}
-
 // strided_batched tests
 
 TEST_P(GESVDJ, strided_batched__float)
@@ -232,25 +229,6 @@ TEST_P(GESVDJ_FORTRAN, strided_batched__double_complex)
     run_tests<false, true, rocblas_double_complex>();
 }
 
-TEST_P(GESVDJ_COMPAT, strided_batched__float)
-{
-    run_tests<false, true, float>();
-}
-
-TEST_P(GESVDJ_COMPAT, strided_batched__double)
-{
-    run_tests<false, true, double>();
-}
-
-TEST_P(GESVDJ_COMPAT, strided_batched__float_complex)
-{
-    run_tests<false, true, rocblas_float_complex>();
-}
-
-TEST_P(GESVDJ_COMPAT, strided_batched__double_complex)
-{
-    run_tests<false, true, rocblas_double_complex>();
-}
 // INSTANTIATE_TEST_SUITE_P(daily_lapack,
 //                          GESVDJ,
 //                          Combine(ValuesIn(large_size_range), ValuesIn(large_opt_range)));
@@ -266,4 +244,3 @@ INSTANTIATE_TEST_SUITE_P(checkin_lapack,
 INSTANTIATE_TEST_SUITE_P(checkin_lapack,
                          GESVDJ_FORTRAN,
                          Combine(ValuesIn(size_range), ValuesIn(opt_range)));
-

--- a/clients/include/hipsolver.hpp
+++ b/clients/include/hipsolver.hpp
@@ -1377,6 +1377,8 @@ inline hipsolverStatus_t hipsolver_gebrd_bufferSize(
         return hipsolverSgebrd_bufferSize(handle, m, n, lwork);
     case API_FORTRAN:
         return hipsolverSgebrd_bufferSizeFortran(handle, m, n, lwork);
+    case API_COMPAT:
+        return hipsolverDnSgebrd_bufferSize(handle, m, n, lwork);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1391,6 +1393,8 @@ inline hipsolverStatus_t hipsolver_gebrd_bufferSize(
         return hipsolverDgebrd_bufferSize(handle, m, n, lwork);
     case API_FORTRAN:
         return hipsolverDgebrd_bufferSizeFortran(handle, m, n, lwork);
+    case API_COMPAT:
+        return hipsolverDnDgebrd_bufferSize(handle, m, n, lwork);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1405,6 +1409,8 @@ inline hipsolverStatus_t hipsolver_gebrd_bufferSize(
         return hipsolverCgebrd_bufferSize(handle, m, n, lwork);
     case API_FORTRAN:
         return hipsolverCgebrd_bufferSizeFortran(handle, m, n, lwork);
+    case API_COMPAT:
+        return hipsolverDnCgebrd_bufferSize(handle, m, n, lwork);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1424,6 +1430,8 @@ inline hipsolverStatus_t hipsolver_gebrd_bufferSize(testAPI_t               API,
         return hipsolverZgebrd_bufferSize(handle, m, n, lwork);
     case API_FORTRAN:
         return hipsolverZgebrd_bufferSizeFortran(handle, m, n, lwork);
+    case API_COMPAT:
+        return hipsolverDnZgebrd_bufferSize(handle, m, n, lwork);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1455,6 +1463,8 @@ inline hipsolverStatus_t hipsolver_gebrd(testAPI_t         API,
         return hipsolverSgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
     case API_FORTRAN:
         return hipsolverSgebrdFortran(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
+    case API_COMPAT:
+        return hipsolverDnSgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1486,6 +1496,8 @@ inline hipsolverStatus_t hipsolver_gebrd(testAPI_t         API,
         return hipsolverDgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
     case API_FORTRAN:
         return hipsolverDgebrdFortran(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
+    case API_COMPAT:
+        return hipsolverDnDgebrd(handle, m, n, A, lda, D, E, tauq, taup, work, lwork, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1539,6 +1551,8 @@ inline hipsolverStatus_t hipsolver_gebrd(testAPI_t         API,
                                       (hipFloatComplex*)work,
                                       lwork,
                                       info);
+    case API_COMPAT:
+        return hipsolverDnCgebrd(handle, m, n,(hipFloatComplex*) A, lda, D, E,(hipFloatComplex*) tauq,(hipFloatComplex*) taup,(hipFloatComplex*) work, lwork, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }
@@ -1592,6 +1606,8 @@ inline hipsolverStatus_t hipsolver_gebrd(testAPI_t               API,
                                       (hipDoubleComplex*)work,
                                       lwork,
                                       info);
+    case API_COMPAT:
+        return hipsolverDnZgebrd(handle, m, n, (hipDoubleComplex*)A, lda, D, E,(hipDoubleComplex*) tauq,(hipDoubleComplex*) taup,(hipDoubleComplex*) work, lwork, info);
     default:
         return HIPSOLVER_STATUS_NOT_SUPPORTED;
     }


### PR DESCRIPTION
This PR is a draft to convey changes that will be proposed in a larger PR. This draft PR demonstrates the changes on just a single LAPACK function, gebrd.

I modify the gtest and hipsolver templated functions to allow for the API_COMPAT (parity with cuDn) functions to be invoked.

This allows for increased code coverage, as the hipDn functions were previously unreached.