### PR TITLE
Fix syntax error in clients/gtest/CMakeLists.txt

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -177,7 +177,7 @@ if(WIN32)
       ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/staging/
     )
   endforeach()
-  if(DEFINED $ENV{rocblas_DIR})
+  if(DEFINED ENV{rocblas_DIR})
     add_custom_command(TARGET hipsolver-test
       POST_BUILD
       COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/variable/ENV.html

Follow-up to https://github.com/ROCm/hipSOLVER/pull/397