### PR TITLE
Add softlink for hipsolver_fortran library target

### DIFF
--- a/library/src/CMakeLists.txt
+++ b/library/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(hipsolver_f90_source
 if(BUILD_FORTRAN_BINDINGS)
   # Create hipSOLVER Fortran module
   add_library(hipsolver_fortran ${hipsolver_f90_source})
+  rocm_set_soversion(hipsolver_fortran ${hipsolver_SOVERSION})
   rocm_install(TARGETS hipsolver_fortran)
 endif()
 


### PR DESCRIPTION
Changes Proposed:
- To Enable version-based symbol link to the library target hipsolver_fortran
- SWDEV-538237
- BAAS - 1620 Test results