### PR TITLE
ci: Remove call to junit from math ci

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -38,7 +38,6 @@ def runTestCommand(platform, project)
                 """
 
     platform.runCommand(this, command)
-    junit "${project.paths.project_build_prefix}/build/${buildType}/clients/staging/*.xml"
 }
 
 def runPackageCommand(platform, project, jobName, label='')


### PR DESCRIPTION
math-ci no longer uses junit