### PR TITLE
Fix CMake DEFINED check syntax for environment variable

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -177,7 +177,7 @@ if(WIN32)
       ARGS -E copy ${file_i} ${PROJECT_BINARY_DIR}/staging/
     )
   endforeach()
-  if(DEFINED $ENV{rocblas_DIR})
+  if(DEFINED ENV{rocblas_DIR})
     add_custom_command(TARGET hipsolver-test
       POST_BUILD
       COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
## Motivation

Fix CMake syntax error preventing hipSOLVER from correctly copying the required library from rocBLAS in Windows. ref https://cmake.org/cmake/help/latest/command/if.html#defined

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
